### PR TITLE
Replaces 11 floors on the 5 in rotation maps with indestructible vari…

### DIFF
--- a/RussStation.dme
+++ b/RussStation.dme
@@ -2858,6 +2858,7 @@
 #include "russstation\code\datums\action.dm"
 #include "russstation\code\game\objects\items\spiritboard.dm"
 #include "russstation\code\game\objects\items\storage\boxes.dm"
+#include "russstation\code\game\turfs\simulated\floor\floor.dm"
 #include "russstation\code\modules\admin\verbs\randomverbs.dm"
 #include "russstation\code\modules\cargo\packs.dm"
 #include "russstation\code\modules\client\client.dm"

--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -44567,7 +44567,7 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
 	},
-/turf/open/indestructible,
+/turf/open/floor/engine/no_decon,
 /area/engine/supermatter)
 "cru" = (
 /obj/machinery/meter,
@@ -46884,7 +46884,7 @@
 /area/crew_quarters/kitchen)
 "cAm" = (
 /obj/machinery/power/supermatter_crystal/engine,
-/turf/open/indestructible,
+/turf/open/floor/engine/no_decon,
 /area/engine/supermatter)
 "cAo" = (
 /obj/effect/turf_decal/stripes/corner{
@@ -48027,13 +48027,13 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
 	},
-/turf/open/indestructible,
+/turf/open/floor/engine/no_decon,
 /area/engine/supermatter)
 "cEx" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
 	},
-/turf/open/indestructible,
+/turf/open/floor/engine/no_decon,
 /area/engine/supermatter)
 "cEy" = (
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
@@ -48876,7 +48876,7 @@
 /area/engine/supermatter)
 "cMN" = (
 /obj/effect/spawner/structure/window/plasma/reinforced,
-/turf/open/indestructible,
+/turf/open/floor/engine/no_decon,
 /area/engine/supermatter)
 "cMQ" = (
 /obj/machinery/power/solar{
@@ -50048,9 +50048,6 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
-"iHv" = (
-/turf/open/indestructible,
-/area/engine/supermatter)
 "iHT" = (
 /obj/machinery/hydroponics/soil,
 /obj/machinery/light{
@@ -50102,6 +50099,9 @@
 	},
 /turf/closed/wall/r_wall,
 /area/security/courtroom)
+"jmD" = (
+/turf/open/floor/engine/no_decon,
+/area/engine/supermatter)
 "jrH" = (
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "rnd2";
@@ -81185,9 +81185,9 @@ cqg
 cqE
 cqZ
 crt
-iHv
+jmD
 cAm
-iHv
+jmD
 cMN
 cFO
 gvG

--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -44567,7 +44567,7 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
 	},
-/turf/open/floor/engine,
+/turf/open/indestructible,
 /area/engine/supermatter)
 "cru" = (
 /obj/machinery/meter,
@@ -46884,7 +46884,7 @@
 /area/crew_quarters/kitchen)
 "cAm" = (
 /obj/machinery/power/supermatter_crystal/engine,
-/turf/open/floor/engine,
+/turf/open/indestructible,
 /area/engine/supermatter)
 "cAo" = (
 /obj/effect/turf_decal/stripes/corner{
@@ -48027,13 +48027,13 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
 	},
-/turf/open/floor/engine,
+/turf/open/indestructible,
 /area/engine/supermatter)
 "cEx" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
 	},
