### PR TITLE
temporarily disable mystery pods

### DIFF
--- a/code/modules/hydroponics/grown/replicapod.dm
+++ b/code/modules/hydroponics/grown/replicapod.dm
@@ -7,7 +7,9 @@
 	species = "replicapod"
 	plantname = "Replica Pod"
 	product = /mob/living/carbon/human //verrry special -- Urist
+	/* honk start -- Putting this on hold until fixed
 	mutatelist = list(/obj/item/seeds/russ/mystery) //honk -- Mystery Pods
+	honk end */
 	lifespan = 50
 	endurance = 8
 	maturation = 10


### PR DESCRIPTION
At least until they're not comically broken, and have an icon.