### PR TITLE
Fixes crew transfer votes still not defaulting to no call when tied

### DIFF
--- a/code/controllers/subsystem/vote.dm
+++ b/code/controllers/subsystem/vote.dm
@@ -108,7 +108,7 @@ SUBSYSTEM_DEF(vote)
 				text = "\n<b>Vote Tied Between:</b>"
 				for(var/option in winners)
 					text += "\n\t[option]"
-			if(mode == "Crew Transfer") // a tied crew transfer vote should always default to not calling
+			if(mode == "crew transfer") // a tied crew transfer vote should always default to not calling
 				. = "Continue The Round"
 			else 
 				. = pick(winners)


### PR DESCRIPTION
Should fix the crew transfer vote for real this time. Late night code though and untested so I'll take another look tomorrow.