-/turf/open/floor/engine,
+/turf/open/indestructible,
 /area/engine/supermatter)
 "cEy" = (
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
@@ -48876,7 +48876,7 @@
 /area/engine/supermatter)
 "cMN" = (
 /obj/effect/spawner/structure/window/plasma/reinforced,
-/turf/open/floor/plating,
+/turf/open/indestructible,
 /area/engine/supermatter)
 "cMQ" = (
 /obj/machinery/power/solar{
@@ -50048,6 +50048,9 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
+"iHv" = (
+/turf/open/indestructible,
+/area/engine/supermatter)
 "iHT" = (
 /obj/machinery/hydroponics/soil,
 /obj/machinery/light{
@@ -81182,9 +81185,9 @@ cqg
 cqE
 cqZ
 crt
-cMH
+iHv
 cAm
-cMH
+iHv
 cMN
 cFO
 gvG

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -8944,7 +8944,7 @@
 /area/engine/supermatter)
 "awh" = (
 /obj/effect/spawner/structure/window/plasma/reinforced,
-/turf/open/indestructible,
+/turf/open/floor/engine/no_decon,
 /area/engine/supermatter)
 "awi" = (
 /obj/machinery/status_display/evac,
@@ -9612,7 +9612,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
 	},
-/turf/open/indestructible,
+/turf/open/floor/engine/no_decon,
 /area/engine/supermatter)
 "axz" = (
 /turf/open/floor/engine,
@@ -9621,7 +9621,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
 	},
-/turf/open/indestructible,
+/turf/open/floor/engine/no_decon,
 /area/engine/supermatter)
 "axB" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
@@ -10280,7 +10280,7 @@
 /area/engine/supermatter)
 "ayK" = (
 /obj/machinery/power/supermatter_crystal/engine,
-/turf/open/indestructible,
+/turf/open/floor/engine/no_decon,
 /area/engine/supermatter)
 "ayL" = (
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
@@ -11365,7 +11365,7 @@
 	req_one_access_txt = "24;10"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/turf/open/indestructible,
+/turf/open/floor/engine/no_decon,
 /area/engine/supermatter)
 "aAX" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
@@ -115311,9 +115311,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/misc_lab/range)
-"lXN" = (
-/turf/open/indestructible,
-/area/engine/supermatter)
 "mkm" = (
 /obj/machinery/atmospherics/components/binary/valve,
 /obj/machinery/embedded_controller/radio/airlock_controller/incinerator_toxmix{
@@ -115816,6 +115813,9 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/science/research/abandoned)
+"pRX" = (
+/turf/open/floor/engine/no_decon,
+/area/engine/supermatter)
 "qbW" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/neutral{
@@ -142596,9 +142596,9 @@ asu
 atS
 avb
 awh
-lXN
+pRX
 ayK
-lXN
+pRX
 aAW
 axz
 uYS

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -8944,7 +8944,7 @@
 /area/engine/supermatter)
 "awh" = (
 /obj/effect/spawner/structure/window/plasma/reinforced,
-/turf/open/floor/plating,
+/turf/open/indestructible,
 /area/engine/supermatter)
 "awi" = (
 /obj/machinery/status_display/evac,
@@ -9612,7 +9612,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
 	},
-/turf/open/floor/engine,
+/turf/open/indestructible,
 /area/engine/supermatter)
 "axz" = (
 /turf/open/floor/engine,
@@ -9621,7 +9621,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
 	},
-/turf/open/floor/engine,
+/turf/open/indestructible,
 /area/engine/supermatter)
 "axB" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
@@ -10280,7 +10280,7 @@
 /area/engine/supermatter)
 "ayK" = (
 /obj/machinery/power/supermatter_crystal/engine,
-/turf/open/floor/engine,
+/turf/open/indestructible,
 /area/engine/supermatter)
 "ayL" = (
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
@@ -11365,7 +11365,7 @@
 	req_one_access_txt = "24;10"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/turf/open/floor/engine,
+/turf/open/indestructible,
 /area/engine/supermatter)
 "aAX" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
@@ -115311,6 +115311,9 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/misc_lab/range)
+"lXN" = (
+/turf/open/indestructible,
+/area/engine/supermatter)
 "mkm" = (
 /obj/machinery/atmospherics/components/binary/valve,
 /obj/machinery/embedded_controller/radio/airlock_controller/incinerator_toxmix{
@@ -142593,9 +142596,9 @@ asu
 atS
 avb
 awh
-axz
+lXN
 ayK
-axz
+lXN
 aAW
 axz
 uYS

--- a/_maps/map_files/Donutstation/Donutstation.dmm
+++ b/_maps/map_files/Donutstation/Donutstation.dmm
@@ -4306,7 +4306,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
 	},
-/turf/open/floor/engine,
+/turf/open/indestructible,
 /area/engine/supermatter)
 "alu" = (
 /obj/effect/turf_decal/tile/bar{
@@ -27386,7 +27386,7 @@
 /area/maintenance/aft)
 "boA" = (
 /obj/effect/spawner/structure/window/plasma/reinforced,
-/turf/open/floor/plating,
+/turf/open/indestructible,
 /area/engine/supermatter)
 "boC" = (
 /obj/effect/decal/cleanable/dirt,
@@ -45559,7 +45559,7 @@
 	req_access_txt = "10"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/turf/open/floor/engine,
+/turf/open/indestructible,
 /area/engine/supermatter)
 "cNG" = (
 /obj/structure/table/wood,
@@ -47409,7 +47409,7 @@
 /area/engine/engine_room)
 "jxP" = (
 /obj/machinery/power/supermatter_crystal/engine,
-/turf/open/floor/engine,
+/turf/open/indestructible,
 /area/engine/supermatter)
 "jzE" = (
 /obj/effect/turf_decal/tile/neutral{
@@ -50043,7 +50043,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
 	},
-/turf/open/floor/engine,
+/turf/open/indestructible,
 /area/engine/supermatter)
 "sZm" = (
 /obj/effect/turf_decal/tile/yellow,
@@ -51377,6 +51377,9 @@
 /obj/machinery/shieldgen,
 /turf/open/floor/plating,
 /area/engine/engineering)
+"xkR" = (
+/turf/open/indestructible,
+/area/engine/supermatter)
 "xoZ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -88519,9 +88522,9 @@ mJV
 eiC
 son
 boA
-nNJ
+xkR
 jxP
-nNJ
+xkR
 cLX
 nNJ
 skl

--- a/_maps/map_files/Donutstation/Donutstation.dmm
+++ b/_maps/map_files/Donutstation/Donutstation.dmm
@@ -4306,7 +4306,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
 	},
-/turf/open/indestructible,
+/turf/open/floor/engine/no_decon,
 /area/engine/supermatter)
 "alu" = (
 /obj/effect/turf_decal/tile/bar{
@@ -27386,7 +27386,7 @@
 /area/maintenance/aft)
 "boA" = (
 /obj/effect/spawner/structure/window/plasma/reinforced,
-/turf/open/indestructible,
+/turf/open/floor/engine/no_decon,
 /area/engine/supermatter)
 "boC" = (
 /obj/effect/decal/cleanable/dirt,
@@ -45559,7 +45559,7 @@
 	req_access_txt = "10"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/turf/open/indestructible,
+/turf/open/floor/engine/no_decon,
 /area/engine/supermatter)
 "cNG" = (
 /obj/structure/table/wood,
@@ -47409,7 +47409,7 @@
 /area/engine/engine_room)
 "jxP" = (
 /obj/machinery/power/supermatter_crystal/engine,
-/turf/open/indestructible,
+/turf/open/floor/engine/no_decon,
 /area/engine/supermatter)
 "jzE" = (
 /obj/effect/turf_decal/tile/neutral{
@@ -50043,7 +50043,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
 	},
-/turf/open/indestructible,
+/turf/open/floor/engine/no_decon,
 /area/engine/supermatter)
 "sZm" = (
 /obj/effect/turf_decal/tile/yellow,
@@ -51377,9 +51377,6 @@
 /obj/machinery/shieldgen,
 /turf/open/floor/plating,
 /area/engine/engineering)
-"xkR" = (
-/turf/open/indestructible,
-/area/engine/supermatter)
 "xoZ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -51514,6 +51511,9 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/fitness/locker_room)
+"xPm" = (
+/turf/open/floor/engine/no_decon,
+/area/engine/supermatter)
 "xRV" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -88522,9 +88522,9 @@ mJV
 eiC
 son
 boA
-xkR
+xPm
 jxP
-xkR
+xPm
 cLX
 nNJ
 skl

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -17703,7 +17703,7 @@
 /area/engine/supermatter)
 "aNv" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
