### PR TITLE
Map preferences fix

### DIFF
--- a/config/maps.txt
+++ b/config/maps.txt
@@ -15,22 +15,27 @@ endmap
 map boxstation
 	default
 	#voteweight 1.5
+	votable
 endmap
 
 map metastation
 	minplayers 25
 	#voteweight 0.5
+	votable
 endmap
 
 map pubbystation
+	votable
 endmap
 
 map deltastation
 	minplayers 50
+	votable
 endmap
 
 map donutstation
 	minplayers 50
+	votable
 endmap
 
 map runtimestation

--- a/html/changelogs/Flufflycthulu-Map-Preferences.yml
+++ b/html/changelogs/Flufflycthulu-Map-Preferences.yml
@@ -1,0 +1,6 @@
+author: "FlufflyCthulu"
+
+delete-after: True
+
+changes: 
+  - bugfix: "Map preferences can be set again."


### PR DESCRIPTION
## About The Pull Request

People were no longer able to set preferred maps in game prefs it looks like we were missing some config changes at some point.

## Why It's Good For The Game

bugfix

## Changelog
:cl:
bugfix: Map preferences can be set again.
/:cl: