### PR TITLE
Donut fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -217,3 +217,5 @@ tools/MapAtmosFixer/MapAtmosFixer/bin/*
 !/config/title_music/sounds/exclude
 /config/title_screens/images/*
 !/config/title_screens/images/exclude
+dmdoc.exe
+dmdoc/

--- a/.gitignore
+++ b/.gitignore
@@ -217,5 +217,4 @@ tools/MapAtmosFixer/MapAtmosFixer/bin/*
 !/config/title_music/sounds/exclude
 /config/title_screens/images/*
 !/config/title_screens/images/exclude
-dmdoc.exe
 dmdoc/

--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -16569,14 +16569,8 @@
 /area/crew_quarters/bar)
 "aRv" = (
 /obj/structure/table/wood,
-/obj/item/reagent_containers/food/condiment/saltshaker{
-	step_x = 3;
-	step_y = 5
-	},
-/obj/item/reagent_containers/food/condiment/peppermill{
-	step_x = -6;
-	step_y = 8
-	},
+/obj/item/reagent_containers/food/condiment/saltshaker,
+/obj/item/reagent_containers/food/condiment/peppermill,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "aRx" = (
@@ -49303,10 +49297,7 @@
 /area/vacant_room/commissary)
 "eIz" = (
 /obj/structure/table/wood,
-/obj/item/reagent_containers/food/condiment/pack/ketchup{
-	step_x = -5;
-	step_y = 6
-	},
+/obj/item/reagent_containers/food/condiment/pack/ketchup,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "eRu" = (
@@ -49787,10 +49778,7 @@
 /area/science/misc_lab)
 "iwZ" = (
 /obj/structure/table/wood,
-/obj/item/reagent_containers/food/condiment/pack/hotsauce{
-	step_x = 8;
-	step_y = 11
-	},
+/obj/item/reagent_containers/food/condiment/pack/hotsauce,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "iBZ" = (
@@ -50034,10 +50022,7 @@
 /area/maintenance/starboard/aft)
 "kti" = (
 /obj/structure/table/wood,
-/obj/item/gun/ballistic/revolver/russian{
-	step_x = 16;
-	step_y = 3
-	},
+/obj/item/gun/ballistic/revolver/russian,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "kwA" = (
@@ -50988,14 +50973,8 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/table/wood/poker,
 /obj/item/coin,
-/obj/item/coin/silver{
-	step_x = -6;
-	step_y = -4
-	},
-/obj/item/coin/iron{
-	step_x = 5;
-	step_y = 4
-	},
+/obj/item/coin/silver,
+/obj/item/coin/iron,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "rcD" = (
@@ -51450,10 +51429,7 @@
 /area/engine/engineering)
 "ugP" = (
 /obj/structure/table/wood/poker,
-/obj/item/clothing/mask/cigarette/cigar{
-	step_x = 2;
-	step_y = 4
-	},
+/obj/item/clothing/mask/cigarette/cigar,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "uhH" = (

--- a/_maps/map_files/Donutstation/Donutstation.dmm
+++ b/_maps/map_files/Donutstation/Donutstation.dmm
@@ -79,17 +79,7 @@
 	},
 /area/hallway/secondary/exit/departure_lounge)
 "aap" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced,
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
 "aaq" = (
@@ -101,16 +91,7 @@
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
 "aas" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/space/basic,
 /area/space/nearstation)
 "aat" = (
@@ -153,7 +134,6 @@
 /turf/open/floor/plating,
 /area/crew_quarters/fitness/recreation)
 "aaB" = (
-/obj/structure/window/reinforced,
 /obj/item/target,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -166,17 +146,6 @@
 	name = "BOMB RANGE"
 	},
 /turf/closed/wall,
-/area/space/nearstation)
-"aaD" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/turf/open/space/basic,
 /area/space/nearstation)
 "aaF" = (
 /obj/structure/chair,
@@ -236,27 +205,7 @@
 /turf/closed/wall/r_wall,
 /area/teleporter)
 "aaQ" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/medical/morgue)
-"aaR" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced,
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/medical/morgue)
 "aaS" = (
@@ -288,14 +237,7 @@
 /turf/open/floor/plating,
 /area/hallway/secondary/exit/departure_lounge)
 "aaX" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/tcommsat/computer)
 "aaY" = (
@@ -336,16 +278,7 @@
 /turf/open/space/basic,
 /area/space)
 "abd" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/quartermaster/storage)
 "abe" = (
@@ -429,34 +362,11 @@
 /turf/open/floor/plating,
 /area/quartermaster/storage)
 "abk" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/quartermaster/miningdock)
-"abl" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/quartermaster/miningdock)
 "abm" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
 "abn" = (
@@ -467,45 +377,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
-"abo" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/hallway/secondary/entry)
 "abp" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/chapel/office)
-"abq" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/hallway/secondary/entry)
 "abr" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/crew_quarters/fitness)
 "abs" = (
@@ -618,17 +495,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
-"abI" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/quartermaster/miningdock)
 "abJ" = (
 /obj/machinery/computer/med_data{
 	dir = 8
@@ -791,14 +657,7 @@
 /turf/open/floor/plasteel,
 /area/science/storage)
 "aci" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/security/checkpoint)
 "acj" = (
@@ -862,14 +721,6 @@
 "acy" = (
 /turf/closed/wall/r_wall,
 /area/science/lab)
-"acz" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/security/checkpoint)
 "acA" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/portable_atmospherics/canister/nitrous_oxide,
@@ -928,19 +779,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/lab)
-"acL" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/maintenance/fore)
 "acN" = (
 /obj/structure/table,
 /obj/item/hand_labeler,
@@ -960,16 +798,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
-"acO" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/hallway/secondary/entry)
 "acP" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -1092,25 +920,7 @@
 /turf/closed/wall/r_wall,
 /area/science/storage)
 "adk" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/science/explab)
-"adl" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/science/explab)
 "adm" = (
@@ -1223,16 +1033,7 @@
 /turf/open/floor/plasteel/white,
 /area/science/lab)
 "adz" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/maintenance/port)
 "adA" = (
@@ -1472,17 +1273,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
-"aeh" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced,
-/turf/open/space/basic,
-/area/space/nearstation)
 "aej" = (
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
@@ -1508,29 +1298,8 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/open/floor/plasteel/white,
 /area/science/explab)
-"aep" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
 "aeq" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced,
+/obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "researchprivate";
 	name = "research privacy shutters"
@@ -1673,17 +1442,6 @@
 /obj/machinery/rnd/server,
 /turf/open/floor/circuit/telecomms/server,
 /area/science/server)
-"aeQ" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/security/checkpoint)
 "aeR" = (
 /obj/machinery/vending/wardrobe/law_wardrobe,
 /turf/open/floor/wood,
@@ -1749,14 +1507,7 @@
 /turf/open/floor/plating,
 /area/storage/tech)
 "afc" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced,
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "afd" = (
@@ -1794,7 +1545,6 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "afg" = (
-/obj/machinery/shieldwallgen,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/dark,
 /area/teleporter)
@@ -1806,7 +1556,6 @@
 /turf/open/floor/plasteel/dark,
 /area/teleporter)
 "afi" = (
-/obj/machinery/shieldwallgen,
 /obj/structure/window/reinforced,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/dark,
@@ -1999,17 +1748,6 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"afD" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/crew_quarters/fitness)
 "afE" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -2069,20 +1807,6 @@
 "afJ" = (
 /turf/closed/wall,
 /area/crew_quarters/heads/hor)
-"afK" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/science/explab)
 "afL" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -2115,16 +1839,6 @@
 "afQ" = (
 /turf/closed/wall/r_wall,
 /area/solar/starboard)
-"afR" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/chapel/office)
 "afS" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/poddoor/shutters{
@@ -2314,31 +2028,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
-"agq" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/chapel/office)
 "agr" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
-"ags" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/chapel/office)
 "agt" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
@@ -2371,16 +2066,6 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
-"agw" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/quartermaster/miningdock)
 "agx" = (
 /obj/machinery/mass_driver{
 	dir = 1;
@@ -2392,14 +2077,6 @@
 	name = "Mass Driver";
 	req_access_txt = "22"
 	},
-/turf/open/floor/plating,
-/area/chapel/office)
-"agy" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/chapel/office)
 "agz" = (
@@ -2504,29 +2181,10 @@
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/hor)
 "agJ" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
+/obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/crew_quarters/heads/hor)
-"agK" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/quartermaster/storage)
 "agL" = (
 /turf/closed/indestructible{
 	desc = "A wall impregnated with Fixium, able to withstand massive explosions with ease";
@@ -2559,17 +2217,6 @@
 	},
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
-"agQ" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/chapel/office)
 "agR" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -2694,21 +2341,6 @@
 	},
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
-"ahi" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/security/brig)
 "ahj" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	name = "output gas connector port"
@@ -2769,17 +2401,6 @@
 	},
 /turf/open/floor/plating,
 /area/quartermaster/storage)
-"aht" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/crew_quarters/heads/hor)
 "ahv" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -2914,28 +2535,6 @@
 "ahM" = (
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/hor)
-"ahN" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/crew_quarters/heads/hor)
-"ahO" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/maintenance/port)
 "ahQ" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
@@ -2997,17 +2596,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/storage/tools)
-"aia" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/quartermaster/storage)
 "aib" = (
 /obj/structure/plasticflaps,
 /obj/machinery/conveyor{
@@ -3032,16 +2620,6 @@
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/captain/private)
-"aie" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/quartermaster/miningdock)
 "aif" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 1
@@ -3111,17 +2689,7 @@
 	},
 /area/science/research)
 "aiq" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced,
+/obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "sciencecheckpoint";
 	name = "checkpoint privacy shutters"
@@ -3212,40 +2780,6 @@
 /obj/item/toy/figure/miner,
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
-"aiD" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/quartermaster/miningdock)
-"aiE" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/quartermaster/storage)
-"aiF" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/quartermaster/storage)
-"aiG" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/quartermaster/storage)
 "aiH" = (
 /obj/machinery/door/airlock/external{
 	name = "Supply Dock Airlock";
@@ -3259,36 +2793,6 @@
 "aiI" = (
 /turf/closed/wall,
 /area/quartermaster/storage)
-"aiJ" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/quartermaster/storage)
-"aiK" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/quartermaster/storage)
-"aiL" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/quartermaster/miningdock)
 "aiM" = (
 /obj/machinery/light/small,
 /turf/open/floor/plasteel,
@@ -3456,22 +2960,6 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel/white,
 /area/science/research)
-"ajk" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "sciencecheckpoint";
-	name = "checkpoint privacy shutters"
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/security/checkpoint/science)
 "ajl" = (
 /obj/machinery/rnd/destructive_analyzer,
 /obj/effect/turf_decal/stripes/line{
@@ -3565,30 +3053,11 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/hop)
 "ajy" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/crew_quarters/heads/hop)
 "ajA" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced,
+/obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/security/prison)
@@ -3631,34 +3100,8 @@
 "ajG" = (
 /turf/open/floor/plating,
 /area/security/prison)
-"ajH" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/tcommsat/computer)
 "ajI" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/bridge)
-"ajJ" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
+/obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/bridge)
@@ -3677,16 +3120,7 @@
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "ajM" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/science/research)
 "ajN" = (
@@ -3712,16 +3146,7 @@
 /turf/open/floor/plasteel/white,
 /area/science/lab)
 "ajQ" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
+/obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/security/brig)
@@ -3751,30 +3176,11 @@
 /turf/closed/wall,
 /area/crew_quarters/heads/hos)
 "ajV" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced,
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/science/mixing)
 "ajW" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "ajX" = (
@@ -3863,14 +3269,7 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "akj" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced,
+/obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
 	id = "brigexternalblast";
 	name = "External Security Blast Door"
@@ -4027,17 +3426,7 @@
 /turf/closed/wall/r_wall,
 /area/security/warden)
 "akG" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced,
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/crew_quarters/bar)
 "akH" = (
@@ -4050,19 +3439,6 @@
 /obj/item/twohanded/required/kirbyplants/dead,
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/hor)
-"akJ" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "sciencecheckpoint";
-	name = "checkpoint privacy shutters"
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/security/checkpoint/science)
 "akK" = (
 /obj/structure/closet/crate{
 	name = "Practice Rifles"
@@ -4457,17 +3833,7 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload)
 "alV" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced,
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/crew_quarters/kitchen)
 "alW" = (
@@ -4545,33 +3911,13 @@
 /turf/open/floor/carpet,
 /area/security/detectives_office)
 "ame" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced,
+/obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "roboticsprivacy";
 	name = "robotics privacy shutters"
 	},
 /turf/open/floor/plating,
 /area/science/robotics/lab)
-"amf" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/crew_quarters/heads/hop)
 "amg" = (
 /obj/machinery/pdapainter,
 /turf/open/floor/wood,
@@ -4590,16 +3936,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"amk" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/science/research)
 "aml" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -4610,36 +3946,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/research)
-"amm" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/science/research)
-"amn" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "sciencecheckpoint";
-	name = "checkpoint privacy shutters"
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/security/checkpoint/science)
 "amo" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /obj/structure/cable,
@@ -4836,17 +4142,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/lab)
-"ana" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/crew_quarters/heads/hop)
 "anb" = (
 /obj/structure/closet/crate,
 /turf/open/floor/plating,
@@ -4904,17 +4199,6 @@
 /obj/structure/cable,
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/captain/private)
-"anh" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/science/research)
 "ani" = (
 /obj/effect/turf_decal/delivery,
 /obj/effect/turf_decal/stripes/line{
@@ -5332,16 +4616,7 @@
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "aoA" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/hydroponics)
 "aoC" = (
@@ -5362,35 +4637,6 @@
 /obj/effect/turf_decal/tile/green,
 /turf/open/floor/plasteel,
 /area/hydroponics)
-"aoE" = (
-/obj/structure/window/reinforced,
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/hydroponics)
-"aoF" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/hydroponics)
-"aoH" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/maintenance/fore)
 "aoJ" = (
 /obj/effect/turf_decal/tile/green,
 /obj/effect/turf_decal/tile/green{
@@ -5446,24 +4692,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
-"aoP" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "sciencecheckpoint";
-	name = "checkpoint privacy shutters"
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/security/checkpoint/science)
 "aoR" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -5640,37 +4868,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
-"apj" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "sciencecheckpoint";
-	name = "checkpoint privacy shutters"
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/security/checkpoint/science)
-"apk" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "sciencecheckpoint";
-	name = "checkpoint privacy shutters"
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/security/checkpoint/science)
 "apl" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
@@ -5996,16 +5193,7 @@
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
 "aqg" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
+/obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "briginteralshutter";
 	name = "Warden Lockdown Shutter"
@@ -6126,14 +5314,7 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "aqv" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
+/obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "medicalcheckpoint";
 	name = "checkpoint privacy shutters"
@@ -6403,17 +5584,6 @@
 /obj/item/target/syndicate,
 /turf/open/floor/plating,
 /area/maintenance/department/security)
-"ard" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/hallway/secondary/entry)
 "are" = (
 /obj/structure/closet/secure_closet/captains,
 /obj/item/pinpointer/nuke,
@@ -6457,24 +5627,7 @@
 /turf/open/floor/plasteel,
 /area/storage/tools)
 "ari" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/storage/tools)
-"arj" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/storage/tools)
 "ark" = (
@@ -6504,14 +5657,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/vacant_room/commissary)
-"aro" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/hallway/secondary/entry)
 "arp" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -6677,17 +5822,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/storage/tools)
-"arG" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/storage/tools)
 "arJ" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -6769,14 +5903,7 @@
 /turf/closed/wall/r_wall,
 /area/ai_monitored/security/armory)
 "arU" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "arV" = (
@@ -6806,32 +5933,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
-"arY" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/storage/tools)
-"arZ" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "medicalcheckpoint";
-	name = "checkpoint privacy shutters"
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/security/checkpoint/medical)
 "asa" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -6902,17 +6003,6 @@
 /obj/item/storage/fancy/donut_box,
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
-"ash" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/maintenance/port)
 "asi" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin{
@@ -6949,14 +6039,6 @@
 /obj/item/stack/sheet/metal/fifty,
 /turf/open/floor/plasteel/white,
 /area/science/lab)
-"asl" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/storage/tools)
 "asm" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -7059,17 +6141,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/storage/tools)
-"asv" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/maintenance/port)
 "asw" = (
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
@@ -7125,15 +6196,7 @@
 /turf/open/floor/plasteel/grimy,
 /area/ai_monitored/turret_protected/aisat/foyer)
 "asD" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 1;
-	layer = 2.9
-	},
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/solar/starboard)
 "asE" = (
@@ -7200,16 +6263,7 @@
 /turf/open/floor/plating,
 /area/solar/starboard)
 "asO" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
+/obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
 	id = "brigexternalblast";
 	name = "External Security Blast Door"
@@ -7262,17 +6316,6 @@
 /obj/machinery/light/small,
 /turf/open/floor/plasteel,
 /area/security/brig)
-"asX" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/tcommsat/computer)
 "asY" = (
 /obj/structure/filingcabinet{
 	pixel_x = 3
@@ -7350,16 +6393,7 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "atg" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/engine/atmos)
 "ath" = (
@@ -7504,60 +6538,19 @@
 	dir = 1
 	},
 /area/hallway/secondary/exit/departure_lounge)
-"atx" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/hallway/secondary/entry)
 "aty" = (
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "atz" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/hallway/secondary/exit/departure_lounge)
-"atA" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/hallway/secondary/entry)
 "atB" = (
 /obj/machinery/space_heater,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos)
-"atC" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/open/floor/plating,
 /area/engine/atmos)
 "atD" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
@@ -7616,16 +6609,7 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "atM" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
+/obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "lawyerprivate";
 	name = "privacy shutters"
@@ -7695,16 +6679,7 @@
 /turf/open/floor/plasteel/grimy,
 /area/tcommsat/computer)
 "atX" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/ai_monitored/security/armory)
 "atY" = (
@@ -7963,14 +6938,7 @@
 /turf/open/floor/plasteel,
 /area/ai_monitored/security/armory)
 "auC" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
+/obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/security/checkpoint)
@@ -8023,17 +6991,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/bridge)
-"auI" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/hallway/secondary/entry)
 "auJ" = (
 /turf/closed/wall,
 /area/ai_monitored/storage/eva)
@@ -8057,17 +7014,6 @@
 "auM" = (
 /obj/structure/closet/crate,
 /turf/open/floor/plasteel,
-/area/engine/atmos)
-"auN" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced,
-/turf/open/floor/plating,
 /area/engine/atmos)
 "auO" = (
 /obj/machinery/door/airlock/command/glass{
@@ -8181,19 +7127,6 @@
 "avd" = (
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/storage/eva)
-"ave" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/hallway/secondary/entry)
 "avf" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -8321,17 +7254,6 @@
 "avt" = (
 /turf/open/floor/plating,
 /area/hallway/secondary/exit/departure_lounge)
-"avu" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/hallway/secondary/exit/departure_lounge)
 "avv" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 9
@@ -8367,25 +7289,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"avA" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/hallway/secondary/exit/departure_lounge)
-"avB" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/hallway/secondary/exit/departure_lounge)
 "avC" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 5
@@ -8421,17 +7324,6 @@
 	},
 /turf/closed/wall/r_wall,
 /area/engine/atmos)
-"avG" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/hallway/secondary/exit/departure_lounge)
 "avH" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/atmos/mix_input{
 	dir = 8
@@ -8454,26 +7346,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/bridge)
-"avK" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/engine/atmos)
 "avL" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 6
 	},
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/engine/atmos)
 "avM" = (
@@ -8481,36 +7358,18 @@
 /area/construction/mining/aux_base)
 "avN" = (
 /obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/purple/visible,
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 4
 	},
 /turf/open/floor/plating,
 /area/engine/atmos)
-"avO" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/hallway/secondary/exit/departure_lounge)
 "avP" = (
 /obj/structure/grille,
 /turf/open/space/basic,
 /area/space/nearstation)
 "avR" = (
 /obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 4
 	},
@@ -8518,10 +7377,6 @@
 /area/engine/atmos)
 "avS" = (
 /obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 4
 	},
@@ -8530,10 +7385,6 @@
 /area/engine/atmos)
 "avT" = (
 /obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 4
 	},
@@ -8563,13 +7414,6 @@
 /area/quartermaster/miningdock)
 "avW" = (
 /obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/manifold/cyan/visible{
 	dir = 4
 	},
@@ -8579,17 +7423,7 @@
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
 	dir = 8
 	},
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/engine/atmos)
 "avY" = (
@@ -8615,15 +7449,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"awc" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 1;
-	layer = 2.9
-	},
-/turf/open/floor/plating,
-/area/solar/starboard)
 "awd" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 8
@@ -8686,20 +7511,6 @@
 /obj/item/stack/sheet/metal/twenty,
 /turf/open/floor/plating,
 /area/construction)
-"awl" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/hallway/secondary/exit/departure_lounge)
 "awm" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -8727,18 +7538,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"awq" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 1;
-	layer = 2.9
-	},
-/turf/open/floor/plating,
-/area/solar/starboard)
 "awr" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -8764,17 +7563,6 @@
 	},
 /turf/closed/wall/r_wall,
 /area/engine/atmos)
-"awu" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/aft)
 "awv" = (
 /obj/structure/sign/departments/evac{
 	pixel_y = 32
@@ -10544,16 +9332,7 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
 "aAD" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
+/obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "hop";
 	name = "Privacy Shutters"
@@ -10582,17 +9361,7 @@
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "aAH" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced,
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/science/xenobiology)
 "aAI" = (
@@ -10677,21 +9446,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/robotics/lab)
-"aAX" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/crew_quarters/heads/hor)
 "aAY" = (
 /obj/machinery/vending/wardrobe/robo_wardrobe,
 /turf/open/floor/plasteel/white,
@@ -10781,17 +9535,7 @@
 /turf/closed/wall,
 /area/science/robotics/mechbay)
 "aBj" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced,
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/science/robotics/mechbay)
 "aBk" = (
@@ -10807,36 +9551,6 @@
 	},
 /turf/open/floor/plating,
 /area/science/robotics/lab)
-"aBl" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/science/robotics/mechbay)
-"aBm" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/science/robotics/mechbay)
-"aBn" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/science/robotics/mechbay)
 "aBo" = (
 /turf/closed/wall/r_wall,
 /area/science/robotics/mechbay)
@@ -10877,17 +9591,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aBt" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced,
+/obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobio3";
 	name = "containment blast door"
@@ -10918,17 +9622,6 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
-"aBw" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/maintenance/port)
 "aBx" = (
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
@@ -10973,45 +9666,7 @@
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "aBD" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/maintenance/fore)
-"aBE" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/maintenance/fore)
-"aBF" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/fore)
-"aBG" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced,
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "aBH" = (
@@ -11146,17 +9801,6 @@
 /obj/structure/cable,
 /turf/open/space/basic,
 /area/space/nearstation)
-"aCb" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/tcommsat/server)
 "aCc" = (
 /obj/machinery/recharge_station,
 /turf/open/floor/plasteel,
@@ -11222,39 +9866,9 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
 "aCj" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/tinted,
-/obj/structure/window/reinforced/tinted{
-	dir = 1
-	},
-/obj/structure/window/reinforced/tinted{
-	dir = 8
-	},
+/obj/effect/spawner/structure/window/reinforced/tinted,
 /turf/open/floor/plating,
 /area/crew_quarters/dorms)
-"aCk" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/tcommsat/server)
-"aCl" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/tcommsat/server)
 "aCm" = (
 /obj/machinery/telecomms/processor/preset_three,
 /turf/open/floor/circuit/green/telecomms/mainframe,
@@ -11280,16 +9894,6 @@
 /obj/structure/cable,
 /turf/open/space/basic,
 /area/space/nearstation)
-"aCr" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/tcommsat/server)
 "aCs" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
@@ -11317,16 +9921,6 @@
 /obj/structure/cable,
 /turf/open/space/basic,
 /area/space/nearstation)
-"aCv" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/tcommsat/server)
 "aCw" = (
 /obj/machinery/telecomms/receiver/preset_right,
 /turf/open/floor/circuit/green/telecomms/mainframe,
@@ -11349,20 +9943,6 @@
 /obj/item/soap/nanotrasen,
 /turf/open/floor/plasteel/freezer,
 /area/security/prison)
-"aCB" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/ai_monitored/storage/eva)
 "aCC" = (
 /obj/machinery/suit_storage_unit/standard_unit,
 /turf/open/floor/plasteel,
@@ -11385,37 +9965,8 @@
 "aCF" = (
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/tcommsat/server)
-"aCG" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/tcommsat/server)
-"aCH" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/tcommsat/server)
 "aCI" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced,
+/obj/effect/spawner/structure/window/reinforced,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -11921,22 +10472,6 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel,
 /area/construction/mining/aux_base)
-"aDX" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "briginteralshutter";
-	name = "Warden Lockdown Shutter"
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/security/warden)
 "aDY" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -12350,7 +10885,6 @@
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
 "aEP" = (
-/obj/machinery/shieldwallgen/xenobiologyaccess,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/science/xenobiology)
@@ -12845,62 +11379,14 @@
 /turf/closed/wall,
 /area/medical/genetics/cloning)
 "aFO" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/medical/genetics/cloning)
-"aFP" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/medical/genetics/cloning)
-"aFQ" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/medical/genetics/cloning)
 "aFR" = (
 /turf/open/floor/plasteel/white,
 /area/medical/genetics/cloning)
-"aFS" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/medical/genetics/cloning)
 "aFT" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/medical/genetics)
-"aFU" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/medical/genetics)
 "aFV" = (
@@ -13007,16 +11493,6 @@
 /obj/machinery/clonepod,
 /turf/open/floor/plasteel/white,
 /area/medical/genetics/cloning)
-"aGi" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/medical/genetics/cloning)
 "aGj" = (
 /obj/structure/bed/roller,
 /obj/effect/turf_decal/bot,
@@ -13043,25 +11519,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "aGl" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/medical/storage)
-"aGm" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/medical/storage)
 "aGn" = (
@@ -13091,17 +11549,6 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
-"aGr" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/medical/genetics/cloning)
 "aGs" = (
 /obj/structure/bed/roller,
 /obj/effect/turf_decal/bot,
@@ -13145,17 +11592,7 @@
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "aGz" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced,
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/medical/medbay/lobby)
 "aGA" = (
@@ -13221,17 +11658,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/genetics/cloning)
 "aGK" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced,
+/obj/effect/spawner/structure/window/reinforced,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -13292,37 +11719,16 @@
 /turf/closed/wall,
 /area/medical/cryo)
 "aGS" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "chemistryshutter";
 	name = "Chemistry Privacy Shutters"
 	},
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/medical/chemistry)
 "aGT" = (
 /turf/closed/wall,
 /area/security/checkpoint/medical)
-"aGU" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "chemistryshutter";
-	name = "Chemistry Privacy Shutters"
-	},
-/turf/open/floor/plating,
-/area/medical/chemistry)
 "aGV" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
@@ -13384,27 +11790,6 @@
 	dir = 6
 	},
 /area/science/research)
-"aHc" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/medical/medbay/lobby)
-"aHd" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/medical/medbay/lobby)
 "aHe" = (
 /obj/structure/table,
 /obj/machinery/button/door{
@@ -13425,16 +11810,7 @@
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/hor)
 "aHf" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/medical/virology)
 "aHg" = (
@@ -13470,37 +11846,13 @@
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "aHk" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced,
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/medical/sleeper)
 "aHm" = (
 /obj/machinery/atmospherics/components/unary/cryo_cell,
 /turf/open/floor/plasteel,
 /area/medical/cryo)
-"aHn" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "chemistryshutter";
-	name = "Chemistry Privacy Shutters"
-	},
-/turf/open/floor/plating,
-/area/medical/chemistry)
 "aHo" = (
 /obj/structure/table,
 /obj/item/circular_saw,
@@ -13513,17 +11865,7 @@
 /turf/open/floor/plasteel/dark,
 /area/science/robotics/lab)
 "aHp" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced,
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/medical/cryo)
 "aHq" = (
@@ -13539,22 +11881,6 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel/white,
 /area/science/research)
-"aHs" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "medicalcheckpoint";
-	name = "checkpoint privacy shutters"
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/security/checkpoint/medical)
 "aHt" = (
 /obj/structure/filingcabinet/chestdrawer,
 /obj/effect/turf_decal/tile/red,
@@ -13587,16 +11913,6 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"aHx" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/medical/virology)
 "aHy" = (
 /obj/structure/closet/l3closet,
 /obj/effect/turf_decal/delivery,
@@ -13698,17 +12014,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
-"aHN" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/medical/medbay/lobby)
 "aHO" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/open/floor/plasteel/white,
@@ -13756,17 +12061,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/open/floor/plasteel/white,
 /area/medical/genetics/cloning)
-"aIb" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/medical/virology)
 "aIc" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -13877,28 +12171,6 @@
 "aIu" = (
 /turf/closed/wall/r_wall,
 /area/medical/sleeper)
-"aIv" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/medical/cryo)
-"aIw" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/medical/cryo)
 "aIx" = (
 /obj/structure/cable,
 /turf/open/floor/plasteel/white,
@@ -14060,16 +12332,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
-"aIV" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard)
 "aIW" = (
 /obj/machinery/door/airlock/maintenance{
 	req_one_access_txt = "12"
@@ -14116,16 +12378,7 @@
 /turf/open/floor/plasteel/white/side,
 /area/medical/sleeper)
 "aJc" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/construction/mining/aux_base)
 "aJd" = (
@@ -14396,33 +12649,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "aJI" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/medical/surgery)
-"aJJ" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/medical/surgery)
-"aJK" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/medical/surgery)
 "aJL" = (
@@ -14447,14 +12674,7 @@
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "aJN" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
+/obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plating,
@@ -14886,17 +13106,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
-"aKP" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/tinted,
-/obj/structure/window/reinforced/tinted{
-	dir = 1
-	},
-/obj/structure/window/reinforced/tinted{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/crew_quarters/dorms)
 "aKQ" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
@@ -15090,31 +13299,12 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "aLw" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/library)
 "aLx" = (
 /obj/structure/bookcase/random/religion,
 /turf/open/floor/wood,
-/area/library)
-"aLy" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/open/floor/plating,
 /area/library)
 "aLz" = (
 /obj/machinery/vending/games,
@@ -15147,17 +13337,6 @@
 /area/library)
 "aLE" = (
 /turf/open/floor/carpet,
-/area/library)
-"aLF" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced,
-/turf/open/floor/plating,
 /area/library)
 "aLG" = (
 /obj/structure/displaycase/trophy,
@@ -15398,67 +13577,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
-"aMp" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/hallway/secondary/entry)
 "aMq" = (
 /turf/closed/wall,
 /area/hydroponics/garden)
 "aMr" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/hydroponics/garden)
-"aMt" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/hydroponics/garden)
 "aMu" = (
 /turf/open/floor/grass,
-/area/hydroponics/garden)
-"aMv" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/hydroponics/garden)
-"aMw" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/turf/open/floor/plating,
 /area/hydroponics/garden)
 "aMx" = (
 /obj/structure/sink{
@@ -15470,58 +13597,9 @@
 /obj/machinery/hydroponics/constructable,
 /turf/open/floor/grass,
 /area/hydroponics/garden)
-"aMz" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/hydroponics/garden)
-"aMA" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/hydroponics/garden)
-"aMB" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/hydroponics/garden)
-"aMC" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/hydroponics/garden)
 "aMD" = (
 /obj/machinery/biogenerator,
 /turf/open/floor/grass,
-/area/hydroponics/garden)
-"aME" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/turf/open/floor/plating,
 /area/hydroponics/garden)
 "aMF" = (
 /obj/machinery/computer/scan_consolenew,
@@ -15546,22 +13624,6 @@
 "aMH" = (
 /obj/machinery/seed_extractor,
 /turf/open/floor/grass,
-/area/hydroponics/garden)
-"aMI" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/hydroponics/garden)
-"aMJ" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/turf/open/floor/plating,
 /area/hydroponics/garden)
 "aML" = (
 /obj/structure/table/reinforced,
@@ -15688,14 +13750,7 @@
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/aisat/foyer)
 "aNg" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
+/obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "aishuttersexternal";
 	name = "AI privacy shutters"
@@ -15710,18 +13765,6 @@
 /area/ai_monitored/turret_protected/aisat/foyer)
 "aNi" = (
 /turf/closed/wall/r_wall,
-/area/ai_monitored/turret_protected/aisat/foyer)
-"aNj" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "aishuttersexternal";
-	name = "AI privacy shutters"
-	},
-/turf/open/floor/plating,
 /area/ai_monitored/turret_protected/aisat/foyer)
 "aNk" = (
 /obj/effect/decal/cleanable/dirt,
@@ -15741,21 +13784,6 @@
 "aNl" = (
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat/foyer)
-"aNn" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "aishuttersexternal";
-	name = "AI privacy shutters"
-	},
-/turf/open/floor/plating,
-/area/ai_monitored/turret_protected/aisat/foyer)
 "aNo" = (
 /obj/machinery/door/airlock/hatch{
 	name = "MiniSat Space Access Airlock";
@@ -15764,17 +13792,7 @@
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/aisat/foyer)
 "aNp" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced,
+/obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "aishuttersexternal";
 	name = "AI privacy shutters"
@@ -15923,21 +13941,6 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/medical/cryo)
-"aNO" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "chemistryshutter";
-	name = "Chemistry Privacy Shutters"
-	},
-/turf/open/floor/plating,
-/area/medical/chemistry)
 "aNQ" = (
 /obj/structure/chair/office/light{
 	dir = 1
@@ -15975,16 +13978,7 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/engine_room/external)
 "aNU" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/security/processing)
 "aNV" = (
@@ -16017,16 +14011,6 @@
 /obj/machinery/recharger,
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/main)
-"aNY" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/security/processing)
 "aNZ" = (
 /turf/open/floor/plating,
 /area/security/processing)
@@ -16043,17 +14027,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/security/brig)
-"aOb" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/security/processing)
 "aOc" = (
 /obj/machinery/door/airlock/security{
 	name = "Security Office";
@@ -16154,17 +14127,7 @@
 /turf/closed/wall,
 /area/security/courtroom)
 "aOq" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced,
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/security/courtroom)
 "aOr" = (
@@ -16269,19 +14232,6 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/security/brig)
-"aOH" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/security/courtroom)
 "aOI" = (
 /turf/open/floor/plasteel,
 /area/security/courtroom)
@@ -16333,16 +14283,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/security/courtroom)
-"aOQ" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/open/floor/plating,
 /area/security/courtroom)
 "aOR" = (
 /obj/structure/bed,
@@ -16423,17 +14363,6 @@
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/hos)
-"aPb" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/security/courtroom)
 "aPc" = (
 /obj/machinery/door/airlock/security{
 	name = "Brig";
@@ -16506,22 +14435,12 @@
 /turf/closed/wall/r_wall,
 /area/engine/atmos)
 "aPq" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /obj/machinery/door/poddoor/preopen{
 	id = "atmos";
 	name = "Atmospherics Lockdown"
 	},
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "aPr" = (
@@ -16554,17 +14473,6 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "aPt" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/layer_manifold{
 	dir = 4
 	},
@@ -16572,6 +14480,7 @@
 	id = "atmos";
 	name = "Atmospherics Lockdown"
 	},
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "aPu" = (
@@ -16649,20 +14558,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
-"aPB" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/quartermaster/storage)
 "aPC" = (
 /obj/structure/table/reinforced,
 /obj/item/paper_bin{
@@ -17007,52 +14902,12 @@
 /obj/effect/landmark/start/medical_doctor,
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
-"aQu" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "lawyerprivate";
-	name = "privacy shutters"
-	},
-/turf/open/floor/plating,
-/area/lawoffice)
-"aQv" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "lawyerprivate";
-	name = "privacy shutters"
-	},
-/turf/open/floor/plating,
-/area/lawoffice)
 "aQw" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
 /turf/open/floor/wood,
-/area/lawoffice)
-"aQx" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "lawyerprivate";
-	name = "privacy shutters"
-	},
-/turf/open/floor/plating,
 /area/lawoffice)
 "aQy" = (
 /obj/structure/rack,
@@ -17068,17 +14923,6 @@
 	},
 /turf/open/floor/wood,
 /area/lawoffice)
-"aQz" = (
-/obj/structure/window/reinforced,
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/hydroponics)
 "aQA" = (
 /obj/machinery/door/airlock/medical/glass{
 	name = "Hydroponics";
@@ -17099,17 +14943,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
-"aQC" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/hydroponics)
 "aQD" = (
 /obj/structure/chair{
 	dir = 1
@@ -17164,14 +14997,6 @@
 "aQI" = (
 /turf/open/floor/plating,
 /area/maintenance/department/security)
-"aQJ" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/maintenance/aft)
 "aQK" = (
 /turf/closed/wall,
 /area/maintenance/department/security)
@@ -17271,24 +15096,6 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/medical/cryo)
-"aQZ" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "medicalcheckpoint";
-	name = "checkpoint privacy shutters"
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/security/checkpoint/medical)
 "aRa" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/firedoor,
@@ -17326,19 +15133,9 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "aRh" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/engine/atmos)
 "aRi" = (
@@ -17392,17 +15189,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aRr" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced,
+/obj/effect/spawner/structure/window/reinforced,
 /obj/structure/barricade/wooden/crude,
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
@@ -17463,19 +15250,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
-"aRH" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/fore)
 "aRI" = (
 /obj/machinery/computer/atmos_alert{
 	dir = 4
@@ -17494,16 +15268,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"aRK" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/fore)
 "aRL" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 5
@@ -17582,28 +15346,8 @@
 /obj/machinery/light/small,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
-"aRX" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/maintenance/port/fore)
 "aRY" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "aRZ" = (
@@ -17611,17 +15355,6 @@
 /area/maintenance/starboard/fore)
 "aSa" = (
 /turf/closed/wall,
-/area/maintenance/starboard/fore)
-"aSb" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced,
-/turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "aSc" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
@@ -17894,17 +15627,7 @@
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
 "aSO" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced,
+/obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /turf/open/floor/plating,
 /area/maintenance/disposal/incinerator)
@@ -18176,33 +15899,7 @@
 /turf/open/floor/plasteel,
 /area/medical/sleeper)
 "aTE" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/security)
-"aTF" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/maintenance/department/security)
-"aTG" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/maintenance/department/security)
 "aTI" = (
@@ -18640,25 +16337,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "aUC" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/engine/gravity_generator)
-"aUD" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/engine/gravity_generator)
 "aUE" = (
@@ -18824,28 +16503,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
-"aVc" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/hallway/secondary/exit/departure_lounge)
-"aVd" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/hallway/secondary/exit/departure_lounge)
 "aVe" = (
 /obj/structure/closet/toolcloset,
 /obj/effect/turf_decal/tile/yellow{
@@ -18879,17 +16536,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/construction/mining/aux_base)
-"aVh" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced,
-/turf/open/floor/plating,
 /area/construction/mining/aux_base)
 "aVi" = (
 /obj/effect/turf_decal/tile/yellow{
@@ -18991,16 +16637,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/construction/mining/aux_base)
-"aVs" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/construction/mining/aux_base)
 "aVt" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable,
@@ -19083,21 +16719,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/security/checkpoint/medical)
-"aVG" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "medicalcheckpoint";
-	name = "checkpoint privacy shutters"
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
 /area/security/checkpoint/medical)
 "aVH" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -19189,25 +16810,6 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/security/brig)
-"aVT" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "briginteralshutter";
-	name = "Warden Lockdown Shutter"
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/security/warden)
 "aVU" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -19249,37 +16851,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
 /area/security/prison)
-"aVZ" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "hop";
-	name = "Privacy Shutters"
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/crew_quarters/heads/hop)
-"aWb" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id = "brigexternalblast";
-	name = "External Security Blast Door"
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/security/brig)
 "aWc" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -19381,17 +16952,7 @@
 /turf/open/floor/plasteel,
 /area/security/processing)
 "aWn" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced,
+/obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/security/main)
@@ -19428,55 +16989,6 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/main)
-"aWu" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "brigexternalblast";
-	name = "External Security Blast Door"
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/security/brig)
-"aWv" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id = "brigexternalblast";
-	name = "External Security Blast Door"
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/security/brig)
-"aWw" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "brigexternalblast";
-	name = "External Security Blast Door"
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/security/brig)
 "aWy" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
 	dir = 4
@@ -19625,17 +17137,7 @@
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "aWT" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced,
+/obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "briginteralshutter";
 	name = "Warden Lockdown Shutter"
@@ -19645,17 +17147,7 @@
 /turf/open/floor/plating,
 /area/security/warden)
 "aWU" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced,
+/obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/crew_quarters/heads/hos)
@@ -19679,17 +17171,7 @@
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/hos)
 "aXb" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced,
+/obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "hop";
 	name = "Privacy Shutters"
@@ -19832,17 +17314,7 @@
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "aXn" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced,
+/obj/effect/spawner/structure/window/reinforced,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -19853,17 +17325,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "aXp" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced,
+/obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 10
 	},
@@ -20033,16 +17495,10 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
 "aXN" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/medical/medbay/lobby)
 "aXP" = (
@@ -20166,17 +17622,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "aYb" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced,
+/obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 10
 	},
@@ -20284,22 +17730,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
-"aYr" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "medicalcheckpoint";
-	name = "checkpoint privacy shutters"
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/security/checkpoint/medical)
 "aYs" = (
 /obj/effect/turf_decal/tile/yellow,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
@@ -21886,19 +19316,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
-"bcc" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/hallway/secondary/exit/departure_lounge)
 "bcd" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -22100,14 +19517,6 @@
 	dir = 5
 	},
 /area/crew_quarters/kitchen)
-"bcB" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/hallway/secondary/exit/departure_lounge)
 "bcC" = (
 /turf/closed/wall,
 /area/maintenance/disposal)
@@ -22158,19 +19567,6 @@
 	dir = 1
 	},
 /area/crew_quarters/theatre)
-"bcG" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/maintenance/aft)
 "bcH" = (
 /obj/structure/chair{
 	dir = 4
@@ -22226,22 +19622,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/department/security)
-"bcP" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/engine/atmos)
 "bcQ" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Medical Maintenance Access";
@@ -22605,17 +19985,7 @@
 /turf/open/floor/plasteel,
 /area/medical/cryo)
 "bdR" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced,
+/obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plating,
 /area/medical/virology)
@@ -22641,17 +20011,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "bdV" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced,
+/obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 10
 	},
@@ -22769,17 +20129,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "bek" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced,
+/obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
 	},
@@ -22898,20 +20248,10 @@
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "bez" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment,
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "beA" = (
@@ -23022,14 +20362,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "beN" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
+/obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/crew_quarters/heads/cmo)
@@ -23265,18 +20598,14 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "bfn" = (
-/obj/structure/window/reinforced,
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 8
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "chemistryshutter";
 	name = "Chemistry Privacy Shutters"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/medical/chemistry)
 "bfo" = (
@@ -23473,23 +20802,6 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
-"bfI" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "chemistryshutter";
-	name = "Chemistry Privacy Shutters"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/medical/chemistry)
 "bfJ" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -23662,14 +20974,6 @@
 	},
 /turf/open/floor/plating,
 /area/crew_quarters/fitness/recreation)
-"bgg" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/maintenance/port/fore)
 "bgh" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -24413,42 +21717,6 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
-"bhX" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/crew_quarters/heads/cmo)
-"bhY" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/crew_quarters/heads/cmo)
-"bhZ" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/crew_quarters/heads/cmo)
 "bia" = (
 /obj/structure/chair{
 	dir = 4
@@ -24758,17 +22026,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
-"biU" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/ai_monitored/security/armory)
 "biV" = (
 /obj/machinery/suit_storage_unit/security,
 /obj/effect/turf_decal/tile/red{
@@ -24799,59 +22056,8 @@
 /obj/item/gun/grenadelauncher,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
-"biX" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/ai_monitored/security/armory)
-"biY" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id = "brigexternalblast";
-	name = "External Security Blast Door"
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/security/brig)
-"biZ" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "brigexternalblast";
-	name = "External Security Blast Door"
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/security/brig)
 "bja" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 1;
-	layer = 2.9
-	},
-/obj/structure/window/reinforced,
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/solar/aft)
 "bjb" = (
@@ -25395,33 +22601,12 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/security/prison)
-"bkf" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/crew_quarters/heads/hor)
 "bkg" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/science/robotics/lab)
-"bkh" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/crew_quarters/heads/hor)
 "bki" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -25518,18 +22703,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
 /area/science/research)
-"bkq" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/crew_quarters/heads/hor)
 "bkr" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -25965,17 +23138,7 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
 "blj" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced,
+/obj/effect/spawner/structure/window/reinforced,
 /obj/structure/sign/warning/securearea{
 	desc = "A warning sign which reads 'SERVER ROOM'.";
 	name = "SERVER ROOM";
@@ -25991,17 +23154,7 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/fitness)
 "bll" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced,
+/obj/effect/spawner/structure/window/reinforced,
 /obj/structure/sign/warning/securearea{
 	desc = "A warning sign which reads 'SERVER ROOM'.";
 	name = "SERVER ROOM";
@@ -26364,17 +23517,7 @@
 /turf/open/floor/plasteel,
 /area/security/checkpoint)
 "bmb" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced,
+/obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "robotics2";
 	name = "robotics lab shutters"
@@ -26416,16 +23559,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/security)
 "bmh" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
+/obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/medical/genetics/cloning)
@@ -26981,17 +24115,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/circuit,
 /area/science/robotics/mechbay)
-"bnF" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/fore)
 "bnG" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/mech_bay_recharge_floor,
@@ -27072,16 +24195,7 @@
 /turf/open/floor/plasteel,
 /area/science/robotics/mechbay)
 "bnO" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
+/obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
 	id = "xenocontainment";
 	name = "containment chamber blastdoor"
@@ -27151,17 +24265,7 @@
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "bnT" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced,
+/obj/effect/spawner/structure/window/reinforced,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobio3";
@@ -27449,17 +24553,7 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "boJ" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced,
+/obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobio2";
 	name = "containment blast door"
@@ -27533,29 +24627,8 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
-"boV" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/science/explab)
 "boX" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced,
+/obj/effect/spawner/structure/window/reinforced,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobio2";
@@ -28038,17 +25111,7 @@
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "bqt" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced,
+/obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobio1";
 	name = "containment blast door"
@@ -28101,17 +25164,7 @@
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "bqy" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced,
+/obj/effect/spawner/structure/window/reinforced,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobio1";
@@ -28217,17 +25270,7 @@
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "bqG" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced,
+/obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobio6";
 	name = "containment blast door"
@@ -28248,17 +25291,7 @@
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "bqI" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced,
+/obj/effect/spawner/structure/window/reinforced,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobio6";
@@ -28268,17 +25301,7 @@
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "bqJ" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced,
+/obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobio5";
 	name = "containment blast door"
@@ -28299,17 +25322,7 @@
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "bqL" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced,
+/obj/effect/spawner/structure/window/reinforced,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobio5";
@@ -28319,17 +25332,7 @@
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "bqM" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced,
+/obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobio4";
 	name = "containment blast door"
@@ -28350,17 +25353,7 @@
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "bqO" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced,
+/obj/effect/spawner/structure/window/reinforced,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobio4";
@@ -28782,27 +25775,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/solar/aft)
-"brI" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 1;
-	layer = 2.9
-	},
-/turf/open/floor/plating,
-/area/solar/aft)
-"brJ" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 1;
-	layer = 2.9
-	},
-/turf/open/floor/plating,
-/area/solar/aft)
 "brK" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	name = "Air to Ports"
@@ -29068,14 +26040,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bsr" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced,
+/obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "kanyewest";
 	name = "privacy shutters"
@@ -29426,21 +26391,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"btd" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "kanyewest";
-	name = "privacy shutters"
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/security/detectives_office)
 "bte" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -29873,21 +26823,6 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"bub" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "lawyerprivate";
-	name = "privacy shutters"
-	},
-/turf/open/floor/plating,
-/area/lawoffice)
 "bud" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
@@ -30836,18 +27771,6 @@
 	dir = 4
 	},
 /area/hallway/secondary/exit/departure_lounge)
-"bwd" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/security/checkpoint)
 "bwe" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -31399,17 +28322,6 @@
 /turf/open/floor/plasteel/white,
 /area/science/lab)
 "bxu" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "researchprivate";
 	name = "research privacy shutters"
@@ -31417,6 +28329,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/science/lab)
 "bxv" = (
@@ -31491,53 +28404,7 @@
 /turf/open/floor/wood,
 /area/library)
 "bxz" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/ai_monitored/storage/eva)
-"bxA" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/ai_monitored/storage/eva)
-"bxB" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/ai_monitored/storage/eva)
-"bxC" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/ai_monitored/storage/eva)
-"bxD" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced,
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/ai_monitored/storage/eva)
 "bxF" = (
@@ -31896,35 +28763,6 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"byG" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "kanyewest";
-	name = "privacy shutters"
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/security/detectives_office)
-"byH" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "kanyewest";
-	name = "privacy shutters"
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/security/detectives_office)
 "byJ" = (
 /obj/machinery/power/smes{
 	charge = 5e+006
@@ -32005,25 +28843,7 @@
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "byR" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/quartermaster/qm)
-"byS" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/quartermaster/qm)
 "byT" = (
@@ -32053,17 +28873,6 @@
 /obj/structure/disposalpipe/trunk,
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
-"byX" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/quartermaster/storage)
 "byZ" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -32134,19 +28943,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/quartermaster/qm)
-"bzf" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/turf/open/floor/plating,
 /area/quartermaster/qm)
 "bzg" = (
 /obj/structure/closet/emcloset,
@@ -32619,16 +29415,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
-"bAg" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/quartermaster/qm)
 "bAh" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -32646,20 +29432,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
-"bAj" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/chapel/office)
 "bAk" = (
 /turf/open/floor/plasteel/chapel{
 	dir = 1
@@ -32694,17 +29466,7 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload)
 "bAr" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced,
+/obj/effect/spawner/structure/window/reinforced,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -33159,17 +29921,7 @@
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "bBs" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced,
+/obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "roboticsprivacy";
 	name = "robotics privacy shutters"
@@ -33421,16 +30173,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "bBV" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
+/obj/effect/spawner/structure/window/reinforced,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -33537,22 +30280,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"bCj" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "hop";
-	name = "Privacy Shutters"
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/crew_quarters/heads/hop)
 "bCk" = (
 /obj/structure/table,
 /obj/item/paper_bin{
@@ -33585,17 +30312,7 @@
 /turf/open/floor/wood,
 /area/crew_quarters/heads/hop)
 "bCn" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced,
+/obj/effect/spawner/structure/window/reinforced,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -33657,32 +30374,6 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/hop)
-"bCt" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/bridge)
-"bCu" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/security/checkpoint)
 "bCv" = (
 /obj/structure/table/reinforced,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -33869,16 +30560,7 @@
 /turf/open/floor/grass,
 /area/hydroponics/garden)
 "bCT" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "bCU" = (
@@ -33903,17 +30585,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/disposal)
-"bCW" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/maintenance/aft)
 "bCY" = (
 /obj/machinery/mineral/stacking_machine{
 	input_dir = 1;
@@ -33930,16 +30601,6 @@
 	machinedir = 8
 	},
 /turf/closed/wall,
-/area/maintenance/disposal)
-"bDa" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/open/floor/plating,
 /area/maintenance/disposal)
 "bDb" = (
 /obj/effect/turf_decal/stripes/line{
@@ -34407,13 +31068,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bDV" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
+/obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "kanyewest";
 	name = "privacy shutters"
@@ -34463,17 +31118,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
-"bEc" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/quartermaster/qm)
 "bEd" = (
 /obj/machinery/navbeacon{
 	codes_txt = "delivery;dir=8";
@@ -34520,14 +31164,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
 "bEk" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
+/obj/effect/spawner/structure/window/reinforced,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/quartermaster/qm)
@@ -34549,10 +31186,6 @@
 	home_destination = "QM #2";
 	suffix = "#2"
 	},
-/turf/open/floor/plasteel,
-/area/quartermaster/office)
-"bEm" = (
-/obj/structure/window/reinforced,
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "bEn" = (
@@ -34975,17 +31608,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
-"bFf" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/quartermaster/office)
 "bFg" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/delivery,
@@ -35003,17 +31625,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "bFi" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced,
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/quartermaster/office)
 "bFj" = (
@@ -35180,14 +31792,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bFv" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced,
+/obj/effect/spawner/structure/window/reinforced,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -35269,17 +31874,7 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "bFG" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced,
+/obj/effect/spawner/structure/window/reinforced,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -35446,17 +32041,7 @@
 /turf/open/floor/plasteel,
 /area/security/main)
 "bGa" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced,
+/obj/effect/spawner/structure/window/reinforced,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -35528,17 +32113,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/security)
 "bGm" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced,
+/obj/effect/spawner/structure/window/reinforced,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/security/courtroom)
@@ -36455,20 +33030,6 @@
 /obj/machinery/telecomms/server/presets/engineering,
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/tcommsat/server)
-"bId" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/tcommsat/computer)
 "bIe" = (
 /obj/machinery/blackbox_recorder,
 /turf/open/floor/circuit/telecomms/mainframe,
@@ -36495,6 +33056,7 @@
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/tcommsat/server)
 "bIk" = (
+/obj/machinery/telecomms/message_server/preset,
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/tcommsat/server)
 "bIl" = (
@@ -36673,17 +33235,7 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "bIF" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced,
+/obj/effect/spawner/structure/window/reinforced,
 /obj/structure/transit_tube/horizontal,
 /turf/open/floor/plating,
 /area/tcommsat/computer)
@@ -36734,15 +33286,7 @@
 /turf/open/floor/plasteel/grimy,
 /area/tcommsat/computer)
 "bIP" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced,
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/tcommsat/server)
 "bIQ" = (
@@ -37310,15 +33854,6 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
-"bKB" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/bridge)
 "bKC" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
@@ -38092,16 +34627,7 @@
 /turf/closed/wall,
 /area/crew_quarters/fitness/locker_room)
 "bMy" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
+/obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
 	id = "xenocontainment";
 	name = "containment chamber blastdoor"
@@ -38193,6 +34719,7 @@
 /obj/machinery/power/smes{
 	charge = 5e+006
 	},
+/obj/structure/cable,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai)
 "bMI" = (
@@ -39139,20 +35666,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/gateway)
-"bPb" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 1;
-	layer = 2.9
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/engine/atmos)
 "bPc" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
@@ -39727,34 +36240,10 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plating,
 /area/maintenance/fore)
-"bQC" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard)
 "bQD" = (
 /obj/structure/chair{
 	dir = 4
 	},
-/turf/open/floor/plating,
-/area/maintenance/starboard)
-"bQE" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "bQF" = (
@@ -40844,14 +37333,7 @@
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "bTk" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced,
+/obj/effect/spawner/structure/window/reinforced,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -41476,17 +37958,6 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/engine/gravity_generator)
-"bUG" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/quartermaster/office)
 "bUH" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
@@ -41515,14 +37986,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "bUK" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
+/obj/effect/spawner/structure/window/reinforced,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/quartermaster/office)
@@ -41786,17 +38250,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "bVw" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced,
+/obj/effect/spawner/structure/window/reinforced,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/quartermaster/storage)
@@ -41901,14 +38355,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"bVL" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/maintenance/port)
 "bVM" = (
 /turf/closed/wall,
 /area/maintenance/department/crew_quarters/bar)
@@ -41993,17 +38439,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "bVY" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced,
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
 "bVZ" = (
@@ -42323,14 +38759,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "bWK" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "bWL" = (
@@ -42622,25 +39051,6 @@
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"bXI" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
-"bXJ" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
 "bXK" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer/on{
 	dir = 8
@@ -43184,17 +39594,6 @@
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/plating,
 /area/maintenance/port)
-"bZy" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/maintenance/disposal)
 "bZz" = (
 /obj/structure/closet/crate,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -44027,14 +40426,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "cbI" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced,
+/obj/effect/spawner/structure/window/reinforced,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -44141,9 +40533,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics/cloning)
 "cbT" = (
@@ -44179,22 +40568,6 @@
 /obj/machinery/status_display,
 /turf/closed/wall,
 /area/lawoffice)
-"cbZ" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id = "xenocontainment";
-	name = "containment chamber blastdoor"
-	},
-/obj/structure/cable,
-/turf/open/floor/engine,
-/area/science/xenobiology)
 "cca" = (
 /obj/item/toy/figure/scientist,
 /obj/machinery/light/small,
@@ -44463,19 +40836,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/disposal)
-"ccL" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/maintenance/disposal)
 "ccM" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
@@ -44503,45 +40863,8 @@
 /obj/structure/fans/tiny,
 /turf/open/floor/plating,
 /area/maintenance/disposal)
-"ccP" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/maintenance/disposal)
-"ccQ" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/maintenance/disposal)
-"ccR" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/maintenance/disposal)
 "ccS" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced,
+/obj/effect/spawner/structure/window/reinforced,
 /obj/structure/transit_tube/curved/flipped{
 	dir = 4
 	},
@@ -44560,14 +40883,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "ccW" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
+/obj/effect/spawner/structure/window/reinforced,
 /obj/structure/transit_tube/curved{
 	dir = 8
 	},
@@ -44782,17 +41098,7 @@
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/aisat/foyer)
 "cdx" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced,
+/obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "aishuttersexternal";
 	name = "AI privacy shutters"
@@ -45835,17 +42141,7 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "dUt" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced,
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/engine/engineering)
 "dUT" = (
@@ -45925,14 +42221,6 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel/dark/telecomms,
 /area/tcommsat/server)
-"elZ" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/engine/engineering)
 "emg" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
@@ -46296,12 +42584,7 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/engine_room)
 "fhM" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 1;
-	layer = 2.9
-	},
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/space)
 "fid" = (
@@ -47238,17 +43521,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/medical/cryo)
-"iIq" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/engine/engineering)
 "iJC" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
@@ -47641,17 +43913,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
 "kAG" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced,
+/obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/crew_quarters/heads/chief)
@@ -47689,18 +43951,6 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
-"kCA" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 1;
-	layer = 2.9
-	},
-/turf/open/floor/plating,
-/area/space)
 "kDh" = (
 /obj/machinery/suit_storage_unit/security,
 /obj/effect/turf_decal/tile/red{
@@ -47957,18 +44207,6 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/engine/engine_room)
-"lKv" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 1;
-	layer = 2.9
-	},
-/turf/open/floor/plating,
-/area/space/nearstation)
 "lLE" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
@@ -48705,12 +44943,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "ocL" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 1;
-	layer = 2.9
-	},
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/space/nearstation)
 "odJ" = (
@@ -49088,17 +45321,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/medical)
-"pmD" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/engine/engineering)
 "ppV" = (
 /turf/closed/wall/r_wall,
 /area/hydroponics)
@@ -49278,9 +45500,6 @@
 	pixel_y = -23
 	},
 /obj/item/toy/figure/geneticist,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
 /obj/structure/cable,
 /turf/open/floor/plasteel/white,
 /area/medical/genetics/cloning)
@@ -49881,16 +46100,10 @@
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "srD" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/layer_manifold{
 	dir = 4
 	},
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/engine/atmos)
 "stN" = (
@@ -50055,18 +46268,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"tcB" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/crew_quarters/heads/chief)
 "tdw" = (
 /obj/machinery/power/apc{
 	areastring = "/area/crew_quarters/heads/cmo";
@@ -50504,17 +46705,7 @@
 /area/maintenance/port/fore)
 "uEJ" = (
 /obj/structure/cable,
-/obj/structure/grille,
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/engine/engine_room)
 "uIo" = (
@@ -50590,17 +46781,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced,
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/engine/atmos)
 "uUp" = (
@@ -51110,20 +47291,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"wpG" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/crew_quarters/heads/chief)
 "wrV" = (
 /obj/structure/kitchenspike,
 /obj/item/radio/intercom{
@@ -55614,9 +51781,9 @@ aaa
 aaa
 aal
 aal
-aeh
+aas
 aab
-aeh
+aas
 aal
 aal
 aaa
@@ -55871,9 +52038,9 @@ aaa
 aal
 aal
 aaC
-aep
+aas
 agL
-aep
+aas
 aaC
 aal
 aal
@@ -56127,12 +52294,12 @@ aaa
 aal
 aal
 aas
-aaD
+aas
 aeC
 agM
 agS
 aas
-aaD
+aas
 aal
 aal
 aaa
@@ -57155,12 +53322,12 @@ aaa
 aal
 aal
 aas
-aaD
+aas
 agB
 agP
 ahc
 aas
-aaD
+aas
 aal
 aal
 aaa
@@ -57413,9 +53580,9 @@ aaa
 aal
 aal
 aaC
-aeh
+aas
 agR
-aeh
+aas
 aaC
 aal
 aal
@@ -57670,9 +53837,9 @@ aaa
 aaa
 aal
 aal
-aep
+aas
 agP
-aep
+aas
 aal
 aal
 aaa
@@ -66160,15 +62327,15 @@ aaa
 aeS
 aeS
 aeS
-aRH
-aRK
-aRK
-aRK
-aRK
-aRK
-aRK
-aRK
-aRX
+arU
+arU
+arU
+arU
+arU
+arU
+arU
+arU
+arU
 aeS
 aeS
 aeS
@@ -68222,7 +64389,7 @@ bnO
 bTk
 bTl
 bMy
-cbZ
+bnO
 aEP
 ano
 bXN
@@ -68519,7 +64686,7 @@ aug
 aug
 aaN
 atO
-bId
+aaX
 aaN
 aaN
 aaN
@@ -69005,13 +65172,13 @@ aeS
 acB
 acB
 adz
-ahO
-ahO
-ahO
-ahO
-ahO
-ahO
-aBw
+adz
+adz
+adz
+adz
+adz
+adz
+adz
 acB
 acB
 aaa
@@ -69495,9 +65662,9 @@ bTy
 agU
 bSc
 ajM
-amk
-amk
-anh
+ajM
+ajM
+ajM
 ano
 ano
 ano
@@ -69736,12 +65903,12 @@ aeS
 aeS
 aeS
 aeS
-aRH
-aRK
-aRK
-aRK
-aRK
-aRX
+arU
+arU
+arU
+arU
+arU
+arU
 aeS
 aeS
 aeS
@@ -70036,7 +66203,7 @@ bmk
 aGE
 aGE
 aHf
-aIb
+aHf
 aGE
 aGE
 bMs
@@ -70058,7 +66225,7 @@ aal
 aaa
 aaa
 aaa
-ajH
+aaX
 atm
 atV
 bIw
@@ -70066,9 +66233,9 @@ bIw
 bIx
 bIw
 bIw
-aCb
-aCr
-aCG
+bIP
+bIP
+bIP
 elA
 elA
 elA
@@ -70315,7 +66482,7 @@ aal
 aaa
 aaa
 aaa
-ajH
+aaX
 atn
 atW
 bIx
@@ -70523,9 +66690,9 @@ aco
 aco
 aco
 aco
-amm
+ajM
 bkv
-amm
+ajM
 ano
 ano
 ano
@@ -70572,7 +66739,7 @@ aal
 aaa
 aaa
 aaa
-ajH
+aaX
 atn
 atW
 bIw
@@ -70580,9 +66747,9 @@ bIw
 bIw
 bIw
 bIw
-aCk
-aCv
-aCH
+bIP
+bIP
+bIP
 elA
 elA
 elA
@@ -70829,7 +66996,7 @@ aal
 aal
 aal
 aal
-asX
+aaX
 ato
 aBN
 bIB
@@ -70837,7 +67004,7 @@ bIJ
 bIw
 bIw
 bIw
-aCl
+bIP
 aCw
 aCF
 aCp
@@ -71525,7 +67692,7 @@ aaa
 aaa
 aal
 aal
-bnF
+arU
 bWZ
 bXa
 bTU
@@ -71573,9 +67740,9 @@ bYm
 cbF
 aGE
 aHf
-aHx
-aHx
-aIb
+aHf
+aHf
+aHf
 aGO
 aGO
 bee
@@ -71588,7 +67755,7 @@ bRj
 acB
 aCK
 bAA
-ash
+adz
 aaa
 aaa
 aaa
@@ -71845,7 +68012,7 @@ bYu
 acB
 bLA
 ccU
-asv
+adz
 aaa
 aaa
 aaa
@@ -72557,10 +68724,10 @@ aaa
 aaa
 aaa
 aal
-bgg
+arU
 bYc
 bml
-bgg
+arU
 aal
 acm
 acr
@@ -72814,10 +68981,10 @@ aaa
 aaa
 aaa
 aal
-bnF
+arU
 bTU
 bml
-bnF
+arU
 aal
 acm
 acr
@@ -74123,7 +70290,7 @@ blV
 ahI
 bgO
 bko
-bkf
+agJ
 blE
 aoN
 bkG
@@ -74364,10 +70531,10 @@ rBV
 bYc
 aeS
 aeS
-aRH
-aRK
-aRK
-aRX
+arU
+arU
+arU
+arU
 aeS
 aeS
 bbT
@@ -74380,7 +70547,7 @@ aho
 ahJ
 bjY
 bkt
-bkh
+agJ
 afN
 ajc
 ili
@@ -74637,7 +70804,7 @@ ahp
 ahK
 bka
 ajf
-bkh
+agJ
 afN
 ajc
 afO
@@ -74675,7 +70842,7 @@ aIY
 aIY
 bMs
 bfq
-ash
+adz
 ctw
 bVZ
 cep
@@ -74894,7 +71061,7 @@ ahr
 ahL
 bAV
 bBt
-bkh
+agJ
 afN
 ajc
 afO
@@ -74907,7 +71074,7 @@ aKp
 aBU
 aGn
 bhT
-aFP
+aFO
 aGg
 aQD
 cbK
@@ -74932,7 +71099,7 @@ bNI
 aIY
 bYm
 bZp
-bVL
+adz
 ctw
 bWk
 bVY
@@ -75128,7 +71295,7 @@ adO
 adO
 aCg
 abr
-afD
+abr
 aCg
 adO
 adO
@@ -75143,7 +71310,7 @@ acp
 acp
 acp
 bBV
-boV
+adk
 acp
 acp
 agI
@@ -75151,7 +71318,7 @@ aGC
 ahM
 bAW
 ajh
-bkh
+agJ
 afN
 ajc
 afO
@@ -75164,7 +71331,7 @@ aYc
 aBU
 aGn
 bhU
-aFQ
+aFO
 aGh
 aFR
 cbL
@@ -75174,13 +71341,13 @@ aHm
 aNN
 bdQ
 aIi
-aIw
+aHp
 aGt
 bBQ
 aIY
 aJi
 aJi
-aJJ
+aJI
 aJQ
 aKa
 bdp
@@ -75189,7 +71356,7 @@ biB
 aIY
 ctw
 bZq
-bVL
+adz
 ctw
 bWk
 bVM
@@ -75408,7 +71575,7 @@ aHe
 aje
 bBa
 akI
-bkq
+agJ
 afN
 ajc
 afO
@@ -75437,7 +71604,7 @@ bBQ
 aIZ
 aJj
 aJj
-aJJ
+aJI
 aJR
 bzW
 bMf
@@ -75446,7 +71613,7 @@ aKa
 aXZ
 ctw
 bRk
-bVL
+adz
 jHr
 bXA
 bVM
@@ -75654,17 +71821,17 @@ cIZ
 acp
 acw
 acw
-adl
+adk
 adG
 adW
 aik
 qHu
 acp
 agJ
-aht
-ahN
+agJ
+agJ
 bBg
-aAX
+agJ
 afJ
 bgN
 ape
@@ -75688,13 +71855,13 @@ aHm
 aNS
 azG
 aIk
-aIv
+aHp
 aGt
 bhN
 aIY
 bHZ
 aJi
-aJJ
+aJI
 aJQ
 bdi
 bdr
@@ -75703,7 +71870,7 @@ aKn
 aIY
 oWU
 bdC
-asv
+adz
 ctw
 bLQ
 bVM
@@ -75935,9 +72102,9 @@ aBe
 caY
 aNQ
 aIo
-aFS
-aGi
-aGr
+aFO
+aFO
+aFO
 beA
 aGK
 aGR
@@ -75945,13 +72112,13 @@ clO
 aQY
 azU
 aIl
-aIw
+aHp
 aGt
 bBQ
 aIY
 bcV
 aJi
-aJK
+aJI
 aJP
 aKb
 aYn
@@ -76173,7 +72340,7 @@ adH
 aCX
 aik
 adW
-afK
+adk
 afN
 ahX
 bhA
@@ -76402,9 +72569,9 @@ avZ
 avM
 aaa
 aaa
-awl
+atz
 avt
-awl
+atz
 aaa
 aaa
 adO
@@ -76425,7 +72592,7 @@ ljF
 acp
 acw
 acw
-adl
+adk
 adJ
 aen
 amp
@@ -76649,31 +72816,31 @@ bbH
 avM
 avM
 aJc
-aVs
-aVh
+aJc
+aJc
 aVo
 aJc
-aVs
-aVs
-aVh
+aJc
+aJc
+aJc
 avM
-bcc
-avu
+atz
+atz
 avi
 aQS
 avi
-bcc
-avu
+atz
+atz
 adO
 adO
 abr
-afD
+abr
 aCg
 abr
-afD
+abr
 aCg
 abr
-afD
+abr
 adO
 adO
 mjC
@@ -76687,14 +72854,14 @@ acq
 pwu
 anj
 adW
-afK
+adk
 afN
 ajc
 aAa
 ail
-aoP
-apj
-apk
+aiq
+aiq
+aiq
 aeA
 aeA
 aFI
@@ -76706,7 +72873,7 @@ aBe
 vXg
 anC
 aFK
-aFU
+aFT
 bNL
 aGt
 beE
@@ -76720,7 +72887,7 @@ beK
 beK
 bGK
 aXj
-bhX
+beN
 aJB
 bzU
 aJB
@@ -76970,14 +73137,14 @@ beE
 aRt
 aGT
 aGT
-aQZ
-aVG
-aYr
+aqv
+aqv
+aqv
 aGT
 aGT
 ygs
 aGt
-bhY
+beN
 aoR
 apb
 aJC
@@ -77257,7 +73424,7 @@ asy
 asy
 bYx
 aBx
-bXI
+bWK
 aaa
 aaa
 aaa
@@ -77462,7 +73629,7 @@ aeA
 afN
 ajc
 ahU
-ajk
+aiq
 bkm
 blS
 gBb
@@ -77478,20 +73645,20 @@ aEV
 aHC
 aIy
 aFm
-aGm
+aGl
 aGt
 beE
 aIM
-arZ
+aqv
 azZ
 bms
 caD
 aRc
 aYu
-arZ
+aqv
 bGP
 aRe
-bhZ
+beN
 ben
 bfo
 bfp
@@ -77514,7 +73681,7 @@ bPs
 asy
 qKO
 bXV
-bXI
+bWK
 aaa
 aaa
 aaa
@@ -77719,7 +73886,7 @@ cbn
 afN
 ajc
 ahU
-akJ
+aiq
 blP
 aIr
 aEX
@@ -77739,13 +73906,13 @@ aIL
 aKc
 bRp
 aIM
-aHs
+aqv
 aHt
 jEw
 aHT
 aVF
 blF
-aHs
+aqv
 bGP
 aRe
 aJp
@@ -77771,7 +73938,7 @@ myk
 asy
 kpo
 aBx
-bXI
+bWK
 aaa
 aaa
 aaa
@@ -77976,7 +74143,7 @@ aeA
 afN
 ajc
 ahU
-amn
+aiq
 blQ
 bnL
 bHV
@@ -77997,9 +74164,9 @@ beu
 aRb
 aJG
 aGT
-aQZ
-aVG
-aYr
+aqv
+aqv
+aqv
 aXk
 aGT
 aGT
@@ -78028,7 +74195,7 @@ bOU
 asy
 kpo
 aBx
-bXI
+bWK
 aaa
 aaa
 aaa
@@ -78173,7 +74340,7 @@ aaa
 aaa
 aaa
 aaa
-avA
+atz
 awe
 anQ
 awe
@@ -78285,7 +74452,7 @@ bOV
 asy
 kpo
 aBx
-bXI
+bWK
 aaa
 aaa
 aaa
@@ -78431,7 +74598,7 @@ aaa
 aaa
 aaa
 avi
-awl
+atz
 avi
 aaW
 avi
@@ -78506,7 +74673,7 @@ aFn
 aFC
 aFM
 aGe
-aGm
+aGl
 aGt
 aRe
 aRe
@@ -78542,7 +74709,7 @@ bOW
 asy
 bYx
 aBx
-bXI
+bWK
 aaa
 aaa
 aaa
@@ -78694,24 +74861,24 @@ bcN
 avi
 bcN
 avi
-bcc
-avO
-avu
+atz
+atz
+atz
 avi
 bcX
 avi
 bcX
 avi
-bcc
-avO
-avO
-avu
+atz
+atz
+atz
+atz
 avi
 avi
-bcc
-avO
-avO
-avu
+atz
+atz
+atz
+atz
 avi
 avY
 bvK
@@ -78799,7 +74966,7 @@ bOX
 asy
 kpo
 aBx
-bXI
+bWK
 aaa
 aaa
 aaa
@@ -78969,7 +75136,7 @@ aaa
 aaa
 aaa
 aaa
-aVc
+atz
 avY
 bvK
 avi
@@ -79056,7 +75223,7 @@ bOY
 azH
 kpo
 aBx
-bXJ
+bWK
 aaa
 aaa
 aaa
@@ -79226,7 +75393,7 @@ aaa
 aaa
 aaa
 aaa
-avB
+atz
 avY
 bvK
 avi
@@ -79483,7 +75650,7 @@ aaa
 aaa
 aaa
 aaa
-avB
+atz
 avY
 aBh
 avi
@@ -79740,7 +75907,7 @@ aaa
 aaa
 aaa
 aaa
-avB
+atz
 avY
 bvK
 avi
@@ -79759,7 +75926,7 @@ aCh
 auo
 aCh
 avn
-aKP
+aCj
 aKV
 bro
 asP
@@ -79997,7 +76164,7 @@ aaa
 aaa
 aaa
 aaa
-aVd
+atz
 bvD
 bvN
 avi
@@ -80040,7 +76207,7 @@ aHg
 aAx
 blJ
 ajp
-aBl
+aBj
 bmf
 aFo
 bCM
@@ -80297,7 +76464,7 @@ ajt
 bmr
 ajp
 ajp
-aBm
+aBj
 bmf
 aEA
 aEA
@@ -80510,7 +76677,7 @@ aaa
 aaa
 aaa
 aaa
-aVc
+atz
 bfM
 avY
 bvK
@@ -80530,7 +76697,7 @@ bqR
 aum
 bRK
 afv
-aKP
+aCj
 aKX
 brq
 asP
@@ -80554,7 +76721,7 @@ bmp
 bkP
 ijH
 aAY
-aBn
+aBj
 bmN
 bmQ
 bmQ
@@ -80767,7 +76934,7 @@ aaa
 aaa
 aaa
 aaa
-avB
+atz
 bfN
 avY
 bvK
@@ -80823,7 +76990,7 @@ awD
 aGz
 aXC
 aXC
-aHc
+aGz
 aXM
 aUt
 aHW
@@ -81024,7 +77191,7 @@ aaa
 aaa
 aaa
 aaa
-avB
+atz
 bfO
 avY
 bvK
@@ -81080,9 +77247,9 @@ axM
 afu
 aXR
 bts
-aHd
+aGz
 aXN
-aHN
+aGz
 aUl
 aGS
 aUx
@@ -81281,7 +77448,7 @@ aaa
 aaa
 aaa
 aaa
-aVd
+atz
 bfO
 aEJ
 agp
@@ -81341,8 +77508,8 @@ bGL
 aXR
 axM
 bfG
-aGU
-aHn
+aGS
+aGS
 bfn
 aIR
 aJf
@@ -81600,9 +77767,9 @@ iMs
 aIn
 axM
 aTK
-bfI
-aHn
-aNO
+bfn
+aGS
+aGS
 aHW
 bCg
 ahT
@@ -81796,7 +77963,7 @@ aaa
 aaa
 aaa
 aaa
-aVc
+atz
 avY
 bvK
 avi
@@ -81836,14 +78003,14 @@ aLn
 aLn
 aLn
 aLw
-aLy
-aLy
-aLF
+aLw
+aLw
+aLw
 bxx
 aLw
-aLy
-aLy
-aLF
+aLw
+aLw
+aLw
 aLn
 aLn
 aLn
@@ -81888,7 +78055,7 @@ bbm
 aUk
 bpS
 bVg
-aUD
+aUC
 bbu
 aUI
 aXg
@@ -82053,7 +78220,7 @@ aaa
 aaa
 aaa
 aaa
-avB
+atz
 avY
 bvK
 avi
@@ -82310,7 +78477,7 @@ aaa
 aaa
 aaa
 aaa
-bcB
+atz
 avY
 bvK
 avi
@@ -82567,7 +78734,7 @@ aaa
 aaa
 aaa
 aaa
-avB
+atz
 bvF
 bvO
 avi
@@ -82659,7 +78826,7 @@ aUk
 aUk
 bto
 aUz
-aUD
+aUC
 bbx
 bbz
 bbB
@@ -82824,7 +78991,7 @@ aaa
 aaa
 aaa
 aaa
-aVd
+atz
 avY
 bvK
 avi
@@ -82847,8 +79014,8 @@ awO
 abP
 bsI
 axk
-bxA
-bxD
+bxz
+bxz
 auJ
 auJ
 bSp
@@ -82887,7 +79054,7 @@ akx
 amv
 afa
 aoA
-aoE
+aoA
 azE
 azR
 btt
@@ -83063,24 +79230,24 @@ bcN
 avi
 bcN
 avi
-bcc
-avO
-avu
+atz
+atz
+atz
 avi
 bcX
 avi
 bcX
 avi
-bcc
-avO
-avO
-avu
+atz
+atz
+atz
+atz
 avi
 avi
-bcc
-avO
-avO
-avu
+atz
+atz
+atz
+atz
 avi
 avU
 aMe
@@ -83103,8 +79270,8 @@ bfC
 abP
 hYI
 axh
-bxA
-bxC
+bxz
+bxz
 avo
 avs
 auJ
@@ -83144,8 +79311,8 @@ bUo
 akp
 bnS
 aoC
-aoF
-aoE
+aoA
+aoA
 azE
 azR
 btt
@@ -83314,7 +79481,7 @@ aaa
 aaa
 aaa
 avi
-awl
+atz
 avi
 aQS
 avi
@@ -83360,7 +79527,7 @@ btc
 boj
 bxq
 axk
-bxB
+bxz
 avk
 avj
 avy
@@ -83402,8 +79569,8 @@ amA
 akp
 akp
 bCE
-aoF
-aoE
+aoA
+aoA
 azE
 azR
 aqe
@@ -83617,7 +79784,7 @@ bAh
 bDD
 axh
 bxz
-bxC
+bxz
 avj
 avj
 axN
@@ -83660,8 +79827,8 @@ bul
 akp
 akp
 bCE
-aoF
-aQz
+aoA
+aoA
 aAd
 arK
 ark
@@ -83827,7 +79994,7 @@ aaa
 aaa
 aaa
 aaa
-avA
+atz
 aam
 awh
 awh
@@ -83878,7 +80045,7 @@ bjd
 bva
 bjc
 bvd
-aCB
+bxz
 bvf
 avj
 aCE
@@ -83901,8 +80068,8 @@ aLn
 aRA
 aaT
 aaT
-acL
-aoH
+aBD
+aBD
 aaT
 aaT
 bSd
@@ -84086,32 +80253,32 @@ aaa
 aaa
 avi
 avi
-bcc
-avO
-avO
-avO
-avO
-avO
-avO
-avO
-avO
+atz
+atz
+atz
+atz
+atz
+atz
+atz
+atz
+atz
 avi
-avO
-avO
-avO
-avO
-avO
-avO
-avO
-avO
-avO
-avO
-avO
-avO
-avO
+atz
+atz
+atz
+atz
+atz
+atz
+atz
+atz
+atz
+atz
+atz
+atz
+atz
 avi
-avO
-avO
+atz
+atz
 avi
 byc
 awe
@@ -84369,7 +80536,7 @@ aaa
 aaa
 aaa
 aaa
-avB
+atz
 aLh
 awe
 awe
@@ -84626,7 +80793,7 @@ aaa
 aaa
 aaa
 aaa
-avG
+atz
 aLV
 awh
 awm
@@ -84649,7 +80816,7 @@ buZ
 avm
 avr
 pSa
-aCB
+bxz
 bvi
 avj
 aLl
@@ -84689,7 +80856,7 @@ caF
 aoD
 aoD
 bux
-aQC
+aoA
 azE
 azR
 alW
@@ -84946,8 +81113,8 @@ alZ
 alZ
 alZ
 bux
-aoF
-aQz
+aoA
+aoA
 aAr
 arK
 axf
@@ -85170,7 +81337,7 @@ aCz
 bQr
 bmo
 aRA
-aBG
+aBD
 aal
 aaa
 aaa
@@ -85396,11 +81563,11 @@ aaa
 aaa
 aaa
 aaa
-acz
+aci
 aeT
 aMh
 agA
-bwd
+auC
 aty
 bwl
 aMg
@@ -85426,8 +81593,8 @@ aBC
 bQr
 aRA
 aRA
-aBE
-aBF
+aBD
+aBD
 aaa
 aaa
 aaa
@@ -85653,7 +81820,7 @@ aaa
 aaa
 aaa
 aaa
-acz
+aci
 afH
 aMh
 bvU
@@ -85664,7 +81831,7 @@ bxQ
 aty
 aty
 aty
-ard
+abm
 byw
 ark
 abP
@@ -85682,8 +81849,8 @@ aRA
 bmo
 aRA
 aRA
-aBE
-aBF
+aBD
+aBD
 aaa
 aaa
 aaa
@@ -85910,18 +82077,18 @@ aaa
 aaa
 aaa
 aaa
-acz
+aci
 agm
 bvV
 blZ
-bCu
+auC
 aty
 bwn
 aMi
 aty
 aty
 aty
-aMp
+abm
 bZO
 aeL
 aff
@@ -85939,7 +82106,7 @@ aaT
 aaT
 aaT
 aBD
-aBF
+aBD
 aaa
 aaa
 aaa
@@ -86167,7 +82334,7 @@ aaa
 aaa
 aaa
 aaa
-acz
+aci
 ago
 bvW
 bwa
@@ -86272,8 +82439,8 @@ aAc
 aAc
 aAc
 aAc
-bcG
-bCW
+afc
+afc
 aAc
 aaa
 aaa
@@ -86290,7 +82457,7 @@ aaa
 aaa
 aaa
 aaa
-aNj
+aNg
 oTz
 bLd
 bLb
@@ -86413,22 +82580,22 @@ aaa
 aaa
 aaa
 aaa
-ard
+abm
 bcJ
-atA
+abm
 aaa
 aaa
-atA
+abm
 bcJ
-atA
+abm
 aaa
 aaa
 aaa
-aeQ
+aci
 agT
 bvX
 byA
-bCu
+auC
 aty
 bwp
 bxP
@@ -86547,7 +82714,7 @@ aaa
 aaa
 aaa
 aal
-aNj
+aNg
 bZL
 bLe
 bLv
@@ -86670,17 +82837,17 @@ aaa
 aaa
 aaa
 abm
-aro
+abm
 aty
 auG
-ave
-auI
+abm
+abm
 auG
 aty
 auG
-ave
-atx
-auI
+abm
+abm
+abm
 acc
 acc
 acc
@@ -86804,7 +82971,7 @@ aaa
 aaa
 aaa
 aal
-aNj
+aNg
 asC
 bLf
 bLH
@@ -86926,7 +83093,7 @@ aaa
 aaa
 aaa
 aaa
-abq
+abm
 atv
 atv
 boF
@@ -86949,7 +83116,7 @@ aMm
 aty
 aty
 aty
-ard
+abm
 anH
 ark
 dNx
@@ -87014,7 +83181,7 @@ aQN
 aQT
 aRM
 xLk
-bcP
+aRh
 bgy
 bgy
 bgy
@@ -87061,7 +83228,7 @@ aal
 aal
 aal
 aal
-aNn
+aNg
 atY
 bLn
 aNl
@@ -87183,7 +83350,7 @@ aaa
 aaa
 aaa
 aaa
-abq
+abm
 aty
 aty
 aty
@@ -87206,7 +83373,7 @@ bqc
 bqc
 arX
 aMn
-aMp
+abm
 arv
 awF
 arK
@@ -87300,7 +83467,7 @@ acj
 bpL
 bXv
 aAc
-bcG
+afc
 ccW
 aAc
 xWW
@@ -87440,10 +83607,10 @@ aaa
 aaa
 aaa
 aaa
-acO
-abo
-atx
-auI
+abm
+abm
+abm
+abm
 auG
 auG
 auG
@@ -87698,7 +83865,7 @@ aaa
 aaa
 aaa
 aaa
-aiE
+abd
 aiS
 awx
 aBa
@@ -87721,7 +83888,7 @@ bFk
 bGJ
 bPj
 bRI
-bFf
+bFi
 aww
 dNx
 awW
@@ -87955,7 +84122,7 @@ aaa
 aaa
 aaa
 aaa
-aiF
+abd
 aiS
 awy
 aBO
@@ -87978,7 +84145,7 @@ bzh
 bIv
 bAo
 bSk
-bUG
+bFi
 aJa
 byF
 awX
@@ -88211,8 +84378,8 @@ aaa
 aaa
 aaa
 abd
-agK
-aiG
+abd
+abd
 aiS
 aAf
 aAh
@@ -88327,7 +84494,7 @@ cdN
 acj
 bXw
 bhn
-aQJ
+afc
 aaa
 aaa
 aaa
@@ -88478,12 +84645,12 @@ aBO
 aAh
 agc
 boq
-byS
+byR
 bze
 bAf
 bBi
 bEb
-byS
+byR
 bEv
 bEN
 bFc
@@ -88558,11 +84725,11 @@ asH
 asJ
 acj
 atg
-atC
+atg
 srD
-auN
+atg
 avl
-avK
+atg
 awf
 ayz
 axv
@@ -88584,7 +84751,7 @@ ceM
 acj
 bTO
 bYI
-aQJ
+afc
 aaa
 aaa
 aaa
@@ -88736,10 +84903,10 @@ aQd
 aQr
 brY
 byT
-bzf
-bAg
-bAg
-bEc
+byR
+byR
+byR
+byR
 byT
 bEw
 bAo
@@ -88841,7 +85008,7 @@ cdN
 acj
 bTP
 bhn
-aQJ
+afc
 aaa
 aaa
 aaa
@@ -88982,7 +85149,7 @@ aaa
 aaa
 aaa
 abd
-aia
+abd
 aiI
 alO
 aAh
@@ -89098,7 +85265,7 @@ acj
 acj
 bpL
 bXv
-awu
+afc
 aaa
 aaa
 aaa
@@ -89263,7 +85430,7 @@ bFp
 bMm
 bRH
 bUD
-bUG
+bFi
 awA
 dNx
 bcw
@@ -89753,8 +85920,8 @@ aaa
 aaa
 aaa
 abd
-agK
-aiJ
+abd
+abd
 asq
 aAj
 aAh
@@ -89763,7 +85930,7 @@ aPW
 aQe
 bgz
 bun
-byX
+abd
 bzh
 bAo
 bBn
@@ -89821,7 +85988,7 @@ mXO
 iUZ
 aaa
 aaa
-iIq
+dUt
 dUa
 aor
 vzQ
@@ -90011,7 +86178,7 @@ aaa
 aaa
 aaa
 aaa
-aiF
+abd
 asq
 awy
 aBO
@@ -90020,12 +86187,12 @@ aPX
 aAh
 agv
 aAh
-aiK
+abd
 bzs
 bAJ
 bAJ
 bAo
-bEm
+bAo
 bEI
 aAn
 bAy
@@ -90078,7 +86245,7 @@ aal
 aaa
 aaa
 aaa
-elZ
+dUt
 mUn
 aor
 aor
@@ -90268,7 +86435,7 @@ aaa
 aaa
 aaa
 aaa
-aiK
+abd
 asq
 abM
 aAh
@@ -90335,7 +86502,7 @@ aal
 aal
 aal
 aal
-pmD
+dUt
 hAI
 vRP
 vRP
@@ -90528,7 +86695,7 @@ aaa
 aiI
 aiI
 aiI
-aPB
+abd
 aPP
 bAr
 aQm
@@ -90855,8 +87022,8 @@ apO
 apO
 kAG
 feg
-wpG
-tcB
+kAG
+kAG
 apO
 apO
 aze
@@ -90901,8 +87068,8 @@ bcC
 bDr
 caw
 bcC
-ccL
-ccP
+bCT
+bCT
 aaa
 aaa
 aaa
@@ -91159,7 +87326,7 @@ bDv
 ccE
 ccI
 ccJ
-ccQ
+bCT
 aaa
 aaa
 aaa
@@ -91295,8 +87462,8 @@ aaa
 aaa
 aaa
 abk
-aie
-aiL
+abk
+abk
 auV
 aAp
 aiw
@@ -91330,10 +87497,10 @@ aRA
 bsp
 aMq
 aal
-aMz
-aMC
-aMC
-aMv
+aMr
+aMr
+aMr
+aMr
 aal
 aal
 aaa
@@ -91416,7 +87583,7 @@ bDy
 ccF
 ccJ
 ccM
-ccR
+bCT
 aaa
 aaa
 aaa
@@ -91551,7 +87718,7 @@ aaa
 aaa
 aaa
 aaa
-abl
+abk
 ain
 aiM
 auV
@@ -91586,12 +87753,12 @@ aaT
 aTs
 bPM
 aMq
-aMt
-aMA
+aMr
+aMr
 aMG
 aMD
-aME
-aMv
+aMr
+aMr
 aal
 aaa
 aaa
@@ -91848,8 +88015,8 @@ aMu
 btw
 aMu
 bCK
-aME
-aMv
+aMr
+aMr
 aaa
 aaa
 aaa
@@ -92065,7 +88232,7 @@ aaa
 aaa
 aaa
 aaa
-abI
+abk
 aiC
 aiQ
 auV
@@ -92106,8 +88273,8 @@ btx
 aMu
 aMu
 bCR
-aME
-aMv
+aMr
+aMr
 aaa
 aaa
 aaa
@@ -92161,9 +88328,9 @@ bXv
 bXv
 biu
 acj
-bPb
-atC
-auN
+atg
+atg
+atg
 acj
 biu
 bXv
@@ -92181,9 +88348,9 @@ bcC
 bcC
 bcC
 bCT
-bDa
-bDa
-bZy
+bCT
+bCT
+bCT
 bcC
 bcC
 aal
@@ -92322,9 +88489,9 @@ aaa
 aaa
 aaa
 aaa
-agw
-aiD
-aiL
+abk
+abk
+abk
 auV
 bVB
 aPH
@@ -92364,7 +88531,7 @@ aMu
 aMu
 aMu
 aMH
-aMI
+aMr
 aaa
 aaa
 aaa
@@ -92621,7 +88788,7 @@ btB
 btD
 btF
 aMG
-aMI
+aMr
 aaa
 aaa
 aaa
@@ -92868,8 +89035,8 @@ aaZ
 act
 ark
 bsT
-aMt
-aMv
+aMr
+aMr
 aMu
 aMu
 aMu
@@ -92877,8 +89044,8 @@ aMu
 aMu
 aMu
 aMu
-aMz
-aMJ
+aMr
+aMr
 aaa
 aaa
 aaa
@@ -93126,15 +89293,15 @@ act
 ark
 bsN
 axe
-aMw
-aMv
+aMr
+aMr
 aMu
 aMu
 aMy
 aMu
 aMu
 bCS
-aMB
+aMr
 aal
 aaa
 aaa
@@ -93354,7 +89521,7 @@ aaa
 aaa
 aaa
 aaa
-agq
+abp
 aaV
 aPM
 agh
@@ -93384,8 +89551,8 @@ aSd
 bsO
 bsw
 axe
-aMw
-aMv
+aMr
+aMr
 aMu
 aMu
 aMu
@@ -93399,7 +89566,7 @@ alk
 alk
 alk
 aRY
-aSb
+aRY
 aSa
 aaa
 aaa
@@ -93610,8 +89777,8 @@ aaa
 aaa
 aaa
 abp
-afR
-ags
+abp
+abp
 agZ
 byl
 agh
@@ -93642,8 +89809,8 @@ aSd
 dNx
 awZ
 axe
-aMw
-aMv
+aMr
+aMr
 aMu
 aMu
 bCI
@@ -93679,8 +89846,8 @@ acZ
 atJ
 atI
 btR
-aQv
-bub
+atM
+atM
 aze
 awO
 arK
@@ -93691,14 +89858,14 @@ aqz
 aqz
 aqz
 aqz
-aOH
-aOQ
-aOQ
-aPb
+aOq
+aOq
+aOq
+aOq
 aZg
-aOH
-aOQ
-aPb
+aOq
+aOq
+aOq
 aOp
 bXv
 biu
@@ -93880,7 +90047,7 @@ bVp
 bzj
 bzo
 bWM
-bAj
+abp
 bAx
 adn
 adn
@@ -93900,7 +90067,7 @@ bsZ
 mnL
 bte
 axe
-aMB
+aMr
 bCC
 aMr
 bFr
@@ -93922,7 +90089,7 @@ aSa
 aSa
 aSa
 aRY
-aSb
+aRY
 aSa
 aSa
 cel
@@ -93935,8 +90102,8 @@ ibF
 acZ
 acZ
 atM
-aQu
-aQx
+atM
+atM
 aze
 awO
 btG
@@ -94124,8 +90291,8 @@ aaa
 aaa
 aaa
 abp
-afR
-agy
+abp
+abp
 agZ
 bzp
 agh
@@ -94217,7 +90384,7 @@ aOp
 bsC
 biu
 bii
-brI
+bja
 biA
 ocL
 aaa
@@ -94382,7 +90549,7 @@ aaa
 aaa
 aaa
 aaa
-agQ
+abp
 agZ
 bgL
 agh
@@ -94419,11 +90586,11 @@ bPA
 iMs
 bFt
 axe
-arj
-arG
+ari
+ari
 anm
-arY
-asl
+ari
+ari
 asE
 alk
 bSq
@@ -94455,7 +90622,7 @@ hYI
 azf
 aOn
 aWg
-biY
+asO
 aqz
 aPh
 aPj
@@ -94474,9 +90641,9 @@ aOp
 bZs
 biu
 bii
-brJ
+bja
 unS
-lKv
+ocL
 aaa
 aal
 aal
@@ -94680,7 +90847,7 @@ arA
 arA
 arD
 axe
-arj
+ari
 bFv
 alk
 aSa
@@ -94711,8 +90878,8 @@ ceA
 aOn
 aWg
 aqz
-aWw
-biZ
+asO
+asO
 aqA
 baC
 caN
@@ -94966,7 +91133,7 @@ aOn
 aWg
 aqz
 asO
-aWb
+asO
 aqz
 bld
 cbW
@@ -95185,9 +91352,9 @@ bta
 anb
 abv
 aby
-btd
+bsr
 bDV
-byG
+bsr
 axy
 btH
 axu
@@ -95219,8 +91386,8 @@ aOn
 aOn
 aVN
 aUp
-aWu
-aWb
+asO
+asO
 aqz
 biD
 cbV
@@ -95444,7 +91611,7 @@ abv
 aca
 btv
 bDW
-byH
+bsr
 abv
 btI
 abv
@@ -95474,9 +91641,9 @@ adr
 bZH
 bZW
 asO
-aWb
+asO
 aqz
-aWv
+asO
 ade
 aqA
 biH
@@ -95712,8 +91879,8 @@ aiO
 aiO
 aAB
 ajy
-amf
-ana
+ajy
+ajy
 aFc
 aiO
 bIo
@@ -95739,7 +91906,7 @@ aqA
 biE
 aZN
 aqA
-ahi
+ajQ
 bIa
 aqA
 akr
@@ -95945,7 +92112,7 @@ aak
 aak
 aak
 aaQ
-aaR
+aaQ
 aak
 aak
 aJd
@@ -95993,7 +92160,7 @@ aqA
 biE
 aZN
 aqA
-ahi
+ajQ
 bHG
 aqA
 akr
@@ -96225,8 +92392,8 @@ aKy
 aKD
 aiO
 aAD
-aVZ
-bCj
+aAD
+aAD
 bCo
 aXb
 aiO
@@ -96247,7 +92414,7 @@ aFx
 aZM
 bat
 aqA
-ahi
+ajQ
 bHn
 aqA
 akr
@@ -96500,9 +92667,9 @@ akt
 aqB
 aBz
 aqA
-ahi
+ajQ
 aEf
-ahi
+ajQ
 aqA
 akr
 aPs
@@ -96701,16 +92868,16 @@ aal
 asj
 asj
 ajW
-bQE
+ajW
 asj
 asj
 asj
 asj
 ajW
-aIV
-aIV
-aIV
-bQE
+ajW
+ajW
+ajW
+ajW
 asj
 asj
 afQ
@@ -97782,11 +93949,11 @@ aCS
 aCS
 akF
 aqg
-aDX
+aqg
 aML
-aVT
+aqg
 aqH
-aVT
+aqg
 akF
 akF
 akC
@@ -98001,7 +94168,7 @@ aaa
 aaa
 fhM
 atc
-awc
+asD
 aFz
 mtv
 aNV
@@ -98071,7 +94238,7 @@ aOZ
 acQ
 akK
 fid
-aTF
+aTE
 aal
 aal
 aaa
@@ -98256,9 +94423,9 @@ aaa
 aaa
 aaa
 aaa
-kCA
+fhM
 foz
-awq
+asD
 aFz
 bAD
 aNV
@@ -98328,7 +94495,7 @@ bnz
 acQ
 bQv
 leE
-aTF
+aTE
 aaa
 bix
 bix
@@ -98559,7 +94726,7 @@ aqy
 baj
 bar
 aqS
-aVT
+aqg
 aWe
 aZI
 aWn
@@ -98585,7 +94752,7 @@ aPm
 acQ
 arc
 fid
-aTF
+aTE
 aal
 bio
 bio
@@ -98842,7 +95009,7 @@ bgT
 acQ
 aQI
 fid
-aTG
+aTE
 aal
 bix
 bix
@@ -99068,10 +95235,10 @@ arT
 arT
 arT
 atX
-biU
+atX
 biK
 bak
-biX
+atX
 arT
 arT
 bjl
@@ -99550,8 +95717,8 @@ asj
 aRR
 asj
 bDB
-bQC
-bQE
+ajW
+ajW
 aiV
 aiV
 aiV
@@ -100076,17 +96243,17 @@ avP
 avP
 aal
 bMK
-ajJ
-bCt
-bCt
-bCt
-bCt
-bCt
-bCt
-bCt
-bCt
-bCt
-bKB
+ajI
+ajI
+ajI
+ajI
+ajI
+ajI
+ajI
+ajI
+ajI
+ajI
+ajI
 aaa
 pWc
 aij
@@ -101393,8 +97560,8 @@ aEc
 aEs
 aFW
 aNU
-aNY
-aOb
+aNU
+aNU
 aaa
 aaa
 aaa
@@ -101907,8 +98074,8 @@ aZs
 bax
 aFX
 aNU
-aNY
-aOb
+aNU
+aNU
 aaa
 aaa
 aaa
@@ -102421,8 +98588,8 @@ aDP
 caI
 aFX
 aNU
-aNY
-aOb
+aNU
+aNU
 aaa
 aaa
 aaa
@@ -102935,8 +99102,8 @@ aDQ
 aZt
 aFZ
 aNU
-aNY
-aOb
+aNU
+aNU
 aaa
 aaa
 aaa

--- a/html/changelogs/FlufflyCthulu-DonutFixes.yml
+++ b/html/changelogs/FlufflyCthulu-DonutFixes.yml
@@ -1,4 +1,4 @@
-author: FlufflyCthulu
+author: "FlufflyCthulu"
    
 delete-after: True
    

--- a/html/changelogs/FlufflyCthulu-DonutFixes.yml
+++ b/html/changelogs/FlufflyCthulu-DonutFixes.yml
@@ -1,0 +1,6 @@
+author: FlufflyCthulu
+   
+delete-after: True
+   
+changes: 
+  - bugfix: "Donut Station now comes with real windows and a PDA messaging server."


### PR DESCRIPTION
## About The Pull Request

Donut Station now uses standard windows instead of snowflake unbuildable traps. Also adds a PDA messaging server cause there was none.

## Why It's Good For The Game

Snowflake Para windows out.

## Changelog
:cl:
bugfix: Donut Station now comes with real windows and a PDA messaging server.
/:cl:
![Donutstation-1](https://user-images.githubusercontent.com/2520037/62003259-70053e00-b0e2-11e9-9a7e-71c76c374d8e.png)