-/turf/open/floor/engine,
+/turf/open/indestructible,
 /area/engine/supermatter)
 "aNw" = (
 /obj/structure/window/reinforced{
@@ -53996,8 +53996,8 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
-/mob/living/simple_animal/pet/gondola/russ/camdola,
 /obj/structure/cable,
+/mob/living/simple_animal/pet/gondola/russ/camdola,
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/cmo)
 "coS" = (
@@ -69314,7 +69314,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
 	},
-/turf/open/floor/engine,
+/turf/open/indestructible,
 /area/engine/supermatter)
 "dbd" = (
 /obj/machinery/vending/wardrobe/bar_wardrobe,
@@ -70693,7 +70693,7 @@
 /area/engine/engineering)
 "dfa" = (
 /obj/machinery/power/supermatter_crystal/engine,
-/turf/open/floor/engine,
+/turf/open/indestructible,
 /area/engine/supermatter)
 "dfb" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
@@ -72281,7 +72281,7 @@
 /area/engine/supermatter)
 "dlN" = (
 /obj/effect/spawner/structure/window/plasma/reinforced,
-/turf/open/floor/plating,
+/turf/open/indestructible,
 /area/engine/supermatter)
 "dlV" = (
 /turf/closed/wall/r_wall,
@@ -73726,6 +73726,9 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/engine/storage_shared)
+"hmL" = (
+/turf/open/indestructible,
+/area/engine/supermatter)
 "hvt" = (
 /obj/structure/kitchenspike_frame,
 /obj/effect/decal/cleanable/blood/gibs/old,
@@ -74805,7 +74808,7 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
 	},
-/turf/open/floor/engine,
+/turf/open/indestructible,
 /area/engine/supermatter)
 "tFJ" = (
 /obj/structure/bodycontainer/morgue{
@@ -118242,7 +118245,7 @@ djt
 aMk
 daZ
 dbb
-aMk
+hmL
 aNv
 dfk
 dfq
@@ -118756,7 +118759,7 @@ djt
 aMk
 deS
 dbb
-aMk
+hmL
 aNv
 dfm
 aMk

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -17703,7 +17703,7 @@
 /area/engine/supermatter)
 "aNv" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
-/turf/open/indestructible,
+/turf/open/floor/engine/no_decon,
 /area/engine/supermatter)
 "aNw" = (
 /obj/structure/window/reinforced{
@@ -69314,7 +69314,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
 	},
-/turf/open/indestructible,
+/turf/open/floor/engine/no_decon,
 /area/engine/supermatter)
 "dbd" = (
 /obj/machinery/vending/wardrobe/bar_wardrobe,
@@ -70693,7 +70693,7 @@
 /area/engine/engineering)
 "dfa" = (
 /obj/machinery/power/supermatter_crystal/engine,
-/turf/open/indestructible,
+/turf/open/floor/engine/no_decon,
 /area/engine/supermatter)
 "dfb" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
@@ -72281,7 +72281,7 @@
 /area/engine/supermatter)
 "dlN" = (
 /obj/effect/spawner/structure/window/plasma/reinforced,
-/turf/open/indestructible,
+/turf/open/floor/engine/no_decon,
 /area/engine/supermatter)
 "dlV" = (
 /turf/closed/wall/r_wall,
@@ -73726,9 +73726,6 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/engine/storage_shared)
-"hmL" = (
-/turf/open/indestructible,
-/area/engine/supermatter)
 "hvt" = (
 /obj/structure/kitchenspike_frame,
 /obj/effect/decal/cleanable/blood/gibs/old,
@@ -74808,7 +74805,7 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
 	},
-/turf/open/indestructible,
+/turf/open/floor/engine/no_decon,
 /area/engine/supermatter)
 "tFJ" = (
 /obj/structure/bodycontainer/morgue{
@@ -74816,6 +74813,9 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
+"tHI" = (
+/turf/open/floor/engine/no_decon,
+/area/engine/supermatter)
 "tPk" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -118245,7 +118245,7 @@ djt
 aMk
 daZ
 dbb
-hmL
+tHI
 aNv
 dfk
 dfq
@@ -118759,7 +118759,7 @@ djt
 aMk
 deS
 dbb
-hmL
+tHI
 aNv
 dfm
 aMk

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -43776,7 +43776,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
 	},
-/turf/open/floor/engine,
+/turf/open/indestructible,
 /area/engine/supermatter)
 "cgU" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
@@ -43800,7 +43800,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
 	},
-/turf/open/floor/engine,
+/turf/open/indestructible,
 /area/engine/supermatter)
 "chb" = (
 /obj/machinery/camera{
@@ -44102,7 +44102,7 @@
 /area/engine/engineering)
 "cit" = (
 /obj/effect/turf_decal/stripes/line,
-/turf/open/floor/engine,
+/turf/open/indestructible,
 /area/engine/supermatter)
 "ciy" = (
 /obj/item/reagent_containers/glass/bucket,
@@ -44165,7 +44165,7 @@
 	name = "Supermatter Chamber";
 	req_access_txt = "10"
 	},
-/turf/open/floor/engine,
+/turf/open/indestructible,
 /area/engine/supermatter)
 "ciI" = (
 /obj/machinery/atmospherics/pipe/manifold/orange/visible,
@@ -50531,7 +50531,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
 	},
-/turf/open/floor/engine,
+/turf/open/indestructible,
 /area/engine/supermatter)
 "heC" = (
 /obj/machinery/power/apc/highcap/five_k{
@@ -52676,7 +52676,7 @@
 /area/maintenance/department/crew_quarters/dorms)
 "mpd" = (
 /obj/effect/spawner/structure/window/plasma/reinforced,
-/turf/open/floor/plating,
+/turf/open/indestructible,
 /area/engine/supermatter)
 "mpy" = (
 /obj/structure/table/wood,
@@ -53395,7 +53395,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
 	},
-/turf/open/floor/engine,
+/turf/open/indestructible,
 /area/engine/supermatter)
 "obj" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -54447,7 +54447,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/turf/open/floor/engine,
+/turf/open/indestructible,
 /area/engine/supermatter)
 "qIC" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -54772,7 +54772,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
 	},
-/turf/open/floor/engine,
+/turf/open/indestructible,
 /area/engine/supermatter)
 "rui" = (
 /obj/structure/closet/emcloset/anchored,
@@ -55080,7 +55080,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
 	},
-/turf/open/floor/engine,
+/turf/open/indestructible,
 /area/engine/supermatter)
 "spz" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -56082,7 +56082,7 @@
 "uMr" = (
 /obj/machinery/power/supermatter_crystal/engine,
 /obj/effect/turf_decal/bot,
-/turf/open/floor/engine,
+/turf/open/indestructible,
 /area/engine/supermatter)
 "uMt" = (
 /obj/effect/turf_decal/plaque,

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -43776,7 +43776,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
 	},
-/turf/open/indestructible,
+/turf/open/floor/engine/no_decon,
 /area/engine/supermatter)
 "cgU" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
@@ -43800,7 +43800,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
 	},
-/turf/open/indestructible,
+/turf/open/floor/engine/no_decon,
 /area/engine/supermatter)
 "chb" = (
 /obj/machinery/camera{
@@ -44102,7 +44102,7 @@
 /area/engine/engineering)
 "cit" = (
 /obj/effect/turf_decal/stripes/line,
-/turf/open/indestructible,
+/turf/open/floor/engine/no_decon,
 /area/engine/supermatter)
 "ciy" = (
 /obj/item/reagent_containers/glass/bucket,
@@ -44165,7 +44165,7 @@
 	name = "Supermatter Chamber";
 	req_access_txt = "10"
 	},
-/turf/open/indestructible,
+/turf/open/floor/engine/no_decon,
 /area/engine/supermatter)
 "ciI" = (
 /obj/machinery/atmospherics/pipe/manifold/orange/visible,
@@ -50531,7 +50531,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
 	},
-/turf/open/indestructible,
+/turf/open/floor/engine/no_decon,
 /area/engine/supermatter)
 "heC" = (
 /obj/machinery/power/apc/highcap/five_k{
@@ -52676,7 +52676,7 @@
 /area/maintenance/department/crew_quarters/dorms)
 "mpd" = (
 /obj/effect/spawner/structure/window/plasma/reinforced,
-/turf/open/indestructible,
+/turf/open/floor/engine/no_decon,
 /area/engine/supermatter)
 "mpy" = (
 /obj/structure/table/wood,
@@ -53395,7 +53395,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
 	},
-/turf/open/indestructible,
+/turf/open/floor/engine/no_decon,
 /area/engine/supermatter)
 "obj" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -54447,7 +54447,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/turf/open/indestructible,
+/turf/open/floor/engine/no_decon,
 /area/engine/supermatter)
 "qIC" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -54772,7 +54772,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
 	},
-/turf/open/indestructible,
+/turf/open/floor/engine/no_decon,
 /area/engine/supermatter)
 "rui" = (
 /obj/structure/closet/emcloset/anchored,
@@ -55080,7 +55080,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
 	},
-/turf/open/indestructible,
+/turf/open/floor/engine/no_decon,
 /area/engine/supermatter)
 "spz" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -56082,7 +56082,7 @@
 "uMr" = (
 /obj/machinery/power/supermatter_crystal/engine,
 /obj/effect/turf_decal/bot,
-/turf/open/indestructible,
+/turf/open/floor/engine/no_decon,
 /area/engine/supermatter)
 "uMt" = (
 /obj/effect/turf_decal/plaque,

--- a/html/changelogs/locarto - SM.yml
+++ b/html/changelogs/locarto - SM.yml
@@ -1,0 +1,5 @@
+author: "locarto"
+
+delete-after: True
+changes: 
+  - tweak: "Replaces 11 floors in the SM chamber with indestructible variants."

--- a/russstation/code/game/turfs/simulated/floor/floor.dm
+++ b/russstation/code/game/turfs/simulated/floor/floor.dm
@@ -1,0 +1,22 @@
+/* A reinforced floor with no deconstruction methods
+ * For use in the SM to prevent players cheesing delaminations
+ * by removing tiles to space in order to get rid of fires.
+ */
+
+/turf/open/floor/engine/no_decon
+	desc = "Very robust."
+
+/turf/open/floor/engine/no_decon/examine(mob/user)
+	. = list("[get_examine_string(user, TRUE)].")
+	. += desc
+	
+	SEND_SIGNAL(src, COMSIG_PARENT_EXAMINE, user, .) 
+
+/turf/open/floor/engine/no_decon/wrench_act(mob/living/user, obj/item/I)
+	return
+
+/turf/open/floor/engine/no_decon/rcd_vals(mob/user, obj/item/construction/rcd/the_rcd)
+	return
+
+/turf/open/floor/engine/no_decon/rcd_act(mob/user, obj/item/construction/rcd/the_rcd, passed_mode)
+	return


### PR DESCRIPTION
## About The Pull Request

In this PR, 11 floor tiles around each SM on the five stations are removed and replaced with indestructible variants.

## Why It's Good For The Game

This change is good for the game because it encourages those in engineering to learn how to properly do their job in stabilizing the SM.

## Changelog
:cl:
tweak: Changed 11 floors in the SM chamber across each of the five in rotation stations with indestructible variants.
/:cl: