### PR TITLE
Fixes caves away mission atmos

### DIFF
--- a/RussStation.dme
+++ b/RussStation.dme
@@ -2886,6 +2886,7 @@
 #include "russstation\code\datums\action.dm"
 #include "russstation\code\game\objects\items\spiritboard.dm"
 #include "russstation\code\game\objects\items\storage\boxes.dm"
+#include "russstation\code\game\turfs\simulated\minerals.dm"
 #include "russstation\code\modules\admin\verbs\randomverbs.dm"
 #include "russstation\code\modules\cargo\packs.dm"
 #include "russstation\code\modules\client\client.dm"

--- a/_maps/RandomZLevels/caves.dmm
+++ b/_maps/RandomZLevels/caves.dmm
@@ -6,107 +6,77 @@
 /turf/open/space,
 /area/space)
 "ac" = (
-/turf/closed/mineral/volcanic,
+/turf/closed/mineral/volcanic/lava_land_surface,
 /area/awaymission/caves/BMP_asteroid/level_three)
 "ad" = (
-/turf/open/lava/smooth{
-	desc = "Looks hot.";
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15";
-	luminosity = 5;
-	name = "lava"
-	},
+/turf/open/lava/smooth/lava_land_surface,
 /area/awaymission/caves/BMP_asteroid/level_four)
 "ae" = (
-/turf/open/floor/plating/asteroid/basalt{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
-	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/awaymission/caves/BMP_asteroid/level_three)
 "af" = (
 /obj/item/greentext,
-/turf/open/floor/plating/asteroid/basalt{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
-	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/awaymission/caves/BMP_asteroid/level_three)
 "ag" = (
 /obj/structure/barricade/wooden,
-/turf/open/floor/plating/asteroid/basalt{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
-	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/awaymission/caves/BMP_asteroid/level_three)
 "ah" = (
-/turf/open/lava/smooth{
-	desc = "Looks hot.";
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15";
-	luminosity = 5;
-	name = "lava"
-	},
+/turf/open/lava/smooth/lava_land_surface,
 /area/awaymission/caves/BMP_asteroid/level_three)
 "ai" = (
-/turf/open/floor/plating/asteroid/basalt{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
-	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/awaymission/caves/BMP_asteroid/level_four)
 "aj" = (
 /obj/structure/flora/rock,
-/turf/open/floor/plating/asteroid/basalt{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
-	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/awaymission/caves/BMP_asteroid/level_three)
 "ak" = (
-/turf/closed/mineral/random/high_chance,
+/turf/closed/mineral/random/high_chance/volcanic,
 /area/awaymission/caves/BMP_asteroid/level_three)
 "al" = (
 /obj/effect/forcefield/cult,
-/turf/open/floor/plating/asteroid/basalt{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
-	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/awaymission/caves/BMP_asteroid/level_four)
 "am" = (
 /obj/effect/decal/remains/human,
-/turf/open/floor/plating/asteroid/basalt{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
-	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/awaymission/caves/BMP_asteroid/level_four)
 "an" = (
 /obj/structure/destructible/cult/pylon,
-/turf/open/floor/plating/asteroid/basalt{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
-	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/awaymission/caves/BMP_asteroid/level_four)
 "ao" = (
 /turf/open/floor/engine/cult{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
+	initial_gas_mix = "LAVALAND_ATMOS"
 	},
 /area/awaymission/caves/BMP_asteroid/level_four)
 "ap" = (
 /obj/structure/destructible/cult/pylon,
 /turf/open/floor/engine/cult{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
+	initial_gas_mix = "LAVALAND_ATMOS"
 	},
 /area/awaymission/caves/BMP_asteroid/level_four)
 "aq" = (
 /obj/item/ectoplasm,
-/turf/open/floor/plating/asteroid/basalt{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
-	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/awaymission/caves/BMP_asteroid/level_four)
 "ar" = (
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/engine/cult{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
+	initial_gas_mix = "LAVALAND_ATMOS"
 	},
 /area/awaymission/caves/BMP_asteroid/level_four)
 "as" = (
 /obj/effect/decal/cleanable/blood/gibs/old,
 /turf/open/floor/engine/cult{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
+	initial_gas_mix = "LAVALAND_ATMOS"
 	},
 /area/awaymission/caves/BMP_asteroid/level_four)
 "at" = (
 /obj/structure/spawner/skeleton,
-/turf/open/floor/plating/asteroid/basalt{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
-	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/awaymission/caves/BMP_asteroid/level_four)
 "au" = (
 /obj/structure/destructible/cult/talisman,
@@ -118,7 +88,7 @@
 /obj/item/clothing/mask/gas/clown_hat,
 /obj/item/organ/heart/demon,
 /turf/open/floor/engine/cult{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
+	initial_gas_mix = "LAVALAND_ATMOS"
 	},
 /area/awaymission/caves/BMP_asteroid/level_four)
 "av" = (
@@ -127,13 +97,13 @@
 	name = "shock rune"
 	},
 /turf/open/floor/engine/cult{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
+	initial_gas_mix = "LAVALAND_ATMOS"
 	},
 /area/awaymission/caves/BMP_asteroid/level_four)
 "aw" = (
 /obj/effect/decal/remains/human,
 /turf/open/floor/engine/cult{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
+	initial_gas_mix = "LAVALAND_ATMOS"
 	},
 /area/awaymission/caves/BMP_asteroid/level_four)
 "ax" = (
@@ -147,39 +117,39 @@
 	},
 /obj/item/coin/antagtoken,
 /turf/open/floor/engine/cult{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
+	initial_gas_mix = "LAVALAND_ATMOS"
 	},
 /area/awaymission/caves/BMP_asteroid/level_four)
 "az" = (
 /obj/structure/constructshell,
 /turf/open/floor/engine/cult{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
+	initial_gas_mix = "LAVALAND_ATMOS"
 	},
 /area/awaymission/caves/BMP_asteroid/level_four)
 "aA" = (
 /obj/structure/girder/cult,
 /obj/item/stack/sheet/runed_metal,
 /turf/open/floor/engine/cult{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
+	initial_gas_mix = "LAVALAND_ATMOS"
 	},
 /area/awaymission/caves/BMP_asteroid/level_four)
 "aB" = (
 /obj/structure/spawner/skeleton,
 /turf/open/floor/engine/cult{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
+	initial_gas_mix = "LAVALAND_ATMOS"
 	},
 /area/awaymission/caves/BMP_asteroid/level_four)
 "aC" = (
 /obj/structure/bed,
 /obj/item/bedsheet/cult,
 /turf/open/floor/engine/cult{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
+	initial_gas_mix = "LAVALAND_ATMOS"
 	},
 /area/awaymission/caves/BMP_asteroid/level_four)
 "aD" = (
 /obj/item/stack/sheet/runed_metal,
 /turf/open/floor/engine/cult{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
+	initial_gas_mix = "LAVALAND_ATMOS"
 	},
 /area/awaymission/caves/BMP_asteroid/level_four)
 "aE" = (
@@ -192,7 +162,7 @@
 	name = "an extremely flamboyant book"
 	},
 /turf/open/floor/engine/cult{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
+	initial_gas_mix = "LAVALAND_ATMOS"
 	},
 /area/awaymission/caves/BMP_asteroid/level_four)
 "aF" = (
@@ -203,13 +173,13 @@
 	name = "weak forcefield"
 	},
 /turf/open/floor/engine/cult{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
+	initial_gas_mix = "LAVALAND_ATMOS"
 	},
 /area/awaymission/caves/BMP_asteroid/level_four)
 "aG" = (
 /obj/item/ectoplasm,
 /turf/open/floor/engine/cult{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
+	initial_gas_mix = "LAVALAND_ATMOS"
 	},
 /area/awaymission/caves/BMP_asteroid/level_four)
 "aH" = (
@@ -217,34 +187,33 @@
 /area/awaymission/caves/BMP_asteroid/level_three)
 "aI" = (
 /obj/machinery/door/airlock/external,
-/turf/open/floor/plating{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
+/turf/open/floor/plating/lavaland_baseturf{
+	initial_gas_mix = "LAVALAND_ATMOS"
 	},
 /area/awaymission/caves/BMP_asteroid/level_three)
 "aJ" = (
 /turf/closed/wall/rust,
 /area/awaymission/caves/BMP_asteroid/level_three)
 "aK" = (
-/turf/open/floor/plating{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
+/turf/open/floor/plating/lavaland_baseturf{
+	initial_gas_mix = "LAVALAND_ATMOS"
 	},
 /area/awaymission/caves/BMP_asteroid/level_three)
 "aL" = (
 /obj/machinery/light/small{
 	dir = 4
 	},
-/turf/open/floor/plating{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
+/turf/open/floor/plating/lavaland_baseturf{
+	initial_gas_mix = "LAVALAND_ATMOS"
 	},
 /area/awaymission/caves/BMP_asteroid/level_three)
 "aM" = (
 /obj/structure/ladder/unbreakable{
-	anchored = 1;
 	height = 1;
 	id = "minedeep"
 	},
-/turf/open/floor/plating{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
+/turf/open/floor/plating/lavaland_baseturf{
+	initial_gas_mix = "LAVALAND_ATMOS"
 	},
 /area/awaymission/caves/BMP_asteroid/level_three)
 "aN" = (
@@ -252,52 +221,45 @@
 	desc = "Rusted mines planted out by the miners before, probably to keep the cave monsters at bay.";
 	name = "rusted mine"
 	},
-/turf/open/floor/plating/asteroid/basalt{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
-	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/awaymission/caves/BMP_asteroid/level_three)
 "aO" = (
 /obj/machinery/light/small{
 	dir = 8
 	},
-/turf/open/floor/plating{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
+/turf/open/floor/plating/lavaland_baseturf{
+	initial_gas_mix = "LAVALAND_ATMOS"
 	},
 /area/awaymission/caves/BMP_asteroid/level_three)
 "aP" = (
 /obj/structure/ladder/unbreakable{
-	anchored = 1;
 	height = 1;
 	id = "dungeon";
 	name = "rusty ladder"
 	},
 /turf/open/floor/engine/cult{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
+	initial_gas_mix = "LAVALAND_ATMOS"
 	},
 /area/awaymission/caves/BMP_asteroid/level_four)
 "aQ" = (
 /obj/item/stack/rods,
-/turf/open/floor/plating/asteroid/basalt{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
-	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/awaymission/caves/BMP_asteroid/level_three)
 "aR" = (
 /obj/effect/forcefield/cult,
 /turf/open/floor/engine/cult{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
+	initial_gas_mix = "LAVALAND_ATMOS"
 	},
 /area/awaymission/caves/BMP_asteroid/level_four)
 "aS" = (
 /obj/structure/girder/cult,
 /turf/open/floor/engine/cult{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
+	initial_gas_mix = "LAVALAND_ATMOS"
 	},
 /area/awaymission/caves/BMP_asteroid/level_four)
 "aT" = (
 /obj/structure/ore_box,
-/turf/open/floor/plating/asteroid/basalt{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
-	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/awaymission/caves/BMP_asteroid/level_three)
 "aU" = (
 /obj/machinery/light/small/built{
@@ -308,23 +270,16 @@
 	name = "\improper MECH TUNNEL PASSAGE B1 TO A2";
 	pixel_x = 32
 	},
-/turf/open/floor/plating/asteroid/basalt{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
-	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/awaymission/caves/BMP_asteroid/level_three)
 "aV" = (
 /obj/effect/forcefield/cult,
-/turf/open/lava/smooth{
-	desc = "Looks hot.";
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15";
-	luminosity = 5;
-	name = "lava"
-	},
+/turf/open/lava/smooth/lava_land_surface,
 /area/awaymission/caves/BMP_asteroid/level_four)
 "aW" = (
 /obj/structure/barricade/wooden,
-/turf/open/floor/plating{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
+/turf/open/floor/plating/lavaland_baseturf{
+	initial_gas_mix = "LAVALAND_ATMOS"
 	},
 /area/awaymission/caves/BMP_asteroid/level_three)
 "aX" = (
@@ -332,8 +287,8 @@
 	id = "minedeepdown";
 	id_target = "minedeepup"
 	},
-/turf/open/floor/plating{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
+/turf/open/floor/plating/lavaland_baseturf{
+	initial_gas_mix = "LAVALAND_ATMOS"
 	},
 /area/awaymission/caves/BMP_asteroid/level_three)
 "aY" = (
@@ -341,9 +296,7 @@
 	desc = "An old rune inscribed on the floor, giving off an intense amount of heat.";
 	name = "flame rune"
 	},
-/turf/open/floor/plating/asteroid/basalt{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
-	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/awaymission/caves/BMP_asteroid/level_four)
 "aZ" = (
 /obj/structure/trap/fire{
@@ -351,58 +304,48 @@
 	name = "flame rune"
 	},
 /turf/open/floor/engine/cult{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
+	initial_gas_mix = "LAVALAND_ATMOS"
 	},
 /area/awaymission/caves/BMP_asteroid/level_four)
 "ba" = (
 /obj/structure/destructible/cult/talisman,
 /obj/item/book/granter/martial/plasma_fist,
 /turf/open/floor/engine/cult{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
+	initial_gas_mix = "LAVALAND_ATMOS"
 	},
 /area/awaymission/caves/BMP_asteroid/level_four)
 "bb" = (
 /mob/living/simple_animal/hostile/poison/giant_spider/hunter,
-/turf/open/floor/plating/asteroid/basalt{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
-	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/awaymission/caves/BMP_asteroid/level_three)
 "bc" = (
 /obj/structure/spider/stickyweb,
-/turf/open/floor/plating/asteroid/basalt{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
-	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/awaymission/caves/BMP_asteroid/level_three)
 "be" = (
 /obj/structure/spawner/mining/goliath,
-/turf/open/floor/plating/asteroid/basalt{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
-	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/awaymission/caves/BMP_asteroid/level_three)
 "bf" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/engine/cult{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
+	initial_gas_mix = "LAVALAND_ATMOS"
 	},
 /area/awaymission/caves/BMP_asteroid/level_four)
 "bg" = (
 /mob/living/simple_animal/hostile/poison/giant_spider/nurse,
-/turf/open/floor/plating/asteroid/basalt{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
-	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/awaymission/caves/BMP_asteroid/level_three)
 "bh" = (
 /mob/living/simple_animal/hostile/skeleton,
-/turf/open/floor/plating/asteroid/basalt{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
-	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/awaymission/caves/BMP_asteroid/level_three)
 "bi" = (
 /obj/machinery/gateway{
 	dir = 9
 	},
 /turf/open/floor/engine/cult{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
+	initial_gas_mix = "LAVALAND_ATMOS"
 	},
 /area/awaymission/caves/BMP_asteroid/level_four)
 "bj" = (
@@ -410,7 +353,7 @@
 	dir = 1
 	},
 /turf/open/floor/engine/cult{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
+	initial_gas_mix = "LAVALAND_ATMOS"
 	},
 /area/awaymission/caves/BMP_asteroid/level_four)
 "bk" = (
@@ -418,7 +361,7 @@
 	dir = 5
 	},
 /turf/open/floor/engine/cult{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
+	initial_gas_mix = "LAVALAND_ATMOS"
 	},
 /area/awaymission/caves/BMP_asteroid/level_four)
 "bl" = (
@@ -426,7 +369,7 @@
 	dir = 8
 	},
 /turf/open/floor/engine/cult{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
+	initial_gas_mix = "LAVALAND_ATMOS"
 	},
 /area/awaymission/caves/BMP_asteroid/level_four)
 "bm" = (
@@ -434,7 +377,7 @@
 	calibrated = 0
 	},
 /turf/open/floor/engine/cult{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
+	initial_gas_mix = "LAVALAND_ATMOS"
 	},
 /area/awaymission/caves/BMP_asteroid/level_four)
 "bn" = (
@@ -442,28 +385,26 @@
 	dir = 4
 	},
 /turf/open/floor/engine/cult{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
+	initial_gas_mix = "LAVALAND_ATMOS"
 	},
 /area/awaymission/caves/BMP_asteroid/level_four)
 "bo" = (
 /obj/structure/flora/rock,
 /obj/item/soulstone/anybody,
-/turf/open/floor/plating/asteroid/basalt{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
-	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/awaymission/caves/BMP_asteroid/level_three)
 "bp" = (
 /obj/machinery/gateway{
 	dir = 10
 	},
 /turf/open/floor/engine/cult{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
+	initial_gas_mix = "LAVALAND_ATMOS"
 	},
 /area/awaymission/caves/BMP_asteroid/level_four)
 "bq" = (
 /obj/machinery/gateway,
 /turf/open/floor/engine/cult{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
+	initial_gas_mix = "LAVALAND_ATMOS"
 	},
 /area/awaymission/caves/BMP_asteroid/level_four)
 "br" = (
@@ -471,7 +412,7 @@
 	dir = 6
 	},
 /turf/open/floor/engine/cult{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
+	initial_gas_mix = "LAVALAND_ATMOS"
 	},
 /area/awaymission/caves/BMP_asteroid/level_four)
 "bs" = (
@@ -479,54 +420,42 @@
 	desc = "A rune inscribed in the floor, the air feeling electrified around it.";
 	name = "shock rune"
 	},
-/turf/open/floor/plating/asteroid/basalt{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
-	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/awaymission/caves/BMP_asteroid/level_four)
 "bt" = (
 /obj/structure/spider/stickyweb,
 /mob/living/simple_animal/hostile/poison/giant_spider/hunter,
-/turf/open/floor/plating/asteroid/basalt{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
-	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/awaymission/caves/BMP_asteroid/level_three)
 "bu" = (
 /obj/structure/spider/cocoon,
-/turf/open/floor/plating/asteroid/basalt{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
-	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/awaymission/caves/BMP_asteroid/level_three)
 "bv" = (
 /obj/structure/destructible/cult/pylon,
-/turf/open/floor/plating/asteroid/basalt{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
-	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/awaymission/caves/BMP_asteroid/level_three)
 "bw" = (
 /obj/effect/decal/cleanable/blood,
 /obj/structure/spawner/skeleton,
 /turf/open/floor/engine/cult{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
+	initial_gas_mix = "LAVALAND_ATMOS"
 	},
 /area/awaymission/caves/BMP_asteroid/level_four)
 "bx" = (
 /obj/item/organ/brain/alien,
-/turf/open/floor/plating/asteroid/basalt{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
-	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/awaymission/caves/BMP_asteroid/level_three)
 "by" = (
 /obj/item/twohanded/mjollnir,
 /mob/living/simple_animal/hostile/poison/giant_spider/nurse,
-/turf/open/floor/plating/asteroid/basalt{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
-	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/awaymission/caves/BMP_asteroid/level_three)
 "bz" = (
 /obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/engine/cult{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
+	initial_gas_mix = "LAVALAND_ATMOS"
 	},
 /area/awaymission/caves/BMP_asteroid/level_four)
 "bA" = (
@@ -534,92 +463,71 @@
 /obj/item/necromantic_stone,
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/engine/cult{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
+	initial_gas_mix = "LAVALAND_ATMOS"
 	},
 /area/awaymission/caves/BMP_asteroid/level_four)
 "bB" = (
 /obj/item/clothing/head/collectable/wizard,
-/turf/open/floor/plating/asteroid/basalt{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
-	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/awaymission/caves/BMP_asteroid/level_three)
 "bC" = (
 /turf/open/floor/engine/cult{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
+	initial_gas_mix = "LAVALAND_ATMOS"
 	},
 /area/awaymission/caves/BMP_asteroid/level_three)
 "bD" = (
 /mob/living/simple_animal/hostile/skeleton,
 /turf/open/floor/engine/cult{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
+	initial_gas_mix = "LAVALAND_ATMOS"
 	},
 /area/awaymission/caves/BMP_asteroid/level_three)
 "bE" = (
 /obj/structure/destructible/cult/pylon,
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/engine/cult{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
+	initial_gas_mix = "LAVALAND_ATMOS"
 	},
 /area/awaymission/caves/BMP_asteroid/level_four)
 "bF" = (
 /obj/structure/ladder/unbreakable{
-	anchored = 1;
 	height = 2;
 	id = "dungeon";
 	name = "rusty ladder"
 	},
 /turf/open/floor/engine/cult{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
+	initial_gas_mix = "LAVALAND_ATMOS"
 	},
 /area/awaymission/caves/BMP_asteroid/level_three)
 "bG" = (
 /obj/item/gun/ballistic/automatic/pistol/deagle/gold,
-/turf/open/floor/plating/asteroid/basalt{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
-	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/awaymission/caves/BMP_asteroid/level_four)
 "bH" = (
 /obj/effect/decal/remains/human,
 /obj/item/clothing/under/patriotsuit,
-/turf/open/floor/plating/asteroid/basalt{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
-	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/awaymission/caves/BMP_asteroid/level_four)
 "bI" = (
 /obj/item/bedsheet/patriot,
-/turf/open/floor/plating/asteroid/basalt{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
-	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/awaymission/caves/BMP_asteroid/level_four)
 "bJ" = (
-/turf/open/floor/plating/asteroid/basalt{
-	initial_gas_mix = "TEMP=2.7"
-	},
+/turf/open/floor/plating/asteroid/basalt/airless,
 /area/awaymission/caves/BMP_asteroid/level_two)
 "bK" = (
-/turf/closed/mineral/volcanic,
+/turf/closed/mineral/volcanic/lava_land_surface,
 /area/awaymission/caves/BMP_asteroid/level_two)
 "bL" = (
-/turf/closed/mineral/volcanic,
+/turf/closed/mineral/volcanic/lava_land_surface,
 /area/awaymission/caves/BMP_asteroid)
 "bM" = (
-/turf/open/lava/smooth{
-	desc = "Looks hot.";
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15";
-	luminosity = 5;
-	name = "lava"
-	},
+/turf/open/lava/smooth/lava_land_surface,
 /area/awaymission/caves/BMP_asteroid)
 "bN" = (
-/turf/closed/mineral/random/high_chance,
+/turf/closed/mineral/random/high_chance/volcanic,
 /area/awaymission/caves/BMP_asteroid/level_two)
 "bO" = (
-/turf/open/lava/smooth{
-	desc = "Looks hot.";
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15";
-	luminosity = 5;
-	name = "lava"
-	},
+/turf/open/lava/smooth/lava_land_surface,
 /area/awaymission/caves/BMP_asteroid/level_two)
 "bP" = (
 /obj/structure/sign/warning/pods{
@@ -630,9 +538,7 @@
 /obj/machinery/light/small/built{
 	dir = 4
 	},
-/turf/open/floor/plating/asteroid/basalt{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
-	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/awaymission/caves/BMP_asteroid/level_two)
 "bQ" = (
 /turf/closed/wall/rust,
@@ -642,48 +548,42 @@
 /area/awaymission/caves/BMP_asteroid/level_two)
 "bS" = (
 /obj/structure/barricade/wooden,
-/turf/open/floor/plating{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
+/turf/open/floor/plating/lavaland_baseturf{
+	initial_gas_mix = "LAVALAND_ATMOS"
 	},
 /area/awaymission/caves/BMP_asteroid/level_two)
 "bT" = (
-/turf/open/floor/plating{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
+/turf/open/floor/plating/lavaland_baseturf{
+	initial_gas_mix = "LAVALAND_ATMOS"
 	},
 /area/awaymission/caves/BMP_asteroid/level_two)
 "bU" = (
 /obj/effect/bump_teleporter{
-	id = "minedeepdown";
-	id_target = "minedeepup"
+	id = "mineintrodown";
+	id_target = "mineintroup"
 	},
-/turf/open/floor/plating{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
+/turf/open/floor/plating/lavaland_baseturf{
+	initial_gas_mix = "LAVALAND_ATMOS"
 	},
 /area/awaymission/caves/BMP_asteroid/level_two)
 "bV" = (
-/turf/open/floor/plating/asteroid/basalt{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
-	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/awaymission/caves/BMP_asteroid)
 "bW" = (
 /obj/machinery/light/small{
 	dir = 8
 	},
-/turf/open/floor/plating/asteroid/basalt{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
-	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/awaymission/caves/BMP_asteroid/level_two)
 "bX" = (
 /obj/structure/table,
 /obj/item/paper/crumpled/awaymissions/caves/unsafe_area,
-/turf/open/floor/plating/asteroid/basalt{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
-	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/awaymission/caves/BMP_asteroid/level_two)
 "bY" = (
 /mob/living/simple_animal/hostile/skeleton,
-/turf/open/floor/plating{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
+/turf/open/floor/plating/lavaland_baseturf{
+	initial_gas_mix = "LAVALAND_ATMOS"
 	},
 /area/awaymission/caves/BMP_asteroid/level_two)
 "bZ" = (
@@ -691,14 +591,12 @@
 	desc = "A rare breed of bat which roosts deep in caves.";
 	name = "Cave Bat"
 	},
-/turf/open/floor/plating/asteroid/basalt{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
-	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/awaymission/caves/BMP_asteroid)
 "ca" = (
 /obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
+/turf/open/floor/plating/lavaland_baseturf{
+	initial_gas_mix = "LAVALAND_ATMOS"
 	},
 /area/awaymission/caves/BMP_asteroid)
 "cb" = (
@@ -713,38 +611,31 @@
 	pixel_x = 5;
 	throwforce = 1
 	},
-/turf/open/floor/plating/asteroid/basalt{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
-	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/awaymission/caves/BMP_asteroid/level_two)
 "cc" = (
 /obj/structure/ore_box,
-/turf/open/floor/plating/asteroid/basalt{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
-	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/awaymission/caves/BMP_asteroid/level_two)
 "cd" = (
 /obj/effect/mine/explosive{
 	desc = "Rusted mines planted out by the miners before, probably to keep the cave monsters at bay.";
 	name = "rusted mine"
 	},
-/turf/open/floor/plating/asteroid/basalt{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
-	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/awaymission/caves/BMP_asteroid/level_two)
 "ce" = (
 /obj/structure/ladder/unbreakable{
-	anchored = 1;
 	height = 1;
 	id = "mineintro"
 	},
-/turf/open/floor/plating{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
+/turf/open/floor/plating/lavaland_baseturf{
+	initial_gas_mix = "LAVALAND_ATMOS"
 	},
 /area/awaymission/caves/BMP_asteroid/level_two)
 "cf" = (
 /turf/open/floor/plasteel/dark{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
+	initial_gas_mix = "LAVALAND_ATMOS"
 	},
 /area/awaymission/caves/BMP_asteroid/level_two)
 "cg" = (
@@ -755,36 +646,30 @@
 /area/awaymission/caves/research)
 "ci" = (
 /obj/item/shard,
-/turf/open/floor/plating/asteroid/basalt{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
-	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/awaymission/caves/BMP_asteroid)
 "cj" = (
 /obj/structure/flora/rock,
-/turf/open/floor/plating/asteroid/basalt{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
-	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/awaymission/caves/BMP_asteroid)
 "ck" = (
 /obj/structure/sign/warning/xeno_mining{
 	pixel_y = -32
 	},
-/turf/open/floor/plating/asteroid/basalt{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
-	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/awaymission/caves/BMP_asteroid/level_two)
 "cl" = (
 /obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
+/turf/open/floor/plating/lavaland_baseturf{
+	initial_gas_mix = "LAVALAND_ATMOS"
 	},
 /area/awaymission/caves/BMP_asteroid/level_two)
 "cm" = (
-/turf/closed/mineral/random/low_chance,
+/turf/closed/mineral/random/low_chance/volcanic,
 /area/awaymission/caves/BMP_asteroid/level_two)
 "cn" = (
 /turf/open/floor/plasteel{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
+	initial_gas_mix = "LAVALAND_ATMOS"
 	},
 /area/awaymission/caves/research)
 "co" = (
@@ -794,30 +679,28 @@
 /obj/structure/filingcabinet,
 /obj/item/paper/fluff/awaymissions/caves/omega,
 /turf/open/floor/plasteel{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
+	initial_gas_mix = "LAVALAND_ATMOS"
 	},
 /area/awaymission/caves/research)
 "cp" = (
 /obj/structure/table,
 /turf/open/floor/plasteel{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
+	initial_gas_mix = "LAVALAND_ATMOS"
 	},
 /area/awaymission/caves/research)
 "cq" = (
 /obj/structure/flora/rock,
-/turf/open/floor/plating/asteroid/basalt{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
-	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/awaymission/caves/BMP_asteroid/level_two)
 "cr" = (
-/turf/open/floor/plating{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
+/turf/open/floor/plating/lavaland_baseturf{
+	initial_gas_mix = "LAVALAND_ATMOS"
 	},
 /area/awaymission/caves/research)
 "cs" = (
 /obj/item/shard,
-/turf/open/floor/plating{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
+/turf/open/floor/plating/lavaland_baseturf{
+	initial_gas_mix = "LAVALAND_ATMOS"
 	},
 /area/awaymission/caves/research)
 "ct" = (
@@ -825,48 +708,44 @@
 /obj/item/stack/rods,
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/plasteel{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
+	initial_gas_mix = "LAVALAND_ATMOS"
 	},
 /area/awaymission/caves/research)
 "cu" = (
 /obj/effect/decal/cleanable/blood/gibs,
 /turf/open/floor/plasteel{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
+	initial_gas_mix = "LAVALAND_ATMOS"
 	},
 /area/awaymission/caves/research)
 "cv" = (
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/plasteel{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
+	initial_gas_mix = "LAVALAND_ATMOS"
 	},
 /area/awaymission/caves/research)
 "cw" = (
 /obj/item/stack/rods,
-/turf/open/floor/plating{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
+/turf/open/floor/plating/lavaland_baseturf{
+	initial_gas_mix = "LAVALAND_ATMOS"
 	},
 /area/awaymission/caves/research)
 "cx" = (
 /turf/open/floor/plasteel/dark{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
+	initial_gas_mix = "LAVALAND_ATMOS"
 	},
 /area/awaymission/caves/BMP_asteroid)
 "cy" = (
 /obj/effect/decal/remains/human,
-/turf/open/floor/plating/asteroid/basalt{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
-	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/awaymission/caves/BMP_asteroid)
 "cz" = (
 /obj/effect/landmark/awaystart,
-/turf/open/floor/plating/asteroid/basalt{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
-	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/awaymission/caves/BMP_asteroid)
 "cA" = (
 /obj/effect/decal/remains/xeno,
-/turf/open/floor/plating{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
+/turf/open/floor/plating/lavaland_baseturf{
+	initial_gas_mix = "LAVALAND_ATMOS"
 	},
 /area/awaymission/caves/research)
 "cB" = (
@@ -874,8 +753,8 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/xenoblood,
-/turf/open/floor/plating{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
+/turf/open/floor/plating/lavaland_baseturf{
+	initial_gas_mix = "LAVALAND_ATMOS"
 	},
 /area/awaymission/caves/research)
 "cC" = (
@@ -883,13 +762,13 @@
 /obj/item/restraints/handcuffs/cable,
 /obj/item/restraints/handcuffs/cable,
 /turf/open/floor/plasteel{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
+	initial_gas_mix = "LAVALAND_ATMOS"
 	},
 /area/awaymission/caves/research)
 "cD" = (
 /obj/effect/decal/remains/human,
 /turf/open/floor/plasteel{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
+	initial_gas_mix = "LAVALAND_ATMOS"
 	},
 /area/awaymission/caves/research)
 "cE" = (
@@ -899,27 +778,25 @@
 	},
 /obj/item/stack/rods,
 /turf/open/floor/plasteel{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
+	initial_gas_mix = "LAVALAND_ATMOS"
 	},
 /area/awaymission/caves/research)
 "cF" = (
 /obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
+/turf/open/floor/plating/lavaland_baseturf{
+	initial_gas_mix = "LAVALAND_ATMOS"
 	},
 /area/awaymission/caves/research)
 "cG" = (
 /obj/machinery/light/small{
 	dir = 8
 	},
-/turf/open/floor/plating/asteroid/basalt{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
-	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/awaymission/caves/BMP_asteroid)
 "cH" = (
 /obj/machinery/door/airlock/external,
-/turf/open/floor/plating{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
+/turf/open/floor/plating/lavaland_baseturf{
+	initial_gas_mix = "LAVALAND_ATMOS"
 	},
 /area/awaymission/caves/BMP_asteroid/level_two)
 "cK" = (
@@ -931,23 +808,21 @@
 /area/awaymission/caves/BMP_asteroid/level_two)
 "cL" = (
 /obj/structure/spawner/mining/basilisk,
-/turf/open/floor/plating/asteroid/basalt{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
-	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/awaymission/caves/BMP_asteroid/level_two)
 "cM" = (
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/open/floor/plating{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
+/turf/open/floor/plating/lavaland_baseturf{
+	initial_gas_mix = "LAVALAND_ATMOS"
 	},
 /area/awaymission/caves/research)
 "cN" = (
 /obj/machinery/door/window/eastleft,
 /obj/effect/decal/cleanable/xenoblood/xgibs,
-/turf/open/floor/plating{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
+/turf/open/floor/plating/lavaland_baseturf{
+	initial_gas_mix = "LAVALAND_ATMOS"
 	},
 /area/awaymission/caves/research)
 "cO" = (
@@ -955,14 +830,14 @@
 	dir = 1
 	},
 /obj/machinery/door/window/eastleft,
-/turf/open/floor/plating{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
+/turf/open/floor/plating/lavaland_baseturf{
+	initial_gas_mix = "LAVALAND_ATMOS"
 	},
 /area/awaymission/caves/research)
 "cP" = (
 /obj/machinery/door/airlock/external,
-/turf/open/floor/plating{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
+/turf/open/floor/plating/lavaland_baseturf{
+	initial_gas_mix = "LAVALAND_ATMOS"
 	},
 /area/awaymission/caves/research)
 "cQ" = (
@@ -974,14 +849,12 @@
 	pixel_x = 5;
 	throwforce = 1
 	},
-/turf/open/floor/plating/asteroid/basalt{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
-	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/awaymission/caves/BMP_asteroid/level_two)
 "cR" = (
 /obj/effect/landmark/awaystart,
-/turf/open/floor/plating{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
+/turf/open/floor/plating/lavaland_baseturf{
+	initial_gas_mix = "LAVALAND_ATMOS"
 	},
 /area/awaymission/caves/research)
 "cS" = (
@@ -990,8 +863,8 @@
 	dir = 4;
 	icon_state = "right"
 	},
-/turf/open/floor/plating{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
+/turf/open/floor/plating/lavaland_baseturf{
+	initial_gas_mix = "LAVALAND_ATMOS"
 	},
 /area/awaymission/caves/research)
 "cT" = (
@@ -1001,8 +874,8 @@
 	dir = 4;
 	icon_state = "right"
 	},
-/turf/open/floor/plating{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
+/turf/open/floor/plating/lavaland_baseturf{
+	initial_gas_mix = "LAVALAND_ATMOS"
 	},
 /area/awaymission/caves/research)
 "cU" = (
@@ -1010,35 +883,33 @@
 	desc = "A rare breed of bat which roosts deep in caves.";
 	name = "Cave Bat"
 	},
-/turf/open/floor/plating/asteroid/basalt{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
-	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/awaymission/caves/BMP_asteroid/level_two)
 "cV" = (
 /obj/effect/decal/cleanable/xenoblood/xgibs,
-/turf/open/floor/plating{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
+/turf/open/floor/plating/lavaland_baseturf{
+	initial_gas_mix = "LAVALAND_ATMOS"
 	},
 /area/awaymission/caves/research)
 "cW" = (
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/turf/open/floor/plating{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
+/turf/open/floor/plating/lavaland_baseturf{
+	initial_gas_mix = "LAVALAND_ATMOS"
 	},
 /area/awaymission/caves/research)
 "cX" = (
 /obj/structure/table,
 /obj/item/melee/baton,
 /turf/open/floor/plasteel{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
+	initial_gas_mix = "LAVALAND_ATMOS"
 	},
 /area/awaymission/caves/research)
 "cY" = (
 /obj/structure/glowshroom/single,
 /turf/open/floor/plasteel{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
+	initial_gas_mix = "LAVALAND_ATMOS"
 	},
 /area/awaymission/caves/research)
 "cZ" = (
@@ -1047,21 +918,19 @@
 	pixel_x = 32
 	},
 /turf/open/floor/plasteel{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
+	initial_gas_mix = "LAVALAND_ATMOS"
 	},
 /area/awaymission/caves/research)
 "da" = (
 /obj/structure/barricade/wooden,
-/turf/open/floor/plating/asteroid/basalt{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
-	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/awaymission/caves/BMP_asteroid)
 "db" = (
 /obj/structure/table,
 /obj/machinery/cell_charger,
 /obj/item/stock_parts/cell/crap,
 /turf/open/floor/plasteel{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
+	initial_gas_mix = "LAVALAND_ATMOS"
 	},
 /area/awaymission/caves/research)
 "dc" = (
@@ -1073,20 +942,18 @@
 	name = "\improper MECH TUNNEL PASSAGE A2 TO A1";
 	pixel_x = -32
 	},
-/turf/open/floor/plating/asteroid/basalt{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
-	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/awaymission/caves/BMP_asteroid/level_two)
 "dd" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/plasteel{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
+	initial_gas_mix = "LAVALAND_ATMOS"
 	},
 /area/awaymission/caves/research)
 "de" = (
 /obj/machinery/light,
 /turf/open/floor/plasteel{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
+	initial_gas_mix = "LAVALAND_ATMOS"
 	},
 /area/awaymission/caves/research)
 "df" = (
@@ -1097,21 +964,21 @@
 /obj/item/grenade/syndieminibomb/concussion,
 /obj/item/grenade/syndieminibomb/concussion,
 /turf/open/floor/plasteel{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
+	initial_gas_mix = "LAVALAND_ATMOS"
 	},
 /area/awaymission/caves/research)
 "dg" = (
 /obj/effect/bump_teleporter{
-	id = "mineintrodown";
-	id_target = "mineintroup"
+	id = "minedeepup";
+	id_target = "minedeepdown"
 	},
-/turf/open/floor/plating{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
+/turf/open/floor/plating/lavaland_baseturf{
+	initial_gas_mix = "LAVALAND_ATMOS"
 	},
 /area/awaymission/caves/BMP_asteroid/level_two)
 "dh" = (
 /obj/machinery/door/airlock/external,
-/turf/open/floor/plating,
+/turf/open/floor/plating/lavaland_baseturf,
 /area/awaymission/caves/BMP_asteroid/level_two)
 "di" = (
 /obj/structure/table,
@@ -1122,7 +989,6 @@
 /area/awaymission/caves/BMP_asteroid/level_two)
 "dj" = (
 /obj/structure/ladder/unbreakable{
-	anchored = 1;
 	height = 2;
 	id = "minedeep"
 	},
@@ -1135,11 +1001,11 @@
 /area/awaymission/caves/BMP_asteroid/level_two)
 "dl" = (
 /obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
+/turf/open/floor/plating/lavaland_baseturf,
 /area/awaymission/caves/BMP_asteroid/level_two)
 "dm" = (
 /obj/structure/spider/stickyweb,
-/turf/open/floor/plating,
+/turf/open/floor/plating/lavaland_baseturf,
 /area/awaymission/caves/BMP_asteroid/level_two)
 "dn" = (
 /obj/structure/chair{
@@ -1262,15 +1128,15 @@
 "dJ" = (
 /obj/item/stack/rods,
 /obj/structure/spider/stickyweb,
-/turf/open/floor/plating,
+/turf/open/floor/plating/lavaland_baseturf,
 /area/awaymission/caves/northblock)
 "dK" = (
 /obj/structure/girder,
-/turf/open/floor/plating,
+/turf/open/floor/plating/lavaland_baseturf,
 /area/awaymission/caves/northblock)
 "dL" = (
 /obj/item/stack/sheet/metal,
-/turf/open/floor/plating,
+/turf/open/floor/plating/lavaland_baseturf,
 /area/awaymission/caves/northblock)
 "dM" = (
 /turf/open/floor/plasteel,
@@ -1296,10 +1162,10 @@
 /obj/machinery/door/airlock/mining{
 	name = "Dorm Access"
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/lavaland_baseturf,
 /area/awaymission/caves/northblock)
 "dR" = (
-/turf/open/floor/plating,
+/turf/open/floor/plating/lavaland_baseturf,
 /area/awaymission/caves/northblock)
 "dS" = (
 /obj/machinery/light/small,
@@ -1313,9 +1179,7 @@
 /obj/structure/closet/crate/miningcar{
 	name = "Mining cart"
 	},
-/turf/open/floor/plating/asteroid/basalt{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
-	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/awaymission/caves/BMP_asteroid)
 "dW" = (
 /turf/closed/wall,
@@ -1346,59 +1210,57 @@
 	dir = 8
 	},
 /turf/open/floor/wood{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
+	initial_gas_mix = "LAVALAND_ATMOS"
 	},
 /area/awaymission/caves/northblock)
 "ec" = (
 /turf/open/floor/wood{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
+	initial_gas_mix = "LAVALAND_ATMOS"
 	},
 /area/awaymission/caves/northblock)
 "ed" = (
 /obj/structure/bed,
 /obj/effect/landmark/awaystart,
 /turf/open/floor/wood{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
+	initial_gas_mix = "LAVALAND_ATMOS"
 	},
 /area/awaymission/caves/northblock)
 "ee" = (
 /obj/structure/girder,
-/turf/open/floor/plating{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
+/turf/open/floor/plating/lavaland_baseturf{
+	initial_gas_mix = "LAVALAND_ATMOS"
 	},
 /area/awaymission/caves/northblock)
 "ef" = (
 /obj/effect/decal/cleanable/ash,
-/turf/open/floor/plating/asteroid/basalt{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
-	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/awaymission/caves/BMP_asteroid)
 "eg" = (
 /obj/effect/decal/cleanable/robot_debris/old,
 /turf/open/floor/plasteel,
-/area/awaymission/caves/BMP_asteroid)
+/area/awaymission/caves/listeningpost)
 "eh" = (
 /obj/structure/table,
 /obj/item/radio,
 /obj/item/radio,
 /turf/open/floor/plasteel,
-/area/awaymission/caves/BMP_asteroid)
+/area/awaymission/caves/listeningpost)
 "ei" = (
 /obj/structure/table,
 /obj/item/paper_bin,
 /obj/item/pen,
-/turf/open/floor/plating,
-/area/awaymission/caves/BMP_asteroid)
+/turf/open/floor/plating/lavaland_baseturf,
+/area/awaymission/caves/listeningpost)
 "ej" = (
-/turf/open/floor/plating,
-/area/awaymission/caves/BMP_asteroid)
+/turf/open/floor/plating/lavaland_baseturf,
+/area/awaymission/caves/listeningpost)
 "ek" = (
 /obj/structure/window{
 	dir = 8
 	},
 /mob/living/simple_animal/hostile/mining_drone,
-/turf/open/floor/plating,
-/area/awaymission/caves/BMP_asteroid)
+/turf/open/floor/plating/lavaland_baseturf,
+/area/awaymission/caves/listeningpost)
 "el" = (
 /obj/structure/closet/secure_closet/personal,
 /obj/item/gun/energy/laser/captain/scattershot,
@@ -1407,24 +1269,24 @@
 "em" = (
 /obj/structure/closet/secure_closet/personal,
 /turf/open/floor/wood{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
+	initial_gas_mix = "LAVALAND_ATMOS"
 	},
 /area/awaymission/caves/northblock)
 "en" = (
 /obj/effect/decal/cleanable/shreds,
 /turf/open/floor/wood{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
+	initial_gas_mix = "LAVALAND_ATMOS"
 	},
 /area/awaymission/caves/northblock)
 "eo" = (
 /obj/item/stack/rods,
 /turf/open/floor/wood{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
+	initial_gas_mix = "LAVALAND_ATMOS"
 	},
 /area/awaymission/caves/northblock)
 "ep" = (
-/turf/open/floor/plating{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
+/turf/open/floor/plating/lavaland_baseturf{
+	initial_gas_mix = "LAVALAND_ATMOS"
 	},
 /area/awaymission/caves/northblock)
 "eq" = (
@@ -1432,30 +1294,28 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/awaymission/caves/BMP_asteroid)
+/area/awaymission/caves/listeningpost)
 "er" = (
 /obj/structure/chair/stool,
-/turf/open/floor/plating,
-/area/awaymission/caves/BMP_asteroid)
+/turf/open/floor/plating/lavaland_baseturf,
+/area/awaymission/caves/listeningpost)
 "es" = (
 /obj/structure/window{
 	dir = 8
 	},
 /obj/structure/window,
 /mob/living/simple_animal/hostile/mining_drone,
-/turf/open/floor/plating,
-/area/awaymission/caves/BMP_asteroid)
+/turf/open/floor/plating/lavaland_baseturf,
+/area/awaymission/caves/listeningpost)
 "et" = (
 /obj/effect/decal/cleanable/shreds,
-/turf/open/floor/plating{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
+/turf/open/floor/plating/lavaland_baseturf{
+	initial_gas_mix = "LAVALAND_ATMOS"
 	},
 /area/awaymission/caves/northblock)
 "eu" = (
 /obj/item/stack/rods,
-/turf/open/floor/plating/asteroid/basalt{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
-	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/awaymission/caves/BMP_asteroid)
 "ev" = (
 /turf/open/floor/plasteel,
@@ -1465,18 +1325,18 @@
 /obj/item/mining_scanner,
 /obj/item/mining_scanner,
 /turf/open/floor/plasteel,
-/area/awaymission/caves/BMP_asteroid)
+/area/awaymission/caves/listeningpost)
 "ex" = (
 /obj/structure/closet/secure_closet/miner,
 /obj/effect/decal/cleanable/cobweb,
 /obj/item/survivalcapsule,
 /obj/item/extinguisher/mini,
 /turf/open/floor/plasteel,
-/area/awaymission/caves/BMP_asteroid)
+/area/awaymission/caves/listeningpost)
 "ey" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plasteel,
-/area/awaymission/caves/BMP_asteroid)
+/area/awaymission/caves/listeningpost)
 "ez" = (
 /obj/machinery/light/small/built{
 	dir = 1
@@ -1486,16 +1346,12 @@
 	name = "rusted suit storage unit"
 	},
 /turf/open/floor/plasteel,
-/area/awaymission/caves/BMP_asteroid)
+/area/awaymission/caves/listeningpost)
 "eA" = (
 /obj/structure/table,
 /obj/item/paper/fluff/awaymissions/caves/work_notice,
 /turf/open/floor/plasteel,
-/area/awaymission/caves/BMP_asteroid)
-"eB" = (
-/obj/structure/barricade/wooden,
-/turf/open/floor/plasteel,
-/area/awaymission/caves/BMP_asteroid)
+/area/awaymission/caves/listeningpost)
 "eC" = (
 /obj/structure/table,
 /obj/item/gps/mining,
@@ -1504,17 +1360,13 @@
 /obj/item/clothing/glasses/meson,
 /obj/item/clothing/glasses/meson,
 /turf/open/floor/plasteel,
-/area/awaymission/caves/BMP_asteroid)
+/area/awaymission/caves/listeningpost)
 "eD" = (
 /obj/structure/closet/secure_closet/miner,
 /obj/item/survivalcapsule,
 /obj/item/extinguisher/mini,
 /turf/open/floor/plasteel,
-/area/awaymission/caves/BMP_asteroid)
-"eE" = (
-/obj/effect/landmark/awaystart,
-/turf/open/floor/plasteel,
-/area/awaymission/caves/BMP_asteroid)
+/area/awaymission/caves/listeningpost)
 "eF" = (
 /turf/closed/wall,
 /area/awaymission/caves/listeningpost)
@@ -1524,7 +1376,7 @@
 "eH" = (
 /obj/machinery/vending/sustenance,
 /turf/open/floor/plasteel,
-/area/awaymission/caves/BMP_asteroid)
+/area/awaymission/caves/listeningpost)
 "eI" = (
 /obj/structure/closet/crate/trashcart,
 /obj/item/switchblade,
@@ -1544,7 +1396,7 @@
 "eL" = (
 /obj/machinery/vending/sovietsoda,
 /turf/open/floor/plasteel,
-/area/awaymission/caves/BMP_asteroid)
+/area/awaymission/caves/listeningpost)
 "eM" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -1584,14 +1436,12 @@
 /area/awaymission/caves/listeningpost)
 "eQ" = (
 /obj/machinery/mineral/mint,
-/turf/open/floor/plating/asteroid/basalt{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
-	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/awaymission/caves/BMP_asteroid)
 "eR" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plasteel,
-/area/awaymission/caves/BMP_asteroid)
+/area/awaymission/caves/listeningpost)
 "eS" = (
 /obj/machinery/light/small/built,
 /obj/machinery/suit_storage_unit/mining{
@@ -1599,11 +1449,11 @@
 	name = "rusted suit storage unit"
 	},
 /turf/open/floor/plasteel,
-/area/awaymission/caves/BMP_asteroid)
+/area/awaymission/caves/listeningpost)
 "eT" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/plasteel,
-/area/awaymission/caves/BMP_asteroid)
+/area/awaymission/caves/listeningpost)
 "eU" = (
 /obj/structure/table,
 /obj/item/storage/toolbox/mechanical,
@@ -1643,9 +1493,7 @@
 /area/awaymission/caves/listeningpost)
 "fb" = (
 /obj/structure/spawner/mining/hivelord,
-/turf/open/floor/plating/asteroid/basalt{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
-	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/awaymission/caves/BMP_asteroid/level_two)
 "fc" = (
 /obj/structure/closet/crate,
@@ -1659,67 +1507,48 @@
 /obj/item/slimepotion/fireproof,
 /obj/item/slimepotion/fireproof,
 /obj/item/clothing/glasses/thermal,
-/turf/open/floor/plating/asteroid/basalt{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
-	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/awaymission/caves/BMP_asteroid/level_two)
 "fd" = (
 /obj/effect/decal/cleanable/blood/old,
-/turf/open/floor/plating/asteroid/basalt{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
-	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/awaymission/caves/BMP_asteroid/level_two)
 "fe" = (
 /obj/effect/decal/cleanable/blood/gibs/old,
-/turf/open/floor/plating/asteroid/basalt{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
-	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/awaymission/caves/BMP_asteroid/level_two)
 "ff" = (
 /obj/machinery/light/small{
 	dir = 4
 	},
-/turf/open/floor/plating/asteroid/basalt{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
-	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/awaymission/caves/BMP_asteroid)
 "fg" = (
 /obj/structure/ore_box,
-/turf/open/floor/plating/asteroid/basalt{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
-	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/awaymission/caves/BMP_asteroid)
 "fh" = (
 /obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
+/turf/open/floor/plating/lavaland_baseturf,
 /area/awaymission/caves/listeningpost)
 "fi" = (
 /obj/machinery/door/airlock/external,
-/turf/open/floor/plating,
+/turf/open/floor/plating/lavaland_baseturf,
 /area/awaymission/caves/listeningpost)
 "fj" = (
 /obj/effect/mob_spawn/human/skeleton/alive{
 	name = "spooky skeleton remains"
 	},
-/turf/open/floor/plating/asteroid/basalt{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
-	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/awaymission/caves/BMP_asteroid/level_two)
 "fk" = (
 /obj/item/grenade/syndieminibomb/concussion,
-/turf/open/floor/plating/asteroid/basalt{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
-	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/awaymission/caves/BMP_asteroid/level_two)
 "fl" = (
 /obj/effect/decal/remains/human,
-/turf/open/floor/plating/asteroid/basalt{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
-	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/awaymission/caves/BMP_asteroid/level_two)
-"fm" = (
-/turf/open/floor/plating,
-/area/awaymission/caves/listeningpost)
 "fn" = (
 /obj/structure/closet/crate{
 	icon_state = "crateopen"
@@ -1728,15 +1557,11 @@
 /obj/item/organ/eyes/robotic/thermals,
 /obj/item/gun/energy/laser/captain/scattershot,
 /obj/item/slimepotion/fireproof,
-/turf/open/floor/plating/asteroid/basalt{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
-	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/awaymission/caves/BMP_asteroid/level_two)
 "fo" = (
 /mob/living/simple_animal/hostile/asteroid/fugu,
-/turf/open/floor/plating/asteroid/basalt{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
-	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/awaymission/caves/BMP_asteroid/level_two)
 "fp" = (
 /obj/structure/sign/warning/pods{
@@ -1747,9 +1572,7 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
-/turf/open/floor/plating/asteroid/basalt{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
-	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/awaymission/caves/BMP_asteroid)
 "fq" = (
 /obj/structure/bed,
@@ -1784,34 +1607,30 @@
 /area/awaymission/caves/BMP_asteroid)
 "fv" = (
 /obj/structure/glowshroom/single,
-/turf/open/floor/plating/asteroid/basalt{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
-	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/awaymission/caves/BMP_asteroid/level_two)
 "fw" = (
 /obj/item/gun/energy/laser/captain/scattershot,
-/turf/open/floor/plating/asteroid/basalt{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
-	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/awaymission/caves/BMP_asteroid/level_two)
 "fx" = (
 /obj/effect/bump_teleporter{
 	id = "mineintroup";
 	id_target = "mineintrodown"
 	},
-/turf/open/floor/plating{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
+/turf/open/floor/plating/lavaland_baseturf{
+	initial_gas_mix = "LAVALAND_ATMOS"
 	},
 /area/awaymission/caves/BMP_asteroid)
 "fy" = (
-/turf/open/floor/plating{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
+/turf/open/floor/plating/lavaland_baseturf{
+	initial_gas_mix = "LAVALAND_ATMOS"
 	},
 /area/awaymission/caves/BMP_asteroid)
 "fz" = (
 /obj/structure/barricade/wooden,
-/turf/open/floor/plating{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
+/turf/open/floor/plating/lavaland_baseturf{
+	initial_gas_mix = "LAVALAND_ATMOS"
 	},
 /area/awaymission/caves/BMP_asteroid)
 "fA" = (
@@ -1836,15 +1655,11 @@
 /area/awaymission/caves/BMP_asteroid)
 "fE" = (
 /obj/machinery/light/small,
-/turf/open/floor/plating/asteroid/basalt{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
-	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/awaymission/caves/BMP_asteroid)
 "fF" = (
 /obj/item/slimepotion/fireproof,
-/turf/open/floor/plating/asteroid/basalt{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
-	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/awaymission/caves/BMP_asteroid/level_two)
 "fG" = (
 /obj/machinery/door/airlock/medical{
@@ -1855,19 +1670,17 @@
 /area/awaymission/caves/BMP_asteroid)
 "fH" = (
 /obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
+/turf/open/floor/plating/lavaland_baseturf,
 /area/awaymission/caves/BMP_asteroid)
 "fI" = (
 /obj/structure/sign/departments/medbay{
 	pixel_x = -32
 	},
-/turf/open/floor/plating/asteroid/basalt{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
-	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/awaymission/caves/BMP_asteroid)
 "fJ" = (
 /obj/structure/grille,
-/turf/open/floor/plating,
+/turf/open/floor/plating/lavaland_baseturf,
 /area/awaymission/caves/BMP_asteroid)
 "fK" = (
 /obj/effect/decal/cleanable/cobweb,
@@ -1887,34 +1700,30 @@
 /area/awaymission/caves/BMP_asteroid)
 "fN" = (
 /obj/machinery/door/airlock/external,
-/turf/open/floor/plating,
+/turf/open/floor/plating/lavaland_baseturf,
 /area/awaymission/caves/BMP_asteroid)
 "fO" = (
 /obj/machinery/light/small{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
+	initial_gas_mix = "LAVALAND_ATMOS"
 	},
 /area/awaymission/caves/BMP_asteroid)
 "fP" = (
 /obj/structure/grille,
-/turf/open/floor/plating/asteroid/basalt{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
-	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/awaymission/caves/BMP_asteroid)
 "fQ" = (
 /turf/open/floor/plasteel/elevatorshaft{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15";
+	initial_gas_mix = "LAVALAND_ATMOS";
 	name = "elevator flooring"
 	},
 /area/awaymission/caves/BMP_asteroid)
 "fR" = (
 /obj/structure/grille,
 /obj/structure/barricade/wooden,
-/turf/open/floor/plating/asteroid/basalt{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
-	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/awaymission/caves/BMP_asteroid/level_two)
 "fS" = (
 /obj/structure/table,
@@ -1930,14 +1739,14 @@
 "fU" = (
 /obj/effect/landmark/awaystart,
 /turf/open/floor/plasteel/elevatorshaft{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15";
+	initial_gas_mix = "LAVALAND_ATMOS";
 	name = "elevator flooring"
 	},
 /area/awaymission/caves/BMP_asteroid)
 "fW" = (
 /obj/structure/girder,
-/turf/open/floor/plating{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
+/turf/open/floor/plating/lavaland_baseturf{
+	initial_gas_mix = "LAVALAND_ATMOS"
 	},
 /area/awaymission/caves/BMP_asteroid)
 "fX" = (
@@ -1955,9 +1764,7 @@
 /obj/item/stack/sheet/mineral/adamantine{
 	amount = 15
 	},
-/turf/open/floor/plating/asteroid/basalt{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
-	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/awaymission/caves/BMP_asteroid/level_two)
 "fY" = (
 /obj/structure/table,
@@ -1966,12 +1773,11 @@
 /area/awaymission/caves/BMP_asteroid)
 "ga" = (
 /obj/structure/ladder/unbreakable{
-	anchored = 1;
 	height = 2;
 	id = "mineintro"
 	},
-/turf/open/floor/plating{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
+/turf/open/floor/plating/lavaland_baseturf{
+	initial_gas_mix = "LAVALAND_ATMOS"
 	},
 /area/awaymission/caves/BMP_asteroid)
 "gb" = (
@@ -1980,8 +1786,8 @@
 /area/awaymission/caves/BMP_asteroid)
 "gc" = (
 /obj/item/stack/rods,
-/turf/open/floor/plating{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
+/turf/open/floor/plating/lavaland_baseturf{
+	initial_gas_mix = "LAVALAND_ATMOS"
 	},
 /area/awaymission/caves/BMP_asteroid)
 "gd" = (
@@ -1989,17 +1795,13 @@
 	desc = "Its a beachball with a face crudely drawn onto it with some soot.";
 	name = "wilson"
 	},
-/turf/open/floor/plating/asteroid/basalt{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
-	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/awaymission/caves/BMP_asteroid/level_two)
 "ge" = (
 /obj/machinery/light/small{
 	dir = 1
 	},
-/turf/open/floor/plating/asteroid/basalt{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
-	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/awaymission/caves/BMP_asteroid)
 "gf" = (
 /obj/structure/table/reinforced,
@@ -2009,21 +1811,21 @@
 "gg" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/box/donkpockets,
-/turf/open/floor/plating{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
+/turf/open/floor/plating/lavaland_baseturf{
+	initial_gas_mix = "LAVALAND_ATMOS"
 	},
 /area/awaymission/caves/BMP_asteroid)
 "gh" = (
 /obj/structure/table/reinforced,
-/turf/open/floor/plating{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
+/turf/open/floor/plating/lavaland_baseturf{
+	initial_gas_mix = "LAVALAND_ATMOS"
 	},
 /area/awaymission/caves/BMP_asteroid)
 "gi" = (
 /obj/structure/table/reinforced,
 /obj/item/stack/rods,
-/turf/open/floor/plating{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
+/turf/open/floor/plating/lavaland_baseturf{
+	initial_gas_mix = "LAVALAND_ATMOS"
 	},
 /area/awaymission/caves/BMP_asteroid)
 "gj" = (
@@ -2034,9 +1836,7 @@
 /area/awaymission/caves/BMP_asteroid)
 "gk" = (
 /obj/effect/landmark/awaystart,
-/turf/open/floor/plating/asteroid/basalt{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
-	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/awaymission/caves/BMP_asteroid/level_two)
 "gl" = (
 /obj/item/trash/plate,
@@ -2048,20 +1848,18 @@
 /area/awaymission/caves/BMP_asteroid)
 "gn" = (
 /obj/item/grown/log,
-/turf/open/floor/plating/asteroid/basalt{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
-	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/awaymission/caves/BMP_asteroid/level_two)
 "go" = (
 /obj/structure/chair/stool,
-/turf/open/floor/plating{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
+/turf/open/floor/plating/lavaland_baseturf{
+	initial_gas_mix = "LAVALAND_ATMOS"
 	},
 /area/awaymission/caves/BMP_asteroid)
 "gp" = (
 /obj/structure/table_frame,
-/turf/open/floor/plating{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
+/turf/open/floor/plating/lavaland_baseturf{
+	initial_gas_mix = "LAVALAND_ATMOS"
 	},
 /area/awaymission/caves/BMP_asteroid)
 "gq" = (
@@ -2075,9 +1873,7 @@
 /area/awaymission/caves/BMP_asteroid)
 "gs" = (
 /obj/item/assembly/igniter,
-/turf/open/floor/plating/asteroid/basalt{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
-	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/awaymission/caves/BMP_asteroid/level_two)
 "gt" = (
 /obj/structure/table_frame,
@@ -2110,20 +1906,20 @@
 /obj/machinery/door/airlock/external{
 	name = "Mess Hall"
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/lavaland_baseturf,
 /area/awaymission/caves/BMP_asteroid)
 "gA" = (
 /obj/machinery/light/small{
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
+	initial_gas_mix = "LAVALAND_ATMOS"
 	},
 /area/awaymission/caves/BMP_asteroid)
 "gB" = (
 /obj/machinery/mech_bay_recharge_port,
 /turf/open/floor/plasteel{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
+	initial_gas_mix = "LAVALAND_ATMOS"
 	},
 /area/awaymission/caves/BMP_asteroid)
 "gC" = (
@@ -2134,16 +1930,14 @@
 /area/awaymission/caves/BMP_asteroid)
 "gD" = (
 /obj/structure/spawner/mining/hivelord,
-/turf/open/floor/plating/asteroid/basalt{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
-	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/awaymission/caves/BMP_asteroid)
 "gE" = (
 /obj/machinery/light/small{
 	dir = 4
 	},
 /turf/open/floor/plasteel{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
+	initial_gas_mix = "LAVALAND_ATMOS"
 	},
 /area/awaymission/caves/BMP_asteroid)
 "gF" = (
@@ -2151,7 +1945,7 @@
 /obj/item/storage/toolbox/mechanical,
 /obj/item/clothing/glasses/material,
 /turf/open/floor/plasteel{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
+	initial_gas_mix = "LAVALAND_ATMOS"
 	},
 /area/awaymission/caves/BMP_asteroid)
 "gG" = (
@@ -2162,26 +1956,26 @@
 /obj/structure/table,
 /obj/item/mecha_parts/mecha_equipment/drill/diamonddrill,
 /obj/item/paper/fluff/awaymissions/caves/mech_notice,
-/turf/open/floor/plating,
+/turf/open/floor/plating/lavaland_baseturf,
 /area/awaymission/caves/BMP_asteroid)
 "gI" = (
 /obj/structure/chair/stool,
 /turf/open/floor/plasteel{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
+	initial_gas_mix = "LAVALAND_ATMOS"
 	},
 /area/awaymission/caves/BMP_asteroid)
 "gJ" = (
 /turf/open/floor/plasteel{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
+	initial_gas_mix = "LAVALAND_ATMOS"
 	},
 /area/awaymission/caves/BMP_asteroid)
 "gK" = (
 /obj/structure/girder,
-/turf/open/floor/plating,
+/turf/open/floor/plating/lavaland_baseturf,
 /area/awaymission/caves/BMP_asteroid)
 "gL" = (
 /obj/item/stack/rods,
-/turf/open/floor/plating,
+/turf/open/floor/plating/lavaland_baseturf,
 /area/awaymission/caves/BMP_asteroid)
 "gM" = (
 /obj/structure/mecha_wreckage/ripley,
@@ -2190,26 +1984,24 @@
 "gN" = (
 /obj/structure/holohoop,
 /turf/open/floor/plasteel/dark{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
+	initial_gas_mix = "LAVALAND_ATMOS"
 	},
 /area/awaymission/caves/BMP_asteroid)
 "gO" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/plasteel{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
+	initial_gas_mix = "LAVALAND_ATMOS"
 	},
 /area/awaymission/caves/BMP_asteroid)
 "gP" = (
 /obj/item/toy/beach_ball/holoball,
 /turf/open/floor/plasteel/dark{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
+	initial_gas_mix = "LAVALAND_ATMOS"
 	},
 /area/awaymission/caves/BMP_asteroid)
 "gQ" = (
 /obj/structure/spawner/mining/basilisk,
-/turf/open/floor/plating/asteroid/basalt{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
-	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/awaymission/caves/BMP_asteroid)
 "gR" = (
 /obj/structure/closet/crate/miningcar{
@@ -2218,28 +2010,24 @@
 /obj/item/stack/sheet/mineral/mythril{
 	amount = 12
 	},
-/turf/open/floor/plating/asteroid/basalt{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
-	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/awaymission/caves/BMP_asteroid)
 "gS" = (
 /obj/structure/girder,
-/turf/open/floor/plating/asteroid/basalt{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
-	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/awaymission/caves/BMP_asteroid)
 "gT" = (
 /obj/machinery/light/small{
 	dir = 4
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/lavaland_baseturf,
 /area/awaymission/caves/BMP_asteroid)
 "gU" = (
 /obj/structure/holohoop{
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
+	initial_gas_mix = "LAVALAND_ATMOS"
 	},
 /area/awaymission/caves/BMP_asteroid)
 "gV" = (
@@ -2247,43 +2035,51 @@
 	desc = "Rusted mines planted out by the miners before, probably to keep the cave monsters at bay.";
 	name = "rusted mine"
 	},
-/turf/open/floor/plating/asteroid/basalt{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
-	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/awaymission/caves/BMP_asteroid)
 "gX" = (
 /obj/effect/baseturf_helper/lava,
-/turf/closed/mineral/volcanic,
+/turf/closed/mineral/volcanic/lava_land_surface,
 /area/awaymission/caves/BMP_asteroid/level_three)
 "gY" = (
 /obj/effect/baseturf_helper/lava,
-/turf/open/lava/smooth{
-	desc = "Looks hot.";
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15";
-	luminosity = 5;
-	name = "lava"
-	},
+/turf/open/lava/smooth/lava_land_surface,
 /area/awaymission/caves/BMP_asteroid/level_four)
 "gZ" = (
 /obj/effect/baseturf_helper/lava,
-/turf/closed/mineral/volcanic,
+/turf/closed/mineral/volcanic/lava_land_surface,
 /area/awaymission/caves/BMP_asteroid/level_two)
 "ha" = (
 /obj/effect/baseturf_helper/lava,
-/turf/closed/mineral/volcanic,
+/turf/closed/mineral/volcanic/lava_land_surface,
 /area/awaymission/caves/BMP_asteroid)
 "hb" = (
 /obj/effect/baseturf_helper/asteroid/basalt,
 /turf/closed/wall,
 /area/awaymission/caves/northblock)
-"DM" = (
-/turf/open/space/basic,
-/area/awaymission/caves/BMP_asteroid/level_three)
-"YF" = (
-/turf/open/floor/plating/asteroid/basalt{
-	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
-	},
+"si" = (
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/awaymission/caves/BMP_asteroid/level_two)
+"Da" = (
+/obj/effect/baseturf_helper/asteroid/basalt,
+/turf/closed/wall,
+/area/awaymission/caves/listeningpost)
+"EE" = (
+/obj/effect/baseturf_helper/asteroid/basalt,
+/turf/closed/wall,
+/area/awaymission/caves/research)
+"Kl" = (
+/obj/structure/closet/secure_closet/miner,
+/obj/item/survivalcapsule,
+/obj/item/extinguisher/mini,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/awaymission/caves/listeningpost)
+"Qe" = (
+/turf/open/floor/plating/lavaland_baseturf,
+/area/awaymission/caves/BMP_asteroid)
 
 (1,1,1) = {"
 aa
@@ -9175,7 +8971,7 @@ cx
 cx
 bV
 fH
-ej
+Qe
 fH
 bV
 bL
@@ -9514,7 +9310,7 @@ ah
 ah
 ah
 ah
-DM
+ah
 ah
 ah
 ae
@@ -10167,7 +9963,7 @@ bL
 bL
 bL
 bL
-cg
+EE
 cg
 ct
 cC
@@ -10188,13 +9984,13 @@ bL
 bL
 bL
 bL
-dX
-dX
-dW
-dW
-dW
-dW
-dW
+eG
+eG
+eF
+eF
+eF
+eF
+eF
 bL
 bL
 bL
@@ -10445,13 +10241,13 @@ bL
 bL
 bL
 bL
-dX
+eG
 ex
 eD
+Kl
 eD
 eD
-eD
-dX
+eG
 bL
 bL
 bL
@@ -10479,13 +10275,13 @@ bL
 bL
 bL
 cx
-ej
+Qe
 bV
 bM
 bM
 bV
 bV
-ej
+Qe
 bM
 bM
 bM
@@ -10702,13 +10498,13 @@ bL
 bL
 bL
 bL
-dW
+eF
 ey
-ev
-ev
-ev
+eJ
+eJ
+eJ
 eR
-dX
+eG
 bL
 bL
 bL
@@ -10737,7 +10533,7 @@ bL
 bL
 cx
 cx
-ej
+Qe
 bV
 bM
 bV
@@ -10959,13 +10755,13 @@ bL
 bL
 bL
 bL
-dX
+eG
 ez
-eE
-ev
-ev
+eO
+eJ
+eJ
 eS
-dX
+eG
 bL
 bL
 bL
@@ -10994,7 +10790,7 @@ bL
 dW
 gN
 cx
-ej
+Qe
 bV
 bM
 bM
@@ -11216,13 +11012,13 @@ bL
 bL
 bL
 bL
-dX
+eG
 eA
-ev
-ev
-ev
+eJ
+eJ
+eJ
 eT
-dW
+eF
 bL
 bV
 bV
@@ -11252,11 +11048,11 @@ bL
 cx
 gP
 cx
-ej
+Qe
 bV
 bV
 bV
-ej
+Qe
 cx
 cx
 bL
@@ -11473,12 +11269,12 @@ bL
 bL
 bL
 bL
-dX
-ev
-ev
-ev
-ev
-ev
+eG
+eJ
+eJ
+eJ
+eJ
+eJ
 eF
 eG
 eG
@@ -11727,15 +11523,15 @@ bL
 bV
 bV
 bL
-dW
-dX
-dX
-dX
-eB
-dW
+Da
+eG
+eG
+eG
+eW
+eF
 eH
 eL
-ev
+eJ
 eW
 eN
 eJ
@@ -11984,11 +11780,11 @@ bL
 bV
 bV
 bL
-dW
+eF
 eg
 eq
-ev
-ev
+eJ
+eJ
 eF
 eF
 eF
@@ -12241,11 +12037,11 @@ bL
 bV
 bV
 bL
-dX
+eG
 eh
 ej
 eg
-ev
+eJ
 eF
 eI
 eM
@@ -12498,11 +12294,11 @@ bL
 bV
 bV
 bL
-dX
+eG
 ei
 er
 ej
-ev
+eJ
 eG
 eJ
 eN
@@ -12512,7 +12308,7 @@ eZ
 eJ
 eJ
 fi
-fm
+ej
 fi
 cx
 cx
@@ -12755,11 +12551,11 @@ bL
 bV
 bV
 bL
-dX
+eG
 ej
 ej
-ev
-ev
+eJ
+eJ
 eG
 eJ
 eO
@@ -13012,7 +12808,7 @@ bL
 bV
 bV
 bL
-dW
+eF
 ek
 es
 ew
@@ -13269,11 +13065,11 @@ bL
 bV
 bV
 bV
-dW
-dW
-dX
-dX
-dW
+eF
+eF
+eG
+eG
+eF
 eF
 eK
 eP
@@ -15867,7 +15663,7 @@ gl
 ev
 ev
 fN
-ej
+Qe
 gz
 cx
 cx
@@ -16124,7 +15920,7 @@ gm
 ev
 ev
 fN
-ej
+Qe
 gz
 cx
 cx
@@ -17675,8 +17471,8 @@ bL
 bV
 bV
 fH
-ej
-ej
+Qe
+Qe
 fH
 bM
 bM
@@ -18187,10 +17983,10 @@ dW
 dX
 dW
 gL
-ej
-ej
+Qe
+Qe
 bV
-ej
+Qe
 dX
 bM
 bM
@@ -18443,8 +18239,8 @@ bV
 fy
 gF
 gH
-ej
-ej
+Qe
+Qe
 bV
 bV
 bV
@@ -19476,7 +19272,7 @@ fy
 bM
 bV
 eu
-ej
+Qe
 bV
 bV
 bL
@@ -52598,10 +52394,10 @@ bK
 bK
 bK
 bK
-YF
-YF
-YF
-YF
+si
+si
+si
+si
 bK
 bK
 bK
@@ -52854,11 +52650,11 @@ bK
 bK
 bK
 bK
-YF
-YF
-YF
-YF
-YF
+si
+si
+si
+si
+si
 bK
 bK
 bK
@@ -52867,14 +52663,14 @@ bK
 bK
 bK
 bK
-YF
-YF
-YF
-YF
-YF
-YF
-YF
-YF
+si
+si
+si
+si
+si
+si
+si
+si
 bK
 bK
 bK
@@ -53111,11 +52907,11 @@ bK
 bK
 bK
 bK
-YF
-YF
-YF
-YF
-YF
+si
+si
+si
+si
+si
 bK
 bK
 bK
@@ -53124,14 +52920,14 @@ bK
 bK
 bK
 bK
-YF
-YF
-YF
-YF
-YF
-YF
-YF
-YF
+si
+si
+si
+si
+si
+si
+si
+si
 bK
 bK
 bK
@@ -53339,7 +53135,7 @@ aa
 bK
 bK
 bK
-YF
+si
 bR
 bT
 bT
@@ -53368,12 +53164,12 @@ bK
 bK
 bK
 bK
-YF
-YF
-YF
+si
+si
+si
 fb
-YF
-YF
+si
+si
 bK
 bK
 bK
@@ -53381,15 +53177,15 @@ bK
 bK
 bK
 bK
-YF
-YF
-YF
-YF
-YF
-YF
-YF
-YF
-YF
+si
+si
+si
+si
+si
+si
+si
+si
+si
 bK
 bK
 bK
@@ -53596,13 +53392,13 @@ aa
 bK
 bK
 bK
-YF
+si
 bR
-YF
+si
 cf
 ck
 bR
-YF
+si
 bK
 bK
 bK
@@ -53611,12 +53407,12 @@ bR
 bT
 bT
 bR
-YF
-YF
-YF
-YF
-YF
-YF
+si
+si
+si
+si
+si
+si
 bN
 bN
 bN
@@ -53626,27 +53422,27 @@ bK
 bK
 bK
 bK
-YF
-YF
-YF
-YF
-YF
-YF
+si
+si
+si
+si
+si
+si
 bK
 bK
 bK
 bK
 bK
-YF
-YF
-YF
+si
+si
+si
 gd
-YF
+si
 gn
-YF
-YF
-YF
-YF
+si
+si
+si
+si
 bO
 bO
 bO
@@ -53654,10 +53450,10 @@ bO
 bO
 bO
 bO
-YF
-YF
-YF
-YF
+si
+si
+si
+si
 bK
 bK
 bK
@@ -53853,57 +53649,57 @@ aa
 bK
 bK
 bK
-YF
+si
 bW
-YF
+si
 cf
 cf
 bW
-YF
-YF
+si
+si
 bK
 bK
 bK
 dc
-YF
-YF
+si
+si
 dc
-YF
-YF
-YF
-YF
-YF
-YF
-YF
-YF
-YF
-YF
+si
+si
+si
+si
+si
+si
+si
+si
+si
+si
 bK
 bK
 bK
 bK
 bK
-YF
+si
 bK
 bK
 bK
 bK
-YF
+si
 bK
 bK
 bK
 bK
 bK
-YF
-YF
+si
+si
 fv
-YF
+si
 fl
 gn
 gn
-YF
-YF
-YF
+si
+si
+si
 bK
 bK
 bK
@@ -53914,10 +53710,10 @@ bO
 bO
 bO
 bO
-YF
-YF
-YF
-YF
+si
+si
+si
+si
 bK
 bK
 bK
@@ -54110,57 +53906,57 @@ aa
 bK
 bK
 bK
-YF
-YF
-YF
+si
+si
+si
 cf
 cf
 cf
 cf
 cf
-YF
+si
 bK
 bK
-YF
-YF
-YF
-YF
-YF
+si
+si
+si
+si
+si
 bO
 bO
 bO
 bO
-YF
-YF
-YF
+si
+si
+si
 cq
-YF
-YF
-YF
+si
+si
+si
 bK
 bK
-YF
-YF
-bK
-bK
-bK
-bK
-YF
+si
+si
 bK
 bK
 bK
 bK
-YF
-YF
-YF
-YF
+si
+bK
+bK
+bK
+bK
+si
+si
+si
+si
 cQ
 gk
-YF
+si
 gs
-YF
-YF
-YF
+si
+si
+si
 bK
 bK
 bK
@@ -54174,8 +53970,8 @@ bO
 bO
 bO
 bO
-YF
-YF
+si
+si
 bK
 bK
 bK
@@ -54378,8 +54174,8 @@ cf
 cf
 bK
 bK
-YF
-YF
+si
+si
 bO
 bO
 bO
@@ -54391,33 +54187,33 @@ bO
 bO
 bO
 bO
-YF
-YF
-YF
-YF
+si
+si
+si
+si
 cd
-YF
-YF
-YF
+si
+si
+si
 bK
 bK
 bK
-YF
+si
 bK
 bK
 bK
 bK
-YF
-YF
-YF
-YF
-YF
-YF
-YF
-YF
-YF
-YF
-YF
+si
+si
+si
+si
+si
+si
+si
+si
+si
+si
+si
 bK
 bK
 bK
@@ -54432,9 +54228,9 @@ bO
 bO
 bO
 bO
-YF
-YF
-YF
+si
+si
+si
 bK
 bK
 bK
@@ -54627,16 +54423,16 @@ bK
 bK
 bK
 cc
-YF
-YF
-YF
-YF
+si
+si
+si
+si
 cf
 cf
 bK
 bK
-YF
-YF
+si
+si
 bO
 bO
 bO
@@ -54651,30 +54447,30 @@ bO
 bO
 bO
 bO
-YF
-YF
-YF
-YF
+si
+si
+si
+si
 cd
-YF
-YF
-YF
-YF
+si
+si
+si
+si
 bK
 bK
 bK
 bK
 bK
-YF
-YF
-YF
-YF
-YF
-YF
-YF
-YF
-YF
-YF
+si
+si
+si
+si
+si
+si
+si
+si
+si
+si
 bK
 bK
 bK
@@ -54691,9 +54487,9 @@ bO
 bO
 bO
 bO
-YF
-YF
-YF
+si
+si
+si
 bK
 bK
 bK
@@ -54892,7 +54688,7 @@ cH
 cH
 bQ
 bK
-YF
+si
 cq
 bO
 bO
@@ -54912,26 +54708,26 @@ bO
 bO
 bK
 bK
-YF
-YF
-YF
-YF
+si
+si
+si
+si
 bK
 bK
 bK
 bK
 bK
 bK
-YF
-YF
-YF
-YF
-YF
-YF
-YF
-YF
-YF
-YF
+si
+si
+si
+si
+si
+si
+si
+si
+si
+si
 bK
 bK
 bK
@@ -54950,7 +54746,7 @@ bO
 bO
 bO
 bO
-YF
+si
 bK
 bK
 bK
@@ -55148,8 +54944,8 @@ cl
 bT
 bT
 cl
-YF
-YF
+si
+si
 bO
 bO
 bO
@@ -55160,19 +54956,19 @@ bO
 bO
 bO
 bO
-YF
-YF
-YF
-YF
+si
+si
+si
+si
 bO
 bO
 bO
 bO
 bK
 bK
-YF
-YF
-YF
+si
+si
+si
 bK
 bK
 bK
@@ -55181,12 +54977,12 @@ bK
 bK
 bK
 bK
-YF
-YF
-YF
-YF
-YF
-YF
+si
+si
+si
+si
+si
+si
 bK
 bK
 bK
@@ -55207,9 +55003,9 @@ bK
 bO
 bO
 bO
-YF
-YF
-YF
+si
+si
+si
 bK
 bK
 bK
@@ -55405,24 +55201,24 @@ bQ
 cH
 cH
 bR
-YF
+si
 bO
 bO
 bO
 bO
 bO
 bO
-YF
-YF
+si
+si
 bK
-YF
-YF
-YF
-YF
-YF
-YF
-YF
-YF
+si
+si
+si
+si
+si
+si
+si
+si
 bO
 bO
 bK
@@ -55466,7 +55262,7 @@ bO
 bO
 bO
 bO
-YF
+si
 bK
 bK
 bK
@@ -55654,23 +55450,23 @@ bK
 bK
 bK
 bK
-YF
-YF
-YF
-YF
-YF
-YF
-YF
-YF
-YF
+si
+si
+si
+si
+si
+si
+si
+si
+si
 bO
 bO
 bO
-YF
-YF
-YF
-YF
-YF
+si
+si
+si
+si
+si
 bK
 bK
 bK
@@ -55678,8 +55474,8 @@ bK
 bK
 bK
 cd
-YF
-YF
+si
+si
 bO
 bO
 bK
@@ -55723,7 +55519,7 @@ bO
 bO
 bO
 bO
-YF
+si
 bK
 bK
 bK
@@ -55911,11 +55707,11 @@ bK
 bK
 bK
 bK
-YF
-YF
-YF
-YF
-YF
+si
+si
+si
+si
+si
 bO
 bO
 bO
@@ -55923,20 +55719,20 @@ bO
 bO
 bO
 bO
-YF
-YF
-YF
-YF
+si
+si
+si
+si
 cq
-YF
-YF
-YF
-YF
-YF
-YF
-YF
-YF
-YF
+si
+si
+si
+si
+si
+si
+si
+si
+si
 bO
 bO
 bK
@@ -55980,7 +55776,7 @@ bO
 bO
 bO
 bO
-YF
+si
 bK
 bK
 bK
@@ -56168,32 +55964,32 @@ bK
 bK
 bK
 bK
-YF
-YF
-YF
-YF
-YF
+si
+si
+si
+si
+si
 bT
 bT
 bT
 bT
 bT
 bT
-YF
-YF
-YF
-YF
-YF
-YF
-YF
-YF
-YF
-YF
-YF
+si
+si
+si
+si
+si
+si
+si
+si
+si
+si
+si
 cU
-YF
-YF
-YF
+si
+si
+si
 bO
 bO
 bK
@@ -56237,7 +56033,7 @@ bK
 bO
 bO
 bO
-YF
+si
 bK
 bK
 bK
@@ -56425,32 +56221,32 @@ bK
 bK
 bK
 bK
-YF
-YF
-YF
-YF
+si
+si
+si
+si
 bO
 bO
 bO
 bO
 bO
 bO
-YF
-YF
-YF
+si
+si
+si
 bK
 bK
 bK
-YF
-YF
-YF
+si
+si
+si
 bK
 bK
 bK
 bK
 bK
-YF
-YF
+si
+si
 bO
 bO
 bK
@@ -56494,7 +56290,7 @@ bK
 bK
 bO
 bO
-YF
+si
 bK
 bK
 bK
@@ -56683,7 +56479,7 @@ bK
 bK
 bK
 bK
-YF
+si
 bO
 bO
 bO
@@ -56691,9 +56487,9 @@ bO
 bO
 bO
 bO
-YF
-YF
-YF
+si
+si
+si
 bN
 bK
 bK
@@ -56703,11 +56499,11 @@ bK
 bK
 bK
 bK
-YF
-YF
-YF
-YF
-YF
+si
+si
+si
+si
+si
 bO
 bO
 bO
@@ -56751,7 +56547,7 @@ bK
 bK
 bO
 bO
-YF
+si
 bK
 bK
 bK
@@ -56939,18 +56735,18 @@ bK
 bK
 bK
 bK
-YF
-YF
+si
+si
 bO
 bO
 bO
 bO
 bO
 bO
-YF
-YF
-YF
-YF
+si
+si
+si
+si
 bN
 bK
 bK
@@ -56960,7 +56756,7 @@ bK
 bK
 bK
 bK
-YF
+si
 cq
 bO
 bO
@@ -57008,7 +56804,7 @@ bK
 bK
 bO
 bO
-YF
+si
 bK
 bK
 bK
@@ -57197,15 +56993,15 @@ bK
 bK
 bK
 cd
-YF
+si
 bO
 bO
 bO
 bO
 bO
-YF
-YF
-YF
+si
+si
+si
 bR
 dl
 bR
@@ -57217,8 +57013,8 @@ bK
 bK
 bK
 bK
-YF
-YF
+si
+si
 bO
 bO
 bT
@@ -57264,8 +57060,8 @@ bK
 bK
 bK
 bO
-YF
-YF
+si
+si
 bK
 bK
 bK
@@ -57452,17 +57248,17 @@ bK
 bK
 bN
 bN
-YF
-YF
-YF
+si
+si
+si
 bO
 bO
 bO
 bO
 bO
-YF
-YF
-YF
+si
+si
+si
 dh
 dm
 dh
@@ -57474,15 +57270,15 @@ bK
 bK
 bK
 bK
-YF
-YF
+si
+si
 bO
 bO
 bT
 bO
-YF
-YF
-YF
+si
+si
+si
 bK
 bK
 bK
@@ -57521,8 +57317,8 @@ bK
 bO
 bO
 bO
-YF
-YF
+si
+si
 bK
 bK
 bK
@@ -57709,7 +57505,7 @@ bK
 bK
 bN
 bN
-YF
+si
 bO
 bO
 bO
@@ -57717,8 +57513,8 @@ bO
 bO
 bO
 bO
-YF
-YF
+si
+si
 bQ
 bR
 dl
@@ -57729,15 +57525,15 @@ bR
 bK
 bK
 bK
-YF
-YF
-YF
-YF
+si
+si
+si
+si
 bO
 bO
 bT
 bO
-YF
+si
 cm
 cm
 cm
@@ -57778,8 +57574,8 @@ bK
 bO
 bO
 bO
-YF
-YF
+si
+si
 bK
 bK
 bK
@@ -57964,17 +57760,17 @@ aa
 aa
 bK
 bK
-YF
-YF
-YF
+si
+si
+si
 bO
 bO
 bO
 bO
 bO
 bO
-YF
-YF
+si
+si
 cc
 bR
 di
@@ -57986,7 +57782,7 @@ bQ
 bK
 bK
 bK
-YF
+si
 cd
 bO
 bO
@@ -57994,7 +57790,7 @@ bO
 bO
 bT
 bO
-YF
+si
 cm
 cm
 cm
@@ -58035,8 +57831,8 @@ bO
 bO
 bO
 bO
-YF
-YF
+si
+si
 bK
 bK
 bK
@@ -58220,8 +58016,8 @@ aa
 aa
 aa
 bK
-YF
-YF
+si
+si
 bO
 bO
 bO
@@ -58230,8 +58026,8 @@ bO
 bO
 bO
 bO
-YF
-YF
+si
+si
 cc
 bQ
 dj
@@ -58243,15 +58039,15 @@ bR
 bK
 bK
 cm
-YF
-YF
+si
+si
 bO
 bO
 bO
-YF
-YF
-YF
-YF
+si
+si
+si
+si
 cm
 cm
 cm
@@ -58289,11 +58085,11 @@ bO
 bO
 bO
 bO
-YF
-YF
-YF
-YF
-YF
+si
+si
+si
+si
+si
 bK
 bK
 bK
@@ -58477,7 +58273,7 @@ aa
 aa
 aa
 bK
-YF
+si
 bO
 bO
 bO
@@ -58488,7 +58284,7 @@ bO
 bO
 bO
 cd
-YF
+si
 cm
 bQ
 dk
@@ -58500,13 +58296,13 @@ bR
 bK
 bK
 cm
-YF
-YF
+si
+si
 bO
 bO
 bO
-YF
-YF
+si
+si
 bK
 cm
 cm
@@ -58546,10 +58342,10 @@ bO
 bO
 bO
 bO
-YF
-YF
-YF
-YF
+si
+si
+si
+si
 bK
 bK
 bK
@@ -58734,7 +58530,7 @@ aa
 aa
 aa
 bK
-YF
+si
 bO
 bO
 bO
@@ -58742,10 +58538,10 @@ bO
 bO
 bO
 bO
-YF
-YF
-YF
-YF
+si
+si
+si
+si
 cm
 bR
 bR
@@ -58757,13 +58553,13 @@ bQ
 cm
 cm
 cm
-YF
-YF
+si
+si
 bO
 bO
 bO
-YF
-YF
+si
+si
 bK
 cm
 cm
@@ -58771,10 +58567,10 @@ cm
 cm
 cm
 bK
-YF
-YF
-YF
-YF
+si
+si
+si
+si
 cm
 bK
 bK
@@ -58803,8 +58599,8 @@ bO
 bO
 bO
 bO
-YF
-YF
+si
+si
 bK
 bK
 bK
@@ -58991,7 +58787,7 @@ aa
 aa
 aa
 bK
-YF
+si
 bO
 bO
 bO
@@ -58999,7 +58795,7 @@ bO
 bO
 bO
 bO
-YF
+si
 cm
 cm
 bK
@@ -59014,12 +58810,12 @@ cm
 cm
 cm
 bK
-YF
-YF
+si
+si
 bO
 bO
 bO
-YF
+si
 bK
 bK
 cm
@@ -59028,10 +58824,10 @@ cm
 cm
 cm
 bK
-YF
-YF
-YF
-YF
+si
+si
+si
+si
 cm
 bK
 bK
@@ -59060,7 +58856,7 @@ bO
 bO
 bO
 bO
-YF
+si
 bK
 bK
 bK
@@ -59248,15 +59044,15 @@ aa
 aa
 aa
 bK
-YF
+si
 bO
 bO
 bO
 bO
 bO
-YF
-YF
-YF
+si
+si
+si
 cm
 cm
 bK
@@ -59272,11 +59068,11 @@ cm
 cm
 bK
 cd
-YF
+si
 bO
 bO
 bO
-YF
+si
 cm
 cm
 cm
@@ -59285,10 +59081,10 @@ cm
 bK
 bK
 bK
-YF
-YF
+si
+si
 fv
-YF
+si
 bK
 bK
 bK
@@ -59317,7 +59113,7 @@ bO
 bO
 bO
 bO
-YF
+si
 bK
 bK
 bK
@@ -59505,13 +59301,13 @@ aa
 aa
 aa
 bK
-YF
+si
 bO
 bO
 bO
 bO
 bO
-YF
+si
 bK
 bK
 bK
@@ -59525,15 +59321,15 @@ bK
 bK
 cm
 cm
-YF
-YF
-YF
-YF
-YF
+si
+si
+si
+si
+si
 bO
 bO
 bO
-YF
+si
 cm
 cm
 cm
@@ -59541,14 +59337,14 @@ cm
 cm
 bK
 bK
-YF
-YF
-YF
-YF
-YF
-YF
-YF
-YF
+si
+si
+si
+si
+si
+si
+si
+si
 bK
 bK
 bK
@@ -59571,10 +59367,10 @@ bO
 bO
 bO
 bO
-YF
-YF
-YF
-YF
+si
+si
+si
+si
 bK
 bK
 bK
@@ -59762,13 +59558,13 @@ aa
 aa
 aa
 bK
-YF
+si
 bO
 bO
 bO
 bO
 bO
-YF
+si
 cm
 cm
 bK
@@ -59782,15 +59578,15 @@ bK
 bK
 bK
 bK
-YF
+si
 bO
 bO
 bO
 bO
 bO
-YF
-YF
-YF
+si
+si
+si
 cm
 cm
 cm
@@ -59798,13 +59594,13 @@ cm
 bK
 bK
 bK
-YF
-YF
+si
+si
 cq
-YF
-YF
-YF
-YF
+si
+si
+si
+si
 fR
 bK
 bK
@@ -59828,10 +59624,10 @@ bO
 bO
 bO
 bO
-YF
-YF
-YF
-YF
+si
+si
+si
+si
 bK
 bK
 bK
@@ -60019,52 +59815,52 @@ aa
 aa
 aa
 bK
-YF
+si
 bO
 bO
 bO
 bO
-YF
-YF
+si
+si
 cm
 cm
 bR
-YF
-YF
+si
+si
 cK
 bK
 bK
 bN
-YF
-YF
-YF
-YF
-YF
+si
+si
+si
+si
+si
 bO
 bO
 bO
 bO
 bO
-YF
-YF
-YF
+si
+si
+si
 cm
 cm
 cm
 cm
 bK
 bK
-YF
-YF
+si
+si
 fj
 fd
 bK
 bK
-YF
-YF
+si
+si
 fR
-YF
-YF
+si
+si
 bK
 bO
 bO
@@ -60084,8 +59880,8 @@ bO
 bO
 bO
 bO
-YF
-YF
+si
+si
 bK
 bK
 bK
@@ -60276,24 +60072,24 @@ aa
 aa
 aa
 bK
-YF
-YF
+si
+si
 bO
-YF
-YF
-YF
+si
+si
+si
 bK
 bK
 bK
 bR
-YF
-YF
+si
+si
 bR
 bK
 bK
 bK
-YF
-YF
+si
+si
 bO
 bO
 bO
@@ -60302,8 +60098,8 @@ bO
 bO
 bO
 bO
-YF
-YF
+si
+si
 bK
 cm
 cm
@@ -60311,17 +60107,17 @@ cm
 bK
 bK
 bK
-YF
+si
 fd
-YF
-YF
+si
+si
 bK
 bK
-YF
+si
 fR
-YF
-YF
-YF
+si
+si
+si
 bK
 bO
 bO
@@ -60341,7 +60137,7 @@ bO
 bO
 bO
 bO
-YF
+si
 bK
 bK
 bK
@@ -60534,32 +60330,32 @@ aa
 aa
 bK
 bK
-YF
+si
 bO
-YF
+si
 bK
 bK
 bK
 bK
 bR
-YF
-YF
-YF
-YF
+si
+si
+si
+si
 bR
 bN
 bN
-YF
-YF
+si
+si
 bO
 bO
 bO
 bO
-YF
-YF
-YF
-YF
-YF
+si
+si
+si
+si
+si
 bK
 cm
 cm
@@ -60568,17 +60364,17 @@ bK
 bK
 bK
 bK
-YF
-YF
+si
+si
 bK
 bK
 bK
 bK
 bK
 fR
-YF
-YF
-YF
+si
+si
+si
 bK
 bO
 bO
@@ -60598,7 +60394,7 @@ bO
 bO
 bO
 bO
-YF
+si
 bK
 bK
 bK
@@ -60791,22 +60587,22 @@ aa
 aa
 bK
 bK
-YF
+si
 bO
-YF
+si
 bK
 bK
 bK
 bK
 bR
-YF
+si
 cQ
-YF
-YF
+si
+si
 bR
 bN
 bN
-YF
+si
 bO
 bO
 bO
@@ -60832,10 +60628,10 @@ bK
 bK
 bK
 bK
-YF
-YF
-YF
-YF
+si
+si
+si
+si
 bK
 bO
 bO
@@ -60855,7 +60651,7 @@ bO
 bO
 bO
 bO
-YF
+si
 bK
 bK
 bK
@@ -61048,22 +60844,22 @@ aa
 aa
 bK
 bK
-YF
+si
 bO
-YF
-YF
-YF
+si
+si
+si
 bK
 bK
 bK
 cK
-YF
-YF
+si
+si
 bR
 bN
 bK
 bK
-YF
+si
 bO
 bO
 bO
@@ -61089,12 +60885,12 @@ bK
 bK
 bK
 bK
-YF
-YF
-YF
-YF
-YF
-YF
+si
+si
+si
+si
+si
+si
 bO
 bO
 bO
@@ -61112,7 +60908,7 @@ bO
 bO
 bO
 bO
-YF
+si
 bK
 bK
 bK
@@ -61305,11 +61101,11 @@ aa
 aa
 bK
 bK
-YF
+si
 bO
 bO
 bO
-YF
+si
 cm
 cm
 bK
@@ -61320,8 +61116,8 @@ bN
 bK
 bK
 bK
-YF
-YF
+si
+si
 bO
 bO
 bO
@@ -61348,13 +61144,13 @@ bK
 bK
 bK
 bK
-YF
-YF
+si
+si
 cq
-YF
-YF
-YF
-YF
+si
+si
+si
+si
 bO
 bO
 bO
@@ -61369,9 +61165,9 @@ bO
 bO
 bO
 bO
-YF
-YF
-YF
+si
+si
+si
 bK
 bK
 bK
@@ -61562,11 +61358,11 @@ aa
 aa
 bK
 bK
-YF
+si
 bO
 bO
 bO
-YF
+si
 cm
 cm
 bK
@@ -61576,9 +61372,9 @@ bK
 bK
 bK
 bK
-YF
-YF
-YF
+si
+si
+si
 bO
 bO
 bO
@@ -61606,15 +61402,15 @@ bK
 bK
 bK
 fX
-YF
-YF
-YF
-YF
-YF
-YF
-YF
-YF
-YF
+si
+si
+si
+si
+si
+si
+si
+si
+si
 bO
 bO
 bO
@@ -61628,7 +61424,7 @@ bO
 bO
 bO
 bO
-YF
+si
 bK
 bK
 bK
@@ -61819,13 +61615,13 @@ aa
 aa
 bK
 bK
-YF
+si
 bO
 bO
 bO
-YF
-YF
-YF
+si
+si
+si
 bK
 bK
 bK
@@ -61833,8 +61629,8 @@ bK
 bK
 bK
 bK
-YF
-YF
+si
+si
 bO
 bO
 bO
@@ -61865,14 +61661,14 @@ bK
 bK
 bK
 cd
-YF
-YF
-YF
-YF
-YF
-YF
-YF
-YF
+si
+si
+si
+si
+si
+si
+si
+si
 cq
 bO
 bO
@@ -61885,7 +61681,7 @@ bO
 bO
 bO
 bO
-YF
+si
 bK
 bK
 bK
@@ -62076,21 +61872,21 @@ aa
 aa
 bK
 bK
-YF
+si
 bO
 bO
 bO
 bO
 bO
-YF
-YF
-YF
-YF
+si
+si
+si
+si
 bK
 bK
 bK
 bK
-YF
+si
 bO
 bO
 bO
@@ -62121,16 +61917,16 @@ bK
 bK
 bK
 bK
-YF
-YF
+si
+si
 bO
 bO
 bO
-YF
+si
 cq
-YF
-YF
-YF
+si
+si
+si
 bO
 bO
 bO
@@ -62142,7 +61938,7 @@ bO
 bO
 bO
 bO
-YF
+si
 bK
 bK
 bK
@@ -62333,21 +62129,21 @@ aa
 aa
 bK
 bK
-YF
-YF
-YF
+si
+si
+si
 bO
 bO
 bO
 bO
 bO
 bO
-YF
+si
 bK
 bK
 bK
 bK
-YF
+si
 bO
 bO
 bO
@@ -62385,8 +62181,8 @@ bO
 bO
 bO
 bO
-YF
-YF
+si
+si
 bO
 bO
 bO
@@ -62399,7 +62195,7 @@ bO
 bO
 bO
 bO
-YF
+si
 bK
 bK
 bK
@@ -62590,21 +62386,21 @@ aa
 aa
 bK
 bK
-YF
-YF
-YF
-YF
-YF
+si
+si
+si
+si
+si
 bO
 bO
 bO
 bO
 cq
-YF
-YF
-YF
-YF
-YF
+si
+si
+si
+si
+si
 bO
 bO
 bO
@@ -62656,7 +62452,7 @@ bO
 bO
 bO
 bO
-YF
+si
 bK
 bK
 bK
@@ -62848,11 +62644,11 @@ aa
 bK
 bK
 bP
-YF
-YF
-YF
-YF
-YF
+si
+si
+si
+si
+si
 bO
 bO
 bO
@@ -62913,7 +62709,7 @@ bO
 bO
 bO
 bO
-YF
+si
 bK
 bK
 bK
@@ -63105,13 +62901,13 @@ aa
 bK
 bK
 bQ
-YF
-YF
+si
+si
 bP
-YF
-YF
-YF
-YF
+si
+si
+si
+si
 bO
 bO
 bO
@@ -63170,7 +62966,7 @@ bO
 bO
 bO
 bO
-YF
+si
 bK
 bK
 bK
@@ -63362,13 +63158,13 @@ aa
 bK
 bK
 bQ
-YF
-YF
+si
+si
 bQ
-YF
-YF
-YF
-YF
+si
+si
+si
+si
 bO
 bO
 bO
@@ -63427,7 +63223,7 @@ bO
 bO
 bO
 bO
-YF
+si
 bK
 bK
 bK
@@ -63619,14 +63415,14 @@ aa
 bK
 bK
 bQ
-YF
+si
 bT
 bQ
-YF
-YF
-YF
-YF
-YF
+si
+si
+si
+si
+si
 bK
 bK
 bK
@@ -63664,9 +63460,9 @@ bK
 bK
 bK
 bK
-YF
-YF
-YF
+si
+si
+si
 bO
 bO
 bO
@@ -63684,7 +63480,7 @@ bO
 bO
 bO
 bO
-YF
+si
 bK
 bK
 bK
@@ -63879,11 +63675,11 @@ bR
 bS
 bS
 bQ
-YF
-YF
+si
+si
 cq
-YF
-YF
+si
+si
 bK
 bK
 bK
@@ -63918,12 +63714,12 @@ bK
 bK
 bK
 bK
-YF
-YF
-YF
-YF
-YF
-YF
+si
+si
+si
+si
+si
+si
 bO
 bO
 bO
@@ -63941,7 +63737,7 @@ bO
 bO
 bO
 bO
-YF
+si
 bK
 bK
 bK
@@ -64136,12 +63932,12 @@ bR
 bT
 bY
 bR
-YF
-YF
-YF
-YF
-YF
-YF
+si
+si
+si
+si
+si
+si
 bK
 bK
 bK
@@ -64175,12 +63971,12 @@ bK
 bK
 bK
 bK
-YF
-YF
-YF
-YF
+si
+si
+si
+si
 cq
-YF
+si
 bO
 bO
 bO
@@ -64198,7 +63994,7 @@ bO
 bO
 bO
 bO
-YF
+si
 bK
 bK
 bK
@@ -64393,13 +64189,13 @@ bQ
 bT
 bT
 bR
-YF
-YF
-YF
-YF
-YF
-YF
-YF
+si
+si
+si
+si
+si
+si
+si
 bK
 bN
 bN
@@ -64416,29 +64212,29 @@ bK
 bK
 bK
 bK
-YF
-YF
+si
+si
 cq
-YF
-YF
-YF
-YF
-YF
+si
+si
+si
+si
+si
 bK
 bK
 bK
-YF
-YF
-YF
-YF
-YF
-YF
-YF
-YF
-YF
-YF
-YF
-YF
+si
+si
+si
+si
+si
+si
+si
+si
+si
+si
+si
+si
 bO
 bO
 bO
@@ -64453,9 +64249,9 @@ bO
 bO
 bO
 bO
-YF
-YF
-YF
+si
+si
+si
 bK
 bK
 bK
@@ -64652,14 +64448,14 @@ bT
 bQ
 bK
 bK
-YF
-YF
+si
+si
 cL
-YF
-YF
-YF
-YF
-YF
+si
+si
+si
+si
+si
 bK
 bN
 bN
@@ -64673,31 +64469,31 @@ bK
 bK
 bK
 bK
-YF
-YF
-YF
+si
+si
+si
 cU
-YF
-YF
-YF
-YF
+si
+si
+si
+si
 bK
 bK
 bK
 fw
-YF
-YF
+si
+si
 cq
-YF
+si
 bK
 bK
 bK
 bK
 bK
 bK
-YF
-YF
-YF
+si
+si
+si
 bO
 bO
 bO
@@ -64710,7 +64506,7 @@ bO
 bO
 bO
 bO
-YF
+si
 bK
 bK
 bK
@@ -64910,42 +64706,42 @@ bQ
 bK
 bK
 bK
-YF
-YF
-YF
+si
+si
+si
 cU
-YF
-YF
-YF
-YF
-YF
-YF
-YF
-YF
+si
+si
+si
+si
+si
+si
+si
+si
 bK
 bK
 bK
 bK
-YF
-YF
-YF
-YF
-YF
-YF
-YF
-YF
+si
+si
+si
+si
+si
+si
+si
+si
 bK
-YF
-YF
-YF
+si
+si
+si
 fe
 fk
 fn
 fd
-YF
-YF
-YF
-YF
+si
+si
+si
+si
 bK
 bK
 bK
@@ -64953,21 +64749,21 @@ bK
 bK
 bK
 bK
-YF
-YF
-YF
-YF
-YF
-YF
-YF
+si
+si
+si
+si
+si
+si
+si
 cq
-YF
+si
 bO
 bO
 bO
 bO
 bO
-YF
+si
 bK
 bK
 bK
@@ -65168,39 +64964,39 @@ bK
 bK
 bK
 bK
-YF
-YF
-YF
-YF
-YF
-YF
-YF
-YF
-YF
-YF
-YF
-YF
-YF
-YF
-YF
-YF
-YF
-YF
-YF
+si
+si
+si
+si
+si
+si
+si
+si
+si
+si
+si
+si
+si
+si
+si
+si
+si
+si
+si
 bK
 bK
 bK
 bK
 bK
-YF
-YF
+si
+si
 fc
-YF
+si
 fl
 fo
-YF
+si
 fF
-YF
+si
 bK
 bK
 bK
@@ -65218,13 +65014,13 @@ bK
 bK
 bK
 bK
-YF
-YF
-YF
-YF
-YF
-YF
-YF
+si
+si
+si
+si
+si
+si
+si
 bK
 bK
 bK
@@ -65434,12 +65230,12 @@ bK
 bK
 bK
 bK
-YF
-YF
-YF
+si
+si
+si
 cq
 cU
-YF
+si
 bK
 bK
 bK
@@ -65449,15 +65245,15 @@ bK
 bK
 bK
 bK
-YF
-YF
-YF
+si
+si
+si
 fd
-YF
-YF
-YF
-YF
-YF
+si
+si
+si
+si
+si
 bK
 bK
 bK
@@ -65691,12 +65487,12 @@ bK
 bK
 bK
 bK
-YF
-YF
-YF
-YF
-YF
-YF
+si
+si
+si
+si
+si
+si
 bK
 bK
 bK

--- a/_maps/RandomZLevels/caves.dmm
+++ b/_maps/RandomZLevels/caves.dmm
@@ -11,45 +11,45 @@
 "ad" = (
 /turf/open/lava/smooth{
 	desc = "Looks hot.";
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15";
 	luminosity = 5;
-	name = "lava";
-	initial_gas_mix = "n2=23;o2=14"
+	name = "lava"
 	},
 /area/awaymission/caves/BMP_asteroid/level_four)
 "ae" = (
 /turf/open/floor/plating/asteroid/basalt{
-	initial_gas_mix = "n2=23;o2=14"
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/BMP_asteroid/level_three)
 "af" = (
 /obj/item/greentext,
 /turf/open/floor/plating/asteroid/basalt{
-	initial_gas_mix = "n2=23;o2=14"
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/BMP_asteroid/level_three)
 "ag" = (
 /obj/structure/barricade/wooden,
 /turf/open/floor/plating/asteroid/basalt{
-	initial_gas_mix = "n2=23;o2=14"
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/BMP_asteroid/level_three)
 "ah" = (
 /turf/open/lava/smooth{
 	desc = "Looks hot.";
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15";
 	luminosity = 5;
-	name = "lava";
-	initial_gas_mix = "n2=23;o2=14"
+	name = "lava"
 	},
 /area/awaymission/caves/BMP_asteroid/level_three)
 "ai" = (
-/turf/open/floor/plating/asteroid/basalt/lava{
-	initial_gas_mix = "n2=23;o2=14"
+/turf/open/floor/plating/asteroid/basalt{
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/BMP_asteroid/level_four)
 "aj" = (
 /obj/structure/flora/rock,
 /turf/open/floor/plating/asteroid/basalt{
-	initial_gas_mix = "n2=23;o2=14"
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/BMP_asteroid/level_three)
 "ak" = (
@@ -57,55 +57,55 @@
 /area/awaymission/caves/BMP_asteroid/level_three)
 "al" = (
 /obj/effect/forcefield/cult,
-/turf/open/floor/plating/asteroid/basalt/lava{
-	initial_gas_mix = "n2=23;o2=14"
+/turf/open/floor/plating/asteroid/basalt{
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/BMP_asteroid/level_four)
 "am" = (
 /obj/effect/decal/remains/human,
-/turf/open/floor/plating/asteroid/basalt/lava{
-	initial_gas_mix = "n2=23;o2=14"
+/turf/open/floor/plating/asteroid/basalt{
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/BMP_asteroid/level_four)
 "an" = (
 /obj/structure/destructible/cult/pylon,
-/turf/open/floor/plating/asteroid/basalt/lava{
-	initial_gas_mix = "n2=23;o2=14"
+/turf/open/floor/plating/asteroid/basalt{
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/BMP_asteroid/level_four)
 "ao" = (
 /turf/open/floor/engine/cult{
-	initial_gas_mix = "n2=23;o2=14"
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/BMP_asteroid/level_four)
 "ap" = (
 /obj/structure/destructible/cult/pylon,
 /turf/open/floor/engine/cult{
-	initial_gas_mix = "n2=23;o2=14"
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/BMP_asteroid/level_four)
 "aq" = (
 /obj/item/ectoplasm,
-/turf/open/floor/plating/asteroid/basalt/lava{
-	initial_gas_mix = "n2=23;o2=14"
+/turf/open/floor/plating/asteroid/basalt{
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/BMP_asteroid/level_four)
 "ar" = (
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/engine/cult{
-	initial_gas_mix = "n2=23;o2=14"
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/BMP_asteroid/level_four)
 "as" = (
 /obj/effect/decal/cleanable/blood/gibs/old,
 /turf/open/floor/engine/cult{
-	initial_gas_mix = "n2=23;o2=14"
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/BMP_asteroid/level_four)
 "at" = (
 /obj/structure/spawner/skeleton,
-/turf/open/floor/plating/asteroid/basalt/lava{
-	initial_gas_mix = "n2=23;o2=14"
+/turf/open/floor/plating/asteroid/basalt{
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/BMP_asteroid/level_four)
 "au" = (
@@ -118,7 +118,7 @@
 /obj/item/clothing/mask/gas/clown_hat,
 /obj/item/organ/heart/demon,
 /turf/open/floor/engine/cult{
-	initial_gas_mix = "n2=23;o2=14"
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/BMP_asteroid/level_four)
 "av" = (
@@ -127,13 +127,13 @@
 	name = "shock rune"
 	},
 /turf/open/floor/engine/cult{
-	initial_gas_mix = "n2=23;o2=14"
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/BMP_asteroid/level_four)
 "aw" = (
 /obj/effect/decal/remains/human,
 /turf/open/floor/engine/cult{
-	initial_gas_mix = "n2=23;o2=14"
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/BMP_asteroid/level_four)
 "ax" = (
@@ -147,39 +147,39 @@
 	},
 /obj/item/coin/antagtoken,
 /turf/open/floor/engine/cult{
-	initial_gas_mix = "n2=23;o2=14"
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/BMP_asteroid/level_four)
 "az" = (
 /obj/structure/constructshell,
 /turf/open/floor/engine/cult{
-	initial_gas_mix = "n2=23;o2=14"
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/BMP_asteroid/level_four)
 "aA" = (
 /obj/structure/girder/cult,
 /obj/item/stack/sheet/runed_metal,
 /turf/open/floor/engine/cult{
-	initial_gas_mix = "n2=23;o2=14"
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/BMP_asteroid/level_four)
 "aB" = (
 /obj/structure/spawner/skeleton,
 /turf/open/floor/engine/cult{
-	initial_gas_mix = "n2=23;o2=14"
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/BMP_asteroid/level_four)
 "aC" = (
 /obj/structure/bed,
 /obj/item/bedsheet/cult,
 /turf/open/floor/engine/cult{
-	initial_gas_mix = "n2=23;o2=14"
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/BMP_asteroid/level_four)
 "aD" = (
 /obj/item/stack/sheet/runed_metal,
 /turf/open/floor/engine/cult{
-	initial_gas_mix = "n2=23;o2=14"
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/BMP_asteroid/level_four)
 "aE" = (
@@ -192,7 +192,7 @@
 	name = "an extremely flamboyant book"
 	},
 /turf/open/floor/engine/cult{
-	initial_gas_mix = "n2=23;o2=14"
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/BMP_asteroid/level_four)
 "aF" = (
@@ -203,13 +203,13 @@
 	name = "weak forcefield"
 	},
 /turf/open/floor/engine/cult{
-	initial_gas_mix = "n2=23;o2=14"
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/BMP_asteroid/level_four)
 "aG" = (
 /obj/item/ectoplasm,
 /turf/open/floor/engine/cult{
-	initial_gas_mix = "n2=23;o2=14"
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/BMP_asteroid/level_four)
 "aH" = (
@@ -218,7 +218,7 @@
 "aI" = (
 /obj/machinery/door/airlock/external,
 /turf/open/floor/plating{
-	initial_gas_mix = "n2=23;o2=14"
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/BMP_asteroid/level_three)
 "aJ" = (
@@ -226,7 +226,7 @@
 /area/awaymission/caves/BMP_asteroid/level_three)
 "aK" = (
 /turf/open/floor/plating{
-	initial_gas_mix = "n2=23;o2=14"
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/BMP_asteroid/level_three)
 "aL" = (
@@ -234,7 +234,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating{
-	initial_gas_mix = "n2=23;o2=14"
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/BMP_asteroid/level_three)
 "aM" = (
@@ -244,7 +244,7 @@
 	id = "minedeep"
 	},
 /turf/open/floor/plating{
-	initial_gas_mix = "n2=23;o2=14"
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/BMP_asteroid/level_three)
 "aN" = (
@@ -253,7 +253,7 @@
 	name = "rusted mine"
 	},
 /turf/open/floor/plating/asteroid/basalt{
-	initial_gas_mix = "n2=23;o2=14"
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/BMP_asteroid/level_three)
 "aO" = (
@@ -261,7 +261,7 @@
 	dir = 8
 	},
 /turf/open/floor/plating{
-	initial_gas_mix = "n2=23;o2=14"
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/BMP_asteroid/level_three)
 "aP" = (
@@ -272,31 +272,31 @@
 	name = "rusty ladder"
 	},
 /turf/open/floor/engine/cult{
-	initial_gas_mix = "n2=23;o2=14"
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/BMP_asteroid/level_four)
 "aQ" = (
 /obj/item/stack/rods,
 /turf/open/floor/plating/asteroid/basalt{
-	initial_gas_mix = "n2=23;o2=14"
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/BMP_asteroid/level_three)
 "aR" = (
 /obj/effect/forcefield/cult,
 /turf/open/floor/engine/cult{
-	initial_gas_mix = "n2=23;o2=14"
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/BMP_asteroid/level_four)
 "aS" = (
 /obj/structure/girder/cult,
 /turf/open/floor/engine/cult{
-	initial_gas_mix = "n2=23;o2=14"
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/BMP_asteroid/level_four)
 "aT" = (
 /obj/structure/ore_box,
 /turf/open/floor/plating/asteroid/basalt{
-	initial_gas_mix = "n2=23;o2=14"
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/BMP_asteroid/level_three)
 "aU" = (
@@ -309,22 +309,22 @@
 	pixel_x = 32
 	},
 /turf/open/floor/plating/asteroid/basalt{
-	initial_gas_mix = "n2=23;o2=14"
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/BMP_asteroid/level_three)
 "aV" = (
 /obj/effect/forcefield/cult,
 /turf/open/lava/smooth{
 	desc = "Looks hot.";
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15";
 	luminosity = 5;
-	name = "lava";
-	initial_gas_mix = "n2=23;o2=14"
+	name = "lava"
 	},
 /area/awaymission/caves/BMP_asteroid/level_four)
 "aW" = (
 /obj/structure/barricade/wooden,
 /turf/open/floor/plating{
-	initial_gas_mix = "n2=23;o2=14"
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/BMP_asteroid/level_three)
 "aX" = (
@@ -333,7 +333,7 @@
 	id_target = "minedeepup"
 	},
 /turf/open/floor/plating{
-	initial_gas_mix = "n2=23;o2=14"
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/BMP_asteroid/level_three)
 "aY" = (
@@ -341,8 +341,8 @@
 	desc = "An old rune inscribed on the floor, giving off an intense amount of heat.";
 	name = "flame rune"
 	},
-/turf/open/floor/plating/asteroid/basalt/lava{
-	initial_gas_mix = "n2=23;o2=14"
+/turf/open/floor/plating/asteroid/basalt{
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/BMP_asteroid/level_four)
 "aZ" = (
@@ -351,50 +351,50 @@
 	name = "flame rune"
 	},
 /turf/open/floor/engine/cult{
-	initial_gas_mix = "n2=23;o2=14"
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/BMP_asteroid/level_four)
 "ba" = (
 /obj/structure/destructible/cult/talisman,
 /obj/item/book/granter/martial/plasma_fist,
 /turf/open/floor/engine/cult{
-	initial_gas_mix = "n2=23;o2=14"
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/BMP_asteroid/level_four)
 "bb" = (
 /mob/living/simple_animal/hostile/poison/giant_spider/hunter,
 /turf/open/floor/plating/asteroid/basalt{
-	initial_gas_mix = "n2=23;o2=14"
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/BMP_asteroid/level_three)
 "bc" = (
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plating/asteroid/basalt{
-	initial_gas_mix = "n2=23;o2=14"
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/BMP_asteroid/level_three)
 "be" = (
 /obj/structure/spawner/mining/goliath,
 /turf/open/floor/plating/asteroid/basalt{
-	initial_gas_mix = "n2=23;o2=14"
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/BMP_asteroid/level_three)
 "bf" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/engine/cult{
-	initial_gas_mix = "n2=23;o2=14"
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/BMP_asteroid/level_four)
 "bg" = (
 /mob/living/simple_animal/hostile/poison/giant_spider/nurse,
 /turf/open/floor/plating/asteroid/basalt{
-	initial_gas_mix = "n2=23;o2=14"
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/BMP_asteroid/level_three)
 "bh" = (
 /mob/living/simple_animal/hostile/skeleton,
 /turf/open/floor/plating/asteroid/basalt{
-	initial_gas_mix = "n2=23;o2=14"
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/BMP_asteroid/level_three)
 "bi" = (
@@ -402,7 +402,7 @@
 	dir = 9
 	},
 /turf/open/floor/engine/cult{
-	initial_gas_mix = "n2=23;o2=14"
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/BMP_asteroid/level_four)
 "bj" = (
@@ -410,7 +410,7 @@
 	dir = 1
 	},
 /turf/open/floor/engine/cult{
-	initial_gas_mix = "n2=23;o2=14"
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/BMP_asteroid/level_four)
 "bk" = (
@@ -418,7 +418,7 @@
 	dir = 5
 	},
 /turf/open/floor/engine/cult{
-	initial_gas_mix = "n2=23;o2=14"
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/BMP_asteroid/level_four)
 "bl" = (
@@ -426,7 +426,7 @@
 	dir = 8
 	},
 /turf/open/floor/engine/cult{
-	initial_gas_mix = "n2=23;o2=14"
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/BMP_asteroid/level_four)
 "bm" = (
@@ -434,7 +434,7 @@
 	calibrated = 0
 	},
 /turf/open/floor/engine/cult{
-	initial_gas_mix = "n2=23;o2=14"
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/BMP_asteroid/level_four)
 "bn" = (
@@ -442,14 +442,14 @@
 	dir = 4
 	},
 /turf/open/floor/engine/cult{
-	initial_gas_mix = "n2=23;o2=14"
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/BMP_asteroid/level_four)
 "bo" = (
 /obj/structure/flora/rock,
 /obj/item/soulstone/anybody,
 /turf/open/floor/plating/asteroid/basalt{
-	initial_gas_mix = "n2=23;o2=14"
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/BMP_asteroid/level_three)
 "bp" = (
@@ -457,13 +457,13 @@
 	dir = 10
 	},
 /turf/open/floor/engine/cult{
-	initial_gas_mix = "n2=23;o2=14"
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/BMP_asteroid/level_four)
 "bq" = (
 /obj/machinery/gateway,
 /turf/open/floor/engine/cult{
-	initial_gas_mix = "n2=23;o2=14"
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/BMP_asteroid/level_four)
 "br" = (
@@ -471,7 +471,7 @@
 	dir = 6
 	},
 /turf/open/floor/engine/cult{
-	initial_gas_mix = "n2=23;o2=14"
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/BMP_asteroid/level_four)
 "bs" = (
@@ -479,54 +479,54 @@
 	desc = "A rune inscribed in the floor, the air feeling electrified around it.";
 	name = "shock rune"
 	},
-/turf/open/floor/plating/asteroid/basalt/lava{
-	initial_gas_mix = "n2=23;o2=14"
+/turf/open/floor/plating/asteroid/basalt{
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/BMP_asteroid/level_four)
 "bt" = (
 /obj/structure/spider/stickyweb,
 /mob/living/simple_animal/hostile/poison/giant_spider/hunter,
 /turf/open/floor/plating/asteroid/basalt{
-	initial_gas_mix = "n2=23;o2=14"
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/BMP_asteroid/level_three)
 "bu" = (
 /obj/structure/spider/cocoon,
 /turf/open/floor/plating/asteroid/basalt{
-	initial_gas_mix = "n2=23;o2=14"
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/BMP_asteroid/level_three)
 "bv" = (
 /obj/structure/destructible/cult/pylon,
 /turf/open/floor/plating/asteroid/basalt{
-	initial_gas_mix = "n2=23;o2=14"
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/BMP_asteroid/level_three)
 "bw" = (
 /obj/effect/decal/cleanable/blood,
 /obj/structure/spawner/skeleton,
 /turf/open/floor/engine/cult{
-	initial_gas_mix = "n2=23;o2=14"
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/BMP_asteroid/level_four)
 "bx" = (
 /obj/item/organ/brain/alien,
 /turf/open/floor/plating/asteroid/basalt{
-	initial_gas_mix = "n2=23;o2=14"
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/BMP_asteroid/level_three)
 "by" = (
 /obj/item/twohanded/mjollnir,
 /mob/living/simple_animal/hostile/poison/giant_spider/nurse,
 /turf/open/floor/plating/asteroid/basalt{
-	initial_gas_mix = "n2=23;o2=14"
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/BMP_asteroid/level_three)
 "bz" = (
 /obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/engine/cult{
-	initial_gas_mix = "n2=23;o2=14"
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/BMP_asteroid/level_four)
 "bA" = (
@@ -534,31 +534,31 @@
 /obj/item/necromantic_stone,
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/engine/cult{
-	initial_gas_mix = "n2=23;o2=14"
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/BMP_asteroid/level_four)
 "bB" = (
 /obj/item/clothing/head/collectable/wizard,
 /turf/open/floor/plating/asteroid/basalt{
-	initial_gas_mix = "n2=23;o2=14"
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/BMP_asteroid/level_three)
 "bC" = (
 /turf/open/floor/engine/cult{
-	initial_gas_mix = "n2=23;o2=14"
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/BMP_asteroid/level_three)
 "bD" = (
 /mob/living/simple_animal/hostile/skeleton,
 /turf/open/floor/engine/cult{
-	initial_gas_mix = "n2=23;o2=14"
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/BMP_asteroid/level_three)
 "bE" = (
 /obj/structure/destructible/cult/pylon,
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/engine/cult{
-	initial_gas_mix = "n2=23;o2=14"
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/BMP_asteroid/level_four)
 "bF" = (
@@ -569,31 +569,31 @@
 	name = "rusty ladder"
 	},
 /turf/open/floor/engine/cult{
-	initial_gas_mix = "n2=23;o2=14"
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/BMP_asteroid/level_three)
 "bG" = (
 /obj/item/gun/ballistic/automatic/pistol/deagle/gold,
-/turf/open/floor/plating/asteroid/basalt/lava{
-	initial_gas_mix = "n2=23;o2=14"
+/turf/open/floor/plating/asteroid/basalt{
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/BMP_asteroid/level_four)
 "bH" = (
 /obj/effect/decal/remains/human,
 /obj/item/clothing/under/patriotsuit,
-/turf/open/floor/plating/asteroid/basalt/lava{
-	initial_gas_mix = "n2=23;o2=14"
+/turf/open/floor/plating/asteroid/basalt{
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/BMP_asteroid/level_four)
 "bI" = (
 /obj/item/bedsheet/patriot,
-/turf/open/floor/plating/asteroid/basalt/lava{
-	initial_gas_mix = "n2=23;o2=14"
+/turf/open/floor/plating/asteroid/basalt{
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/BMP_asteroid/level_four)
 "bJ" = (
 /turf/open/floor/plating/asteroid/basalt{
-	initial_gas_mix = "n2=23;o2=14"
+	initial_gas_mix = "TEMP=2.7"
 	},
 /area/awaymission/caves/BMP_asteroid/level_two)
 "bK" = (
@@ -605,9 +605,9 @@
 "bM" = (
 /turf/open/lava/smooth{
 	desc = "Looks hot.";
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15";
 	luminosity = 5;
-	name = "lava";
-	initial_gas_mix = "n2=23;o2=14"
+	name = "lava"
 	},
 /area/awaymission/caves/BMP_asteroid)
 "bN" = (
@@ -616,9 +616,9 @@
 "bO" = (
 /turf/open/lava/smooth{
 	desc = "Looks hot.";
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15";
 	luminosity = 5;
-	name = "lava";
-	initial_gas_mix = "n2=23;o2=14"
+	name = "lava"
 	},
 /area/awaymission/caves/BMP_asteroid/level_two)
 "bP" = (
@@ -631,7 +631,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating/asteroid/basalt{
-	initial_gas_mix = "n2=23;o2=14"
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/BMP_asteroid/level_two)
 "bQ" = (
@@ -643,12 +643,12 @@
 "bS" = (
 /obj/structure/barricade/wooden,
 /turf/open/floor/plating{
-	initial_gas_mix = "n2=23;o2=14"
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/BMP_asteroid/level_two)
 "bT" = (
 /turf/open/floor/plating{
-	initial_gas_mix = "n2=23;o2=14"
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/BMP_asteroid/level_two)
 "bU" = (
@@ -657,12 +657,12 @@
 	id_target = "minedeepup"
 	},
 /turf/open/floor/plating{
-	initial_gas_mix = "n2=23;o2=14"
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/BMP_asteroid/level_two)
 "bV" = (
 /turf/open/floor/plating/asteroid/basalt{
-	initial_gas_mix = "n2=23;o2=14"
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/BMP_asteroid)
 "bW" = (
@@ -670,20 +670,20 @@
 	dir = 8
 	},
 /turf/open/floor/plating/asteroid/basalt{
-	initial_gas_mix = "n2=23;o2=14"
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/BMP_asteroid/level_two)
 "bX" = (
 /obj/structure/table,
 /obj/item/paper/crumpled/awaymissions/caves/unsafe_area,
 /turf/open/floor/plating/asteroid/basalt{
-	initial_gas_mix = "n2=23;o2=14"
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/BMP_asteroid/level_two)
 "bY" = (
 /mob/living/simple_animal/hostile/skeleton,
 /turf/open/floor/plating{
-	initial_gas_mix = "n2=23;o2=14"
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/BMP_asteroid/level_two)
 "bZ" = (
@@ -692,13 +692,13 @@
 	name = "Cave Bat"
 	},
 /turf/open/floor/plating/asteroid/basalt{
-	initial_gas_mix = "n2=23;o2=14"
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/BMP_asteroid)
 "ca" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating{
-	initial_gas_mix = "n2=23;o2=14"
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/BMP_asteroid)
 "cb" = (
@@ -714,13 +714,13 @@
 	throwforce = 1
 	},
 /turf/open/floor/plating/asteroid/basalt{
-	initial_gas_mix = "n2=23;o2=14"
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/BMP_asteroid/level_two)
 "cc" = (
 /obj/structure/ore_box,
 /turf/open/floor/plating/asteroid/basalt{
-	initial_gas_mix = "n2=23;o2=14"
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/BMP_asteroid/level_two)
 "cd" = (
@@ -729,7 +729,7 @@
 	name = "rusted mine"
 	},
 /turf/open/floor/plating/asteroid/basalt{
-	initial_gas_mix = "n2=23;o2=14"
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/BMP_asteroid/level_two)
 "ce" = (
@@ -739,12 +739,12 @@
 	id = "mineintro"
 	},
 /turf/open/floor/plating{
-	initial_gas_mix = "n2=23;o2=14"
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/BMP_asteroid/level_two)
 "cf" = (
 /turf/open/floor/plasteel/dark{
-	initial_gas_mix = "n2=23;o2=14"
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/BMP_asteroid/level_two)
 "cg" = (
@@ -756,13 +756,13 @@
 "ci" = (
 /obj/item/shard,
 /turf/open/floor/plating/asteroid/basalt{
-	initial_gas_mix = "n2=23;o2=14"
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/BMP_asteroid)
 "cj" = (
 /obj/structure/flora/rock,
 /turf/open/floor/plating/asteroid/basalt{
-	initial_gas_mix = "n2=23;o2=14"
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/BMP_asteroid)
 "ck" = (
@@ -770,13 +770,13 @@
 	pixel_y = -32
 	},
 /turf/open/floor/plating/asteroid/basalt{
-	initial_gas_mix = "n2=23;o2=14"
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/BMP_asteroid/level_two)
 "cl" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating{
-	initial_gas_mix = "n2=23;o2=14"
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/BMP_asteroid/level_two)
 "cm" = (
@@ -784,7 +784,7 @@
 /area/awaymission/caves/BMP_asteroid/level_two)
 "cn" = (
 /turf/open/floor/plasteel{
-	initial_gas_mix = "n2=23;o2=14"
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/research)
 "co" = (
@@ -794,30 +794,30 @@
 /obj/structure/filingcabinet,
 /obj/item/paper/fluff/awaymissions/caves/omega,
 /turf/open/floor/plasteel{
-	initial_gas_mix = "n2=23;o2=14"
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/research)
 "cp" = (
 /obj/structure/table,
 /turf/open/floor/plasteel{
-	initial_gas_mix = "n2=23;o2=14"
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/research)
 "cq" = (
 /obj/structure/flora/rock,
 /turf/open/floor/plating/asteroid/basalt{
-	initial_gas_mix = "n2=23;o2=14"
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/BMP_asteroid/level_two)
 "cr" = (
 /turf/open/floor/plating{
-	initial_gas_mix = "n2=23;o2=14"
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/research)
 "cs" = (
 /obj/item/shard,
 /turf/open/floor/plating{
-	initial_gas_mix = "n2=23;o2=14"
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/research)
 "ct" = (
@@ -825,48 +825,48 @@
 /obj/item/stack/rods,
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/plasteel{
-	initial_gas_mix = "n2=23;o2=14"
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/research)
 "cu" = (
 /obj/effect/decal/cleanable/blood/gibs,
 /turf/open/floor/plasteel{
-	initial_gas_mix = "n2=23;o2=14"
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/research)
 "cv" = (
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/plasteel{
-	initial_gas_mix = "n2=23;o2=14"
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/research)
 "cw" = (
 /obj/item/stack/rods,
 /turf/open/floor/plating{
-	initial_gas_mix = "n2=23;o2=14"
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/research)
 "cx" = (
 /turf/open/floor/plasteel/dark{
-	initial_gas_mix = "n2=23;o2=14"
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/BMP_asteroid)
 "cy" = (
 /obj/effect/decal/remains/human,
 /turf/open/floor/plating/asteroid/basalt{
-	initial_gas_mix = "n2=23;o2=14"
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/BMP_asteroid)
 "cz" = (
 /obj/effect/landmark/awaystart,
 /turf/open/floor/plating/asteroid/basalt{
-	initial_gas_mix = "n2=23;o2=14"
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/BMP_asteroid)
 "cA" = (
 /obj/effect/decal/remains/xeno,
 /turf/open/floor/plating{
-	initial_gas_mix = "n2=23;o2=14"
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/research)
 "cB" = (
@@ -875,7 +875,7 @@
 	},
 /obj/effect/decal/cleanable/xenoblood,
 /turf/open/floor/plating{
-	initial_gas_mix = "n2=23;o2=14"
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/research)
 "cC" = (
@@ -883,13 +883,13 @@
 /obj/item/restraints/handcuffs/cable,
 /obj/item/restraints/handcuffs/cable,
 /turf/open/floor/plasteel{
-	initial_gas_mix = "n2=23;o2=14"
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/research)
 "cD" = (
 /obj/effect/decal/remains/human,
 /turf/open/floor/plasteel{
-	initial_gas_mix = "n2=23;o2=14"
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/research)
 "cE" = (
@@ -899,13 +899,13 @@
 	},
 /obj/item/stack/rods,
 /turf/open/floor/plasteel{
-	initial_gas_mix = "n2=23;o2=14"
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/research)
 "cF" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating{
-	initial_gas_mix = "n2=23;o2=14"
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/research)
 "cG" = (
@@ -913,13 +913,13 @@
 	dir = 8
 	},
 /turf/open/floor/plating/asteroid/basalt{
-	initial_gas_mix = "n2=23;o2=14"
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/BMP_asteroid)
 "cH" = (
 /obj/machinery/door/airlock/external,
 /turf/open/floor/plating{
-	initial_gas_mix = "n2=23;o2=14"
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/BMP_asteroid/level_two)
 "cK" = (
@@ -932,7 +932,7 @@
 "cL" = (
 /obj/structure/spawner/mining/basilisk,
 /turf/open/floor/plating/asteroid/basalt{
-	initial_gas_mix = "n2=23;o2=14"
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/BMP_asteroid/level_two)
 "cM" = (
@@ -940,14 +940,14 @@
 	dir = 8
 	},
 /turf/open/floor/plating{
-	initial_gas_mix = "n2=23;o2=14"
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/research)
 "cN" = (
 /obj/machinery/door/window/eastleft,
 /obj/effect/decal/cleanable/xenoblood/xgibs,
 /turf/open/floor/plating{
-	initial_gas_mix = "n2=23;o2=14"
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/research)
 "cO" = (
@@ -956,13 +956,13 @@
 	},
 /obj/machinery/door/window/eastleft,
 /turf/open/floor/plating{
-	initial_gas_mix = "n2=23;o2=14"
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/research)
 "cP" = (
 /obj/machinery/door/airlock/external,
 /turf/open/floor/plating{
-	initial_gas_mix = "n2=23;o2=14"
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/research)
 "cQ" = (
@@ -975,13 +975,13 @@
 	throwforce = 1
 	},
 /turf/open/floor/plating/asteroid/basalt{
-	initial_gas_mix = "n2=23;o2=14"
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/BMP_asteroid/level_two)
 "cR" = (
 /obj/effect/landmark/awaystart,
 /turf/open/floor/plating{
-	initial_gas_mix = "n2=23;o2=14"
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/research)
 "cS" = (
@@ -991,7 +991,7 @@
 	icon_state = "right"
 	},
 /turf/open/floor/plating{
-	initial_gas_mix = "n2=23;o2=14"
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/research)
 "cT" = (
@@ -1002,7 +1002,7 @@
 	icon_state = "right"
 	},
 /turf/open/floor/plating{
-	initial_gas_mix = "n2=23;o2=14"
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/research)
 "cU" = (
@@ -1011,13 +1011,13 @@
 	name = "Cave Bat"
 	},
 /turf/open/floor/plating/asteroid/basalt{
-	initial_gas_mix = "n2=23;o2=14"
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/BMP_asteroid/level_two)
 "cV" = (
 /obj/effect/decal/cleanable/xenoblood/xgibs,
 /turf/open/floor/plating{
-	initial_gas_mix = "n2=23;o2=14"
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/research)
 "cW" = (
@@ -1025,20 +1025,20 @@
 	dir = 4
 	},
 /turf/open/floor/plating{
-	initial_gas_mix = "n2=23;o2=14"
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/research)
 "cX" = (
 /obj/structure/table,
 /obj/item/melee/baton,
 /turf/open/floor/plasteel{
-	initial_gas_mix = "n2=23;o2=14"
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/research)
 "cY" = (
 /obj/structure/glowshroom/single,
 /turf/open/floor/plasteel{
-	initial_gas_mix = "n2=23;o2=14"
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/research)
 "cZ" = (
@@ -1047,13 +1047,13 @@
 	pixel_x = 32
 	},
 /turf/open/floor/plasteel{
-	initial_gas_mix = "n2=23;o2=14"
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/research)
 "da" = (
 /obj/structure/barricade/wooden,
 /turf/open/floor/plating/asteroid/basalt{
-	initial_gas_mix = "n2=23;o2=14"
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/BMP_asteroid)
 "db" = (
@@ -1061,7 +1061,7 @@
 /obj/machinery/cell_charger,
 /obj/item/stock_parts/cell/crap,
 /turf/open/floor/plasteel{
-	initial_gas_mix = "n2=23;o2=14"
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/research)
 "dc" = (
@@ -1074,19 +1074,19 @@
 	pixel_x = -32
 	},
 /turf/open/floor/plating/asteroid/basalt{
-	initial_gas_mix = "n2=23;o2=14"
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/BMP_asteroid/level_two)
 "dd" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/plasteel{
-	initial_gas_mix = "n2=23;o2=14"
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/research)
 "de" = (
 /obj/machinery/light,
 /turf/open/floor/plasteel{
-	initial_gas_mix = "n2=23;o2=14"
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/research)
 "df" = (
@@ -1097,7 +1097,7 @@
 /obj/item/grenade/syndieminibomb/concussion,
 /obj/item/grenade/syndieminibomb/concussion,
 /turf/open/floor/plasteel{
-	initial_gas_mix = "n2=23;o2=14"
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/research)
 "dg" = (
@@ -1106,7 +1106,7 @@
 	id_target = "mineintroup"
 	},
 /turf/open/floor/plating{
-	initial_gas_mix = "n2=23;o2=14"
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/BMP_asteroid/level_two)
 "dh" = (
@@ -1314,7 +1314,7 @@
 	name = "Mining cart"
 	},
 /turf/open/floor/plating/asteroid/basalt{
-	initial_gas_mix = "n2=23;o2=14"
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/BMP_asteroid)
 "dW" = (
@@ -1346,31 +1346,31 @@
 	dir = 8
 	},
 /turf/open/floor/wood{
-	initial_gas_mix = "n2=23;o2=14"
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/northblock)
 "ec" = (
 /turf/open/floor/wood{
-	initial_gas_mix = "n2=23;o2=14"
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/northblock)
 "ed" = (
 /obj/structure/bed,
 /obj/effect/landmark/awaystart,
 /turf/open/floor/wood{
-	initial_gas_mix = "n2=23;o2=14"
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/northblock)
 "ee" = (
 /obj/structure/girder,
 /turf/open/floor/plating{
-	initial_gas_mix = "n2=23;o2=14"
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/northblock)
 "ef" = (
 /obj/effect/decal/cleanable/ash,
 /turf/open/floor/plating/asteroid/basalt{
-	initial_gas_mix = "n2=23;o2=14"
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/BMP_asteroid)
 "eg" = (
@@ -1407,24 +1407,24 @@
 "em" = (
 /obj/structure/closet/secure_closet/personal,
 /turf/open/floor/wood{
-	initial_gas_mix = "n2=23;o2=14"
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/northblock)
 "en" = (
 /obj/effect/decal/cleanable/shreds,
 /turf/open/floor/wood{
-	initial_gas_mix = "n2=23;o2=14"
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/northblock)
 "eo" = (
 /obj/item/stack/rods,
 /turf/open/floor/wood{
-	initial_gas_mix = "n2=23;o2=14"
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/northblock)
 "ep" = (
 /turf/open/floor/plating{
-	initial_gas_mix = "n2=23;o2=14"
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/northblock)
 "eq" = (
@@ -1448,13 +1448,13 @@
 "et" = (
 /obj/effect/decal/cleanable/shreds,
 /turf/open/floor/plating{
-	initial_gas_mix = "n2=23;o2=14"
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/northblock)
 "eu" = (
 /obj/item/stack/rods,
 /turf/open/floor/plating/asteroid/basalt{
-	initial_gas_mix = "n2=23;o2=14"
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/BMP_asteroid)
 "ev" = (
@@ -1585,7 +1585,7 @@
 "eQ" = (
 /obj/machinery/mineral/mint,
 /turf/open/floor/plating/asteroid/basalt{
-	initial_gas_mix = "n2=23;o2=14"
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/BMP_asteroid)
 "eR" = (
@@ -1644,7 +1644,7 @@
 "fb" = (
 /obj/structure/spawner/mining/hivelord,
 /turf/open/floor/plating/asteroid/basalt{
-	initial_gas_mix = "n2=23;o2=14"
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/BMP_asteroid/level_two)
 "fc" = (
@@ -1660,19 +1660,19 @@
 /obj/item/slimepotion/fireproof,
 /obj/item/clothing/glasses/thermal,
 /turf/open/floor/plating/asteroid/basalt{
-	initial_gas_mix = "n2=23;o2=14"
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/BMP_asteroid/level_two)
 "fd" = (
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/plating/asteroid/basalt{
-	initial_gas_mix = "n2=23;o2=14"
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/BMP_asteroid/level_two)
 "fe" = (
 /obj/effect/decal/cleanable/blood/gibs/old,
 /turf/open/floor/plating/asteroid/basalt{
-	initial_gas_mix = "n2=23;o2=14"
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/BMP_asteroid/level_two)
 "ff" = (
@@ -1680,13 +1680,13 @@
 	dir = 4
 	},
 /turf/open/floor/plating/asteroid/basalt{
-	initial_gas_mix = "n2=23;o2=14"
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/BMP_asteroid)
 "fg" = (
 /obj/structure/ore_box,
 /turf/open/floor/plating/asteroid/basalt{
-	initial_gas_mix = "n2=23;o2=14"
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/BMP_asteroid)
 "fh" = (
@@ -1702,19 +1702,19 @@
 	name = "spooky skeleton remains"
 	},
 /turf/open/floor/plating/asteroid/basalt{
-	initial_gas_mix = "n2=23;o2=14"
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/BMP_asteroid/level_two)
 "fk" = (
 /obj/item/grenade/syndieminibomb/concussion,
 /turf/open/floor/plating/asteroid/basalt{
-	initial_gas_mix = "n2=23;o2=14"
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/BMP_asteroid/level_two)
 "fl" = (
 /obj/effect/decal/remains/human,
 /turf/open/floor/plating/asteroid/basalt{
-	initial_gas_mix = "n2=23;o2=14"
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/BMP_asteroid/level_two)
 "fm" = (
@@ -1729,13 +1729,13 @@
 /obj/item/gun/energy/laser/captain/scattershot,
 /obj/item/slimepotion/fireproof,
 /turf/open/floor/plating/asteroid/basalt{
-	initial_gas_mix = "n2=23;o2=14"
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/BMP_asteroid/level_two)
 "fo" = (
 /mob/living/simple_animal/hostile/asteroid/fugu,
 /turf/open/floor/plating/asteroid/basalt{
-	initial_gas_mix = "n2=23;o2=14"
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/BMP_asteroid/level_two)
 "fp" = (
@@ -1748,7 +1748,7 @@
 	dir = 8
 	},
 /turf/open/floor/plating/asteroid/basalt{
-	initial_gas_mix = "n2=23;o2=14"
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/BMP_asteroid)
 "fq" = (
@@ -1785,13 +1785,13 @@
 "fv" = (
 /obj/structure/glowshroom/single,
 /turf/open/floor/plating/asteroid/basalt{
-	initial_gas_mix = "n2=23;o2=14"
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/BMP_asteroid/level_two)
 "fw" = (
 /obj/item/gun/energy/laser/captain/scattershot,
 /turf/open/floor/plating/asteroid/basalt{
-	initial_gas_mix = "n2=23;o2=14"
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/BMP_asteroid/level_two)
 "fx" = (
@@ -1800,18 +1800,18 @@
 	id_target = "mineintrodown"
 	},
 /turf/open/floor/plating{
-	initial_gas_mix = "n2=23;o2=14"
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/BMP_asteroid)
 "fy" = (
 /turf/open/floor/plating{
-	initial_gas_mix = "n2=23;o2=14"
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/BMP_asteroid)
 "fz" = (
 /obj/structure/barricade/wooden,
 /turf/open/floor/plating{
-	initial_gas_mix = "n2=23;o2=14"
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/BMP_asteroid)
 "fA" = (
@@ -1837,13 +1837,13 @@
 "fE" = (
 /obj/machinery/light/small,
 /turf/open/floor/plating/asteroid/basalt{
-	initial_gas_mix = "n2=23;o2=14"
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/BMP_asteroid)
 "fF" = (
 /obj/item/slimepotion/fireproof,
 /turf/open/floor/plating/asteroid/basalt{
-	initial_gas_mix = "n2=23;o2=14"
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/BMP_asteroid/level_two)
 "fG" = (
@@ -1862,7 +1862,7 @@
 	pixel_x = -32
 	},
 /turf/open/floor/plating/asteroid/basalt{
-	initial_gas_mix = "n2=23;o2=14"
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/BMP_asteroid)
 "fJ" = (
@@ -1894,26 +1894,26 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark{
-	initial_gas_mix = "n2=23;o2=14"
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/BMP_asteroid)
 "fP" = (
 /obj/structure/grille,
 /turf/open/floor/plating/asteroid/basalt{
-	initial_gas_mix = "n2=23;o2=14"
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/BMP_asteroid)
 "fQ" = (
 /turf/open/floor/plasteel/elevatorshaft{
-	name = "elevator flooring";
-	initial_gas_mix = "n2=23;o2=14"
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15";
+	name = "elevator flooring"
 	},
 /area/awaymission/caves/BMP_asteroid)
 "fR" = (
 /obj/structure/grille,
 /obj/structure/barricade/wooden,
 /turf/open/floor/plating/asteroid/basalt{
-	initial_gas_mix = "n2=23;o2=14"
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/BMP_asteroid/level_two)
 "fS" = (
@@ -1930,14 +1930,14 @@
 "fU" = (
 /obj/effect/landmark/awaystart,
 /turf/open/floor/plasteel/elevatorshaft{
-	name = "elevator flooring";
-	initial_gas_mix = "n2=23;o2=14"
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15";
+	name = "elevator flooring"
 	},
 /area/awaymission/caves/BMP_asteroid)
 "fW" = (
 /obj/structure/girder,
 /turf/open/floor/plating{
-	initial_gas_mix = "n2=23;o2=14"
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/BMP_asteroid)
 "fX" = (
@@ -1956,7 +1956,7 @@
 	amount = 15
 	},
 /turf/open/floor/plating/asteroid/basalt{
-	initial_gas_mix = "n2=23;o2=14"
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/BMP_asteroid/level_two)
 "fY" = (
@@ -1971,7 +1971,7 @@
 	id = "mineintro"
 	},
 /turf/open/floor/plating{
-	initial_gas_mix = "n2=23;o2=14"
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/BMP_asteroid)
 "gb" = (
@@ -1981,7 +1981,7 @@
 "gc" = (
 /obj/item/stack/rods,
 /turf/open/floor/plating{
-	initial_gas_mix = "n2=23;o2=14"
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/BMP_asteroid)
 "gd" = (
@@ -1990,7 +1990,7 @@
 	name = "wilson"
 	},
 /turf/open/floor/plating/asteroid/basalt{
-	initial_gas_mix = "n2=23;o2=14"
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/BMP_asteroid/level_two)
 "ge" = (
@@ -1998,7 +1998,7 @@
 	dir = 1
 	},
 /turf/open/floor/plating/asteroid/basalt{
-	initial_gas_mix = "n2=23;o2=14"
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/BMP_asteroid)
 "gf" = (
@@ -2010,20 +2010,20 @@
 /obj/structure/table/reinforced,
 /obj/item/storage/box/donkpockets,
 /turf/open/floor/plating{
-	initial_gas_mix = "n2=23;o2=14"
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/BMP_asteroid)
 "gh" = (
 /obj/structure/table/reinforced,
 /turf/open/floor/plating{
-	initial_gas_mix = "n2=23;o2=14"
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/BMP_asteroid)
 "gi" = (
 /obj/structure/table/reinforced,
 /obj/item/stack/rods,
 /turf/open/floor/plating{
-	initial_gas_mix = "n2=23;o2=14"
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/BMP_asteroid)
 "gj" = (
@@ -2035,7 +2035,7 @@
 "gk" = (
 /obj/effect/landmark/awaystart,
 /turf/open/floor/plating/asteroid/basalt{
-	initial_gas_mix = "n2=23;o2=14"
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/BMP_asteroid/level_two)
 "gl" = (
@@ -2049,19 +2049,19 @@
 "gn" = (
 /obj/item/grown/log,
 /turf/open/floor/plating/asteroid/basalt{
-	initial_gas_mix = "n2=23;o2=14"
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/BMP_asteroid/level_two)
 "go" = (
 /obj/structure/chair/stool,
 /turf/open/floor/plating{
-	initial_gas_mix = "n2=23;o2=14"
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/BMP_asteroid)
 "gp" = (
 /obj/structure/table_frame,
 /turf/open/floor/plating{
-	initial_gas_mix = "n2=23;o2=14"
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/BMP_asteroid)
 "gq" = (
@@ -2076,7 +2076,7 @@
 "gs" = (
 /obj/item/assembly/igniter,
 /turf/open/floor/plating/asteroid/basalt{
-	initial_gas_mix = "n2=23;o2=14"
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/BMP_asteroid/level_two)
 "gt" = (
@@ -2117,13 +2117,13 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark{
-	initial_gas_mix = "n2=23;o2=14"
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/BMP_asteroid)
 "gB" = (
 /obj/machinery/mech_bay_recharge_port,
 /turf/open/floor/plasteel{
-	initial_gas_mix = "n2=23;o2=14"
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/BMP_asteroid)
 "gC" = (
@@ -2135,7 +2135,7 @@
 "gD" = (
 /obj/structure/spawner/mining/hivelord,
 /turf/open/floor/plating/asteroid/basalt{
-	initial_gas_mix = "n2=23;o2=14"
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/BMP_asteroid)
 "gE" = (
@@ -2143,7 +2143,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel{
-	initial_gas_mix = "n2=23;o2=14"
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/BMP_asteroid)
 "gF" = (
@@ -2151,7 +2151,7 @@
 /obj/item/storage/toolbox/mechanical,
 /obj/item/clothing/glasses/material,
 /turf/open/floor/plasteel{
-	initial_gas_mix = "n2=23;o2=14"
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/BMP_asteroid)
 "gG" = (
@@ -2167,12 +2167,12 @@
 "gI" = (
 /obj/structure/chair/stool,
 /turf/open/floor/plasteel{
-	initial_gas_mix = "n2=23;o2=14"
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/BMP_asteroid)
 "gJ" = (
 /turf/open/floor/plasteel{
-	initial_gas_mix = "n2=23;o2=14"
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/BMP_asteroid)
 "gK" = (
@@ -2190,25 +2190,25 @@
 "gN" = (
 /obj/structure/holohoop,
 /turf/open/floor/plasteel/dark{
-	initial_gas_mix = "n2=23;o2=14"
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/BMP_asteroid)
 "gO" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/plasteel{
-	initial_gas_mix = "n2=23;o2=14"
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/BMP_asteroid)
 "gP" = (
 /obj/item/toy/beach_ball/holoball,
 /turf/open/floor/plasteel/dark{
-	initial_gas_mix = "n2=23;o2=14"
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/BMP_asteroid)
 "gQ" = (
 /obj/structure/spawner/mining/basilisk,
 /turf/open/floor/plating/asteroid/basalt{
-	initial_gas_mix = "n2=23;o2=14"
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/BMP_asteroid)
 "gR" = (
@@ -2219,13 +2219,13 @@
 	amount = 12
 	},
 /turf/open/floor/plating/asteroid/basalt{
-	initial_gas_mix = "n2=23;o2=14"
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/BMP_asteroid)
 "gS" = (
 /obj/structure/girder,
 /turf/open/floor/plating/asteroid/basalt{
-	initial_gas_mix = "n2=23;o2=14"
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/BMP_asteroid)
 "gT" = (
@@ -2239,7 +2239,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark{
-	initial_gas_mix = "n2=23;o2=14"
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/BMP_asteroid)
 "gV" = (
@@ -2248,7 +2248,7 @@
 	name = "rusted mine"
 	},
 /turf/open/floor/plating/asteroid/basalt{
-	initial_gas_mix = "n2=23;o2=14"
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
 	},
 /area/awaymission/caves/BMP_asteroid)
 "gX" = (
@@ -2259,9 +2259,9 @@
 /obj/effect/baseturf_helper/lava,
 /turf/open/lava/smooth{
 	desc = "Looks hot.";
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15";
 	luminosity = 5;
-	name = "lava";
-	initial_gas_mix = "n2=23;o2=14"
+	name = "lava"
 	},
 /area/awaymission/caves/BMP_asteroid/level_four)
 "gZ" = (
@@ -2276,6 +2276,14 @@
 /obj/effect/baseturf_helper/asteroid/basalt,
 /turf/closed/wall,
 /area/awaymission/caves/northblock)
+"DM" = (
+/turf/open/space/basic,
+/area/awaymission/caves/BMP_asteroid/level_three)
+"YF" = (
+/turf/open/floor/plating/asteroid/basalt{
+	initial_gas_mix = "n2=23;o2=14;TEMP=293.15"
+	},
+/area/awaymission/caves/BMP_asteroid/level_two)
 
 (1,1,1) = {"
 aa
@@ -9506,7 +9514,7 @@ ah
 ah
 ah
 ah
-ah
+DM
 ah
 ah
 ae
@@ -52590,10 +52598,10 @@ bK
 bK
 bK
 bK
-bJ
-bJ
-bJ
-bJ
+YF
+YF
+YF
+YF
 bK
 bK
 bK
@@ -52846,11 +52854,11 @@ bK
 bK
 bK
 bK
-bJ
-bJ
-bJ
-bJ
-bJ
+YF
+YF
+YF
+YF
+YF
 bK
 bK
 bK
@@ -52859,14 +52867,14 @@ bK
 bK
 bK
 bK
-bJ
-bJ
-bJ
-bJ
-bJ
-bJ
-bJ
-bJ
+YF
+YF
+YF
+YF
+YF
+YF
+YF
+YF
 bK
 bK
 bK
@@ -53103,11 +53111,11 @@ bK
 bK
 bK
 bK
-bJ
-bJ
-bJ
-bJ
-bJ
+YF
+YF
+YF
+YF
+YF
 bK
 bK
 bK
@@ -53116,14 +53124,14 @@ bK
 bK
 bK
 bK
-bJ
-bJ
-bJ
-bJ
-bJ
-bJ
-bJ
-bJ
+YF
+YF
+YF
+YF
+YF
+YF
+YF
+YF
 bK
 bK
 bK
@@ -53331,7 +53339,7 @@ aa
 bK
 bK
 bK
-bJ
+YF
 bR
 bT
 bT
@@ -53360,12 +53368,12 @@ bK
 bK
 bK
 bK
-bJ
-bJ
-bJ
+YF
+YF
+YF
 fb
-bJ
-bJ
+YF
+YF
 bK
 bK
 bK
@@ -53373,15 +53381,15 @@ bK
 bK
 bK
 bK
-bJ
-bJ
-bJ
-bJ
-bJ
-bJ
-bJ
-bJ
-bJ
+YF
+YF
+YF
+YF
+YF
+YF
+YF
+YF
+YF
 bK
 bK
 bK
@@ -53588,13 +53596,13 @@ aa
 bK
 bK
 bK
-bJ
+YF
 bR
-bJ
+YF
 cf
 ck
 bR
-bJ
+YF
 bK
 bK
 bK
@@ -53603,12 +53611,12 @@ bR
 bT
 bT
 bR
-bJ
-bJ
-bJ
-bJ
-bJ
-bJ
+YF
+YF
+YF
+YF
+YF
+YF
 bN
 bN
 bN
@@ -53618,27 +53626,27 @@ bK
 bK
 bK
 bK
-bJ
-bJ
-bJ
-bJ
-bJ
-bJ
+YF
+YF
+YF
+YF
+YF
+YF
 bK
 bK
 bK
 bK
 bK
-bJ
-bJ
-bJ
+YF
+YF
+YF
 gd
-bJ
+YF
 gn
-bJ
-bJ
-bJ
-bJ
+YF
+YF
+YF
+YF
 bO
 bO
 bO
@@ -53646,10 +53654,10 @@ bO
 bO
 bO
 bO
-bJ
-bJ
-bJ
-bJ
+YF
+YF
+YF
+YF
 bK
 bK
 bK
@@ -53845,57 +53853,57 @@ aa
 bK
 bK
 bK
-bJ
+YF
 bW
-bJ
+YF
 cf
 cf
 bW
-bJ
-bJ
+YF
+YF
 bK
 bK
 bK
 dc
-bJ
-bJ
+YF
+YF
 dc
-bJ
-bJ
-bJ
-bJ
-bJ
-bJ
-bJ
-bJ
-bJ
-bJ
+YF
+YF
+YF
+YF
+YF
+YF
+YF
+YF
+YF
+YF
 bK
 bK
 bK
 bK
 bK
-bJ
+YF
 bK
 bK
 bK
 bK
-bJ
+YF
 bK
 bK
 bK
 bK
 bK
-bJ
-bJ
+YF
+YF
 fv
-bJ
+YF
 fl
 gn
 gn
-bJ
-bJ
-bJ
+YF
+YF
+YF
 bK
 bK
 bK
@@ -53906,10 +53914,10 @@ bO
 bO
 bO
 bO
-bJ
-bJ
-bJ
-bJ
+YF
+YF
+YF
+YF
 bK
 bK
 bK
@@ -54102,57 +54110,57 @@ aa
 bK
 bK
 bK
-bJ
-bJ
-bJ
+YF
+YF
+YF
 cf
 cf
 cf
 cf
 cf
-bJ
+YF
 bK
 bK
-bJ
-bJ
-bJ
-bJ
-bJ
+YF
+YF
+YF
+YF
+YF
 bO
 bO
 bO
 bO
-bJ
-bJ
-bJ
+YF
+YF
+YF
 cq
-bJ
-bJ
-bJ
+YF
+YF
+YF
 bK
 bK
-bJ
-bJ
-bK
-bK
-bK
-bK
-bJ
+YF
+YF
 bK
 bK
 bK
 bK
-bJ
-bJ
-bJ
-bJ
+YF
+bK
+bK
+bK
+bK
+YF
+YF
+YF
+YF
 cQ
 gk
-bJ
+YF
 gs
-bJ
-bJ
-bJ
+YF
+YF
+YF
 bK
 bK
 bK
@@ -54166,8 +54174,8 @@ bO
 bO
 bO
 bO
-bJ
-bJ
+YF
+YF
 bK
 bK
 bK
@@ -54370,8 +54378,8 @@ cf
 cf
 bK
 bK
-bJ
-bJ
+YF
+YF
 bO
 bO
 bO
@@ -54383,33 +54391,33 @@ bO
 bO
 bO
 bO
-bJ
-bJ
-bJ
-bJ
+YF
+YF
+YF
+YF
 cd
-bJ
-bJ
-bJ
+YF
+YF
+YF
 bK
 bK
 bK
-bJ
+YF
 bK
 bK
 bK
 bK
-bJ
-bJ
-bJ
-bJ
-bJ
-bJ
-bJ
-bJ
-bJ
-bJ
-bJ
+YF
+YF
+YF
+YF
+YF
+YF
+YF
+YF
+YF
+YF
+YF
 bK
 bK
 bK
@@ -54424,9 +54432,9 @@ bO
 bO
 bO
 bO
-bJ
-bJ
-bJ
+YF
+YF
+YF
 bK
 bK
 bK
@@ -54619,16 +54627,16 @@ bK
 bK
 bK
 cc
-bJ
-bJ
-bJ
-bJ
+YF
+YF
+YF
+YF
 cf
 cf
 bK
 bK
-bJ
-bJ
+YF
+YF
 bO
 bO
 bO
@@ -54643,30 +54651,30 @@ bO
 bO
 bO
 bO
-bJ
-bJ
-bJ
-bJ
+YF
+YF
+YF
+YF
 cd
-bJ
-bJ
-bJ
-bJ
+YF
+YF
+YF
+YF
 bK
 bK
 bK
 bK
 bK
-bJ
-bJ
-bJ
-bJ
-bJ
-bJ
-bJ
-bJ
-bJ
-bJ
+YF
+YF
+YF
+YF
+YF
+YF
+YF
+YF
+YF
+YF
 bK
 bK
 bK
@@ -54683,9 +54691,9 @@ bO
 bO
 bO
 bO
-bJ
-bJ
-bJ
+YF
+YF
+YF
 bK
 bK
 bK
@@ -54884,7 +54892,7 @@ cH
 cH
 bQ
 bK
-bJ
+YF
 cq
 bO
 bO
@@ -54904,26 +54912,26 @@ bO
 bO
 bK
 bK
-bJ
-bJ
-bJ
-bJ
+YF
+YF
+YF
+YF
 bK
 bK
 bK
 bK
 bK
 bK
-bJ
-bJ
-bJ
-bJ
-bJ
-bJ
-bJ
-bJ
-bJ
-bJ
+YF
+YF
+YF
+YF
+YF
+YF
+YF
+YF
+YF
+YF
 bK
 bK
 bK
@@ -54942,7 +54950,7 @@ bO
 bO
 bO
 bO
-bJ
+YF
 bK
 bK
 bK
@@ -55140,8 +55148,8 @@ cl
 bT
 bT
 cl
-bJ
-bJ
+YF
+YF
 bO
 bO
 bO
@@ -55152,19 +55160,19 @@ bO
 bO
 bO
 bO
-bJ
-bJ
-bJ
-bJ
+YF
+YF
+YF
+YF
 bO
 bO
 bO
 bO
 bK
 bK
-bJ
-bJ
-bJ
+YF
+YF
+YF
 bK
 bK
 bK
@@ -55173,12 +55181,12 @@ bK
 bK
 bK
 bK
-bJ
-bJ
-bJ
-bJ
-bJ
-bJ
+YF
+YF
+YF
+YF
+YF
+YF
 bK
 bK
 bK
@@ -55199,9 +55207,9 @@ bK
 bO
 bO
 bO
-bJ
-bJ
-bJ
+YF
+YF
+YF
 bK
 bK
 bK
@@ -55397,24 +55405,24 @@ bQ
 cH
 cH
 bR
-bJ
+YF
 bO
 bO
 bO
 bO
 bO
 bO
-bJ
-bJ
+YF
+YF
 bK
-bJ
-bJ
-bJ
-bJ
-bJ
-bJ
-bJ
-bJ
+YF
+YF
+YF
+YF
+YF
+YF
+YF
+YF
 bO
 bO
 bK
@@ -55458,7 +55466,7 @@ bO
 bO
 bO
 bO
-bJ
+YF
 bK
 bK
 bK
@@ -55646,23 +55654,23 @@ bK
 bK
 bK
 bK
-bJ
-bJ
-bJ
-bJ
-bJ
-bJ
-bJ
-bJ
-bJ
+YF
+YF
+YF
+YF
+YF
+YF
+YF
+YF
+YF
 bO
 bO
 bO
-bJ
-bJ
-bJ
-bJ
-bJ
+YF
+YF
+YF
+YF
+YF
 bK
 bK
 bK
@@ -55670,8 +55678,8 @@ bK
 bK
 bK
 cd
-bJ
-bJ
+YF
+YF
 bO
 bO
 bK
@@ -55715,7 +55723,7 @@ bO
 bO
 bO
 bO
-bJ
+YF
 bK
 bK
 bK
@@ -55903,11 +55911,11 @@ bK
 bK
 bK
 bK
-bJ
-bJ
-bJ
-bJ
-bJ
+YF
+YF
+YF
+YF
+YF
 bO
 bO
 bO
@@ -55915,20 +55923,20 @@ bO
 bO
 bO
 bO
-bJ
-bJ
-bJ
-bJ
+YF
+YF
+YF
+YF
 cq
-bJ
-bJ
-bJ
-bJ
-bJ
-bJ
-bJ
-bJ
-bJ
+YF
+YF
+YF
+YF
+YF
+YF
+YF
+YF
+YF
 bO
 bO
 bK
@@ -55972,7 +55980,7 @@ bO
 bO
 bO
 bO
-bJ
+YF
 bK
 bK
 bK
@@ -56160,32 +56168,32 @@ bK
 bK
 bK
 bK
-bJ
-bJ
-bJ
-bJ
-bJ
+YF
+YF
+YF
+YF
+YF
 bT
 bT
 bT
 bT
 bT
 bT
-bJ
-bJ
-bJ
-bJ
-bJ
-bJ
-bJ
-bJ
-bJ
-bJ
-bJ
+YF
+YF
+YF
+YF
+YF
+YF
+YF
+YF
+YF
+YF
+YF
 cU
-bJ
-bJ
-bJ
+YF
+YF
+YF
 bO
 bO
 bK
@@ -56229,7 +56237,7 @@ bK
 bO
 bO
 bO
-bJ
+YF
 bK
 bK
 bK
@@ -56417,32 +56425,32 @@ bK
 bK
 bK
 bK
-bJ
-bJ
-bJ
-bJ
+YF
+YF
+YF
+YF
 bO
 bO
 bO
 bO
 bO
 bO
-bJ
-bJ
-bJ
+YF
+YF
+YF
 bK
 bK
 bK
-bJ
-bJ
-bJ
+YF
+YF
+YF
 bK
 bK
 bK
 bK
 bK
-bJ
-bJ
+YF
+YF
 bO
 bO
 bK
@@ -56486,7 +56494,7 @@ bK
 bK
 bO
 bO
-bJ
+YF
 bK
 bK
 bK
@@ -56675,7 +56683,7 @@ bK
 bK
 bK
 bK
-bJ
+YF
 bO
 bO
 bO
@@ -56683,9 +56691,9 @@ bO
 bO
 bO
 bO
-bJ
-bJ
-bJ
+YF
+YF
+YF
 bN
 bK
 bK
@@ -56695,11 +56703,11 @@ bK
 bK
 bK
 bK
-bJ
-bJ
-bJ
-bJ
-bJ
+YF
+YF
+YF
+YF
+YF
 bO
 bO
 bO
@@ -56743,7 +56751,7 @@ bK
 bK
 bO
 bO
-bJ
+YF
 bK
 bK
 bK
@@ -56931,18 +56939,18 @@ bK
 bK
 bK
 bK
-bJ
-bJ
+YF
+YF
 bO
 bO
 bO
 bO
 bO
 bO
-bJ
-bJ
-bJ
-bJ
+YF
+YF
+YF
+YF
 bN
 bK
 bK
@@ -56952,7 +56960,7 @@ bK
 bK
 bK
 bK
-bJ
+YF
 cq
 bO
 bO
@@ -57000,7 +57008,7 @@ bK
 bK
 bO
 bO
-bJ
+YF
 bK
 bK
 bK
@@ -57189,15 +57197,15 @@ bK
 bK
 bK
 cd
-bJ
+YF
 bO
 bO
 bO
 bO
 bO
-bJ
-bJ
-bJ
+YF
+YF
+YF
 bR
 dl
 bR
@@ -57209,8 +57217,8 @@ bK
 bK
 bK
 bK
-bJ
-bJ
+YF
+YF
 bO
 bO
 bT
@@ -57256,8 +57264,8 @@ bK
 bK
 bK
 bO
-bJ
-bJ
+YF
+YF
 bK
 bK
 bK
@@ -57444,17 +57452,17 @@ bK
 bK
 bN
 bN
-bJ
-bJ
-bJ
+YF
+YF
+YF
 bO
 bO
 bO
 bO
 bO
-bJ
-bJ
-bJ
+YF
+YF
+YF
 dh
 dm
 dh
@@ -57466,15 +57474,15 @@ bK
 bK
 bK
 bK
-bJ
-bJ
+YF
+YF
 bO
 bO
 bT
 bO
-bJ
-bJ
-bJ
+YF
+YF
+YF
 bK
 bK
 bK
@@ -57513,8 +57521,8 @@ bK
 bO
 bO
 bO
-bJ
-bJ
+YF
+YF
 bK
 bK
 bK
@@ -57701,7 +57709,7 @@ bK
 bK
 bN
 bN
-bJ
+YF
 bO
 bO
 bO
@@ -57709,8 +57717,8 @@ bO
 bO
 bO
 bO
-bJ
-bJ
+YF
+YF
 bQ
 bR
 dl
@@ -57721,15 +57729,15 @@ bR
 bK
 bK
 bK
-bJ
-bJ
-bJ
-bJ
+YF
+YF
+YF
+YF
 bO
 bO
 bT
 bO
-bJ
+YF
 cm
 cm
 cm
@@ -57770,8 +57778,8 @@ bK
 bO
 bO
 bO
-bJ
-bJ
+YF
+YF
 bK
 bK
 bK
@@ -57956,17 +57964,17 @@ aa
 aa
 bK
 bK
-bJ
-bJ
-bJ
+YF
+YF
+YF
 bO
 bO
 bO
 bO
 bO
 bO
-bJ
-bJ
+YF
+YF
 cc
 bR
 di
@@ -57978,7 +57986,7 @@ bQ
 bK
 bK
 bK
-bJ
+YF
 cd
 bO
 bO
@@ -57986,7 +57994,7 @@ bO
 bO
 bT
 bO
-bJ
+YF
 cm
 cm
 cm
@@ -58027,8 +58035,8 @@ bO
 bO
 bO
 bO
-bJ
-bJ
+YF
+YF
 bK
 bK
 bK
@@ -58212,8 +58220,8 @@ aa
 aa
 aa
 bK
-bJ
-bJ
+YF
+YF
 bO
 bO
 bO
@@ -58222,8 +58230,8 @@ bO
 bO
 bO
 bO
-bJ
-bJ
+YF
+YF
 cc
 bQ
 dj
@@ -58235,15 +58243,15 @@ bR
 bK
 bK
 cm
-bJ
-bJ
+YF
+YF
 bO
 bO
 bO
-bJ
-bJ
-bJ
-bJ
+YF
+YF
+YF
+YF
 cm
 cm
 cm
@@ -58281,11 +58289,11 @@ bO
 bO
 bO
 bO
-bJ
-bJ
-bJ
-bJ
-bJ
+YF
+YF
+YF
+YF
+YF
 bK
 bK
 bK
@@ -58469,7 +58477,7 @@ aa
 aa
 aa
 bK
-bJ
+YF
 bO
 bO
 bO
@@ -58480,7 +58488,7 @@ bO
 bO
 bO
 cd
-bJ
+YF
 cm
 bQ
 dk
@@ -58492,13 +58500,13 @@ bR
 bK
 bK
 cm
-bJ
-bJ
+YF
+YF
 bO
 bO
 bO
-bJ
-bJ
+YF
+YF
 bK
 cm
 cm
@@ -58538,10 +58546,10 @@ bO
 bO
 bO
 bO
-bJ
-bJ
-bJ
-bJ
+YF
+YF
+YF
+YF
 bK
 bK
 bK
@@ -58726,7 +58734,7 @@ aa
 aa
 aa
 bK
-bJ
+YF
 bO
 bO
 bO
@@ -58734,10 +58742,10 @@ bO
 bO
 bO
 bO
-bJ
-bJ
-bJ
-bJ
+YF
+YF
+YF
+YF
 cm
 bR
 bR
@@ -58749,13 +58757,13 @@ bQ
 cm
 cm
 cm
-bJ
-bJ
+YF
+YF
 bO
 bO
 bO
-bJ
-bJ
+YF
+YF
 bK
 cm
 cm
@@ -58763,10 +58771,10 @@ cm
 cm
 cm
 bK
-bJ
-bJ
-bJ
-bJ
+YF
+YF
+YF
+YF
 cm
 bK
 bK
@@ -58795,8 +58803,8 @@ bO
 bO
 bO
 bO
-bJ
-bJ
+YF
+YF
 bK
 bK
 bK
@@ -58983,7 +58991,7 @@ aa
 aa
 aa
 bK
-bJ
+YF
 bO
 bO
 bO
@@ -58991,7 +58999,7 @@ bO
 bO
 bO
 bO
-bJ
+YF
 cm
 cm
 bK
@@ -59006,12 +59014,12 @@ cm
 cm
 cm
 bK
-bJ
-bJ
+YF
+YF
 bO
 bO
 bO
-bJ
+YF
 bK
 bK
 cm
@@ -59020,10 +59028,10 @@ cm
 cm
 cm
 bK
-bJ
-bJ
-bJ
-bJ
+YF
+YF
+YF
+YF
 cm
 bK
 bK
@@ -59052,7 +59060,7 @@ bO
 bO
 bO
 bO
-bJ
+YF
 bK
 bK
 bK
@@ -59240,15 +59248,15 @@ aa
 aa
 aa
 bK
-bJ
+YF
 bO
 bO
 bO
 bO
 bO
-bJ
-bJ
-bJ
+YF
+YF
+YF
 cm
 cm
 bK
@@ -59264,11 +59272,11 @@ cm
 cm
 bK
 cd
-bJ
+YF
 bO
 bO
 bO
-bJ
+YF
 cm
 cm
 cm
@@ -59277,10 +59285,10 @@ cm
 bK
 bK
 bK
-bJ
-bJ
+YF
+YF
 fv
-bJ
+YF
 bK
 bK
 bK
@@ -59309,7 +59317,7 @@ bO
 bO
 bO
 bO
-bJ
+YF
 bK
 bK
 bK
@@ -59497,13 +59505,13 @@ aa
 aa
 aa
 bK
-bJ
+YF
 bO
 bO
 bO
 bO
 bO
-bJ
+YF
 bK
 bK
 bK
@@ -59517,15 +59525,15 @@ bK
 bK
 cm
 cm
-bJ
-bJ
-bJ
-bJ
-bJ
+YF
+YF
+YF
+YF
+YF
 bO
 bO
 bO
-bJ
+YF
 cm
 cm
 cm
@@ -59533,14 +59541,14 @@ cm
 cm
 bK
 bK
-bJ
-bJ
-bJ
-bJ
-bJ
-bJ
-bJ
-bJ
+YF
+YF
+YF
+YF
+YF
+YF
+YF
+YF
 bK
 bK
 bK
@@ -59563,10 +59571,10 @@ bO
 bO
 bO
 bO
-bJ
-bJ
-bJ
-bJ
+YF
+YF
+YF
+YF
 bK
 bK
 bK
@@ -59754,13 +59762,13 @@ aa
 aa
 aa
 bK
-bJ
+YF
 bO
 bO
 bO
 bO
 bO
-bJ
+YF
 cm
 cm
 bK
@@ -59774,15 +59782,15 @@ bK
 bK
 bK
 bK
-bJ
+YF
 bO
 bO
 bO
 bO
 bO
-bJ
-bJ
-bJ
+YF
+YF
+YF
 cm
 cm
 cm
@@ -59790,13 +59798,13 @@ cm
 bK
 bK
 bK
-bJ
-bJ
+YF
+YF
 cq
-bJ
-bJ
-bJ
-bJ
+YF
+YF
+YF
+YF
 fR
 bK
 bK
@@ -59820,10 +59828,10 @@ bO
 bO
 bO
 bO
-bJ
-bJ
-bJ
-bJ
+YF
+YF
+YF
+YF
 bK
 bK
 bK
@@ -60011,52 +60019,52 @@ aa
 aa
 aa
 bK
-bJ
+YF
 bO
 bO
 bO
 bO
-bJ
-bJ
+YF
+YF
 cm
 cm
 bR
-bJ
-bJ
+YF
+YF
 cK
 bK
 bK
 bN
-bJ
-bJ
-bJ
-bJ
-bJ
+YF
+YF
+YF
+YF
+YF
 bO
 bO
 bO
 bO
 bO
-bJ
-bJ
-bJ
+YF
+YF
+YF
 cm
 cm
 cm
 cm
 bK
 bK
-bJ
-bJ
+YF
+YF
 fj
 fd
 bK
 bK
-bJ
-bJ
+YF
+YF
 fR
-bJ
-bJ
+YF
+YF
 bK
 bO
 bO
@@ -60076,8 +60084,8 @@ bO
 bO
 bO
 bO
-bJ
-bJ
+YF
+YF
 bK
 bK
 bK
@@ -60268,24 +60276,24 @@ aa
 aa
 aa
 bK
-bJ
-bJ
+YF
+YF
 bO
-bJ
-bJ
-bJ
+YF
+YF
+YF
 bK
 bK
 bK
 bR
-bJ
-bJ
+YF
+YF
 bR
 bK
 bK
 bK
-bJ
-bJ
+YF
+YF
 bO
 bO
 bO
@@ -60294,8 +60302,8 @@ bO
 bO
 bO
 bO
-bJ
-bJ
+YF
+YF
 bK
 cm
 cm
@@ -60303,17 +60311,17 @@ cm
 bK
 bK
 bK
-bJ
+YF
 fd
-bJ
-bJ
+YF
+YF
 bK
 bK
-bJ
+YF
 fR
-bJ
-bJ
-bJ
+YF
+YF
+YF
 bK
 bO
 bO
@@ -60333,7 +60341,7 @@ bO
 bO
 bO
 bO
-bJ
+YF
 bK
 bK
 bK
@@ -60526,32 +60534,32 @@ aa
 aa
 bK
 bK
-bJ
+YF
 bO
-bJ
+YF
 bK
 bK
 bK
 bK
 bR
-bJ
-bJ
-bJ
-bJ
+YF
+YF
+YF
+YF
 bR
 bN
 bN
-bJ
-bJ
+YF
+YF
 bO
 bO
 bO
 bO
-bJ
-bJ
-bJ
-bJ
-bJ
+YF
+YF
+YF
+YF
+YF
 bK
 cm
 cm
@@ -60560,17 +60568,17 @@ bK
 bK
 bK
 bK
-bJ
-bJ
+YF
+YF
 bK
 bK
 bK
 bK
 bK
 fR
-bJ
-bJ
-bJ
+YF
+YF
+YF
 bK
 bO
 bO
@@ -60590,7 +60598,7 @@ bO
 bO
 bO
 bO
-bJ
+YF
 bK
 bK
 bK
@@ -60783,22 +60791,22 @@ aa
 aa
 bK
 bK
-bJ
+YF
 bO
-bJ
+YF
 bK
 bK
 bK
 bK
 bR
-bJ
+YF
 cQ
-bJ
-bJ
+YF
+YF
 bR
 bN
 bN
-bJ
+YF
 bO
 bO
 bO
@@ -60824,10 +60832,10 @@ bK
 bK
 bK
 bK
-bJ
-bJ
-bJ
-bJ
+YF
+YF
+YF
+YF
 bK
 bO
 bO
@@ -60847,7 +60855,7 @@ bO
 bO
 bO
 bO
-bJ
+YF
 bK
 bK
 bK
@@ -61040,22 +61048,22 @@ aa
 aa
 bK
 bK
-bJ
+YF
 bO
-bJ
-bJ
-bJ
+YF
+YF
+YF
 bK
 bK
 bK
 cK
-bJ
-bJ
+YF
+YF
 bR
 bN
 bK
 bK
-bJ
+YF
 bO
 bO
 bO
@@ -61081,12 +61089,12 @@ bK
 bK
 bK
 bK
-bJ
-bJ
-bJ
-bJ
-bJ
-bJ
+YF
+YF
+YF
+YF
+YF
+YF
 bO
 bO
 bO
@@ -61104,7 +61112,7 @@ bO
 bO
 bO
 bO
-bJ
+YF
 bK
 bK
 bK
@@ -61297,11 +61305,11 @@ aa
 aa
 bK
 bK
-bJ
+YF
 bO
 bO
 bO
-bJ
+YF
 cm
 cm
 bK
@@ -61312,8 +61320,8 @@ bN
 bK
 bK
 bK
-bJ
-bJ
+YF
+YF
 bO
 bO
 bO
@@ -61340,13 +61348,13 @@ bK
 bK
 bK
 bK
-bJ
-bJ
+YF
+YF
 cq
-bJ
-bJ
-bJ
-bJ
+YF
+YF
+YF
+YF
 bO
 bO
 bO
@@ -61361,9 +61369,9 @@ bO
 bO
 bO
 bO
-bJ
-bJ
-bJ
+YF
+YF
+YF
 bK
 bK
 bK
@@ -61554,11 +61562,11 @@ aa
 aa
 bK
 bK
-bJ
+YF
 bO
 bO
 bO
-bJ
+YF
 cm
 cm
 bK
@@ -61568,9 +61576,9 @@ bK
 bK
 bK
 bK
-bJ
-bJ
-bJ
+YF
+YF
+YF
 bO
 bO
 bO
@@ -61598,15 +61606,15 @@ bK
 bK
 bK
 fX
-bJ
-bJ
-bJ
-bJ
-bJ
-bJ
-bJ
-bJ
-bJ
+YF
+YF
+YF
+YF
+YF
+YF
+YF
+YF
+YF
 bO
 bO
 bO
@@ -61620,7 +61628,7 @@ bO
 bO
 bO
 bO
-bJ
+YF
 bK
 bK
 bK
@@ -61811,13 +61819,13 @@ aa
 aa
 bK
 bK
-bJ
+YF
 bO
 bO
 bO
-bJ
-bJ
-bJ
+YF
+YF
+YF
 bK
 bK
 bK
@@ -61825,8 +61833,8 @@ bK
 bK
 bK
 bK
-bJ
-bJ
+YF
+YF
 bO
 bO
 bO
@@ -61857,14 +61865,14 @@ bK
 bK
 bK
 cd
-bJ
-bJ
-bJ
-bJ
-bJ
-bJ
-bJ
-bJ
+YF
+YF
+YF
+YF
+YF
+YF
+YF
+YF
 cq
 bO
 bO
@@ -61877,7 +61885,7 @@ bO
 bO
 bO
 bO
-bJ
+YF
 bK
 bK
 bK
@@ -62068,21 +62076,21 @@ aa
 aa
 bK
 bK
-bJ
+YF
 bO
 bO
 bO
 bO
 bO
-bJ
-bJ
-bJ
-bJ
+YF
+YF
+YF
+YF
 bK
 bK
 bK
 bK
-bJ
+YF
 bO
 bO
 bO
@@ -62113,16 +62121,16 @@ bK
 bK
 bK
 bK
-bJ
-bJ
+YF
+YF
 bO
 bO
 bO
-bJ
+YF
 cq
-bJ
-bJ
-bJ
+YF
+YF
+YF
 bO
 bO
 bO
@@ -62134,7 +62142,7 @@ bO
 bO
 bO
 bO
-bJ
+YF
 bK
 bK
 bK
@@ -62325,21 +62333,21 @@ aa
 aa
 bK
 bK
-bJ
-bJ
-bJ
+YF
+YF
+YF
 bO
 bO
 bO
 bO
 bO
 bO
-bJ
+YF
 bK
 bK
 bK
 bK
-bJ
+YF
 bO
 bO
 bO
@@ -62377,8 +62385,8 @@ bO
 bO
 bO
 bO
-bJ
-bJ
+YF
+YF
 bO
 bO
 bO
@@ -62391,7 +62399,7 @@ bO
 bO
 bO
 bO
-bJ
+YF
 bK
 bK
 bK
@@ -62582,21 +62590,21 @@ aa
 aa
 bK
 bK
-bJ
-bJ
-bJ
-bJ
-bJ
+YF
+YF
+YF
+YF
+YF
 bO
 bO
 bO
 bO
 cq
-bJ
-bJ
-bJ
-bJ
-bJ
+YF
+YF
+YF
+YF
+YF
 bO
 bO
 bO
@@ -62648,7 +62656,7 @@ bO
 bO
 bO
 bO
-bJ
+YF
 bK
 bK
 bK
@@ -62840,11 +62848,11 @@ aa
 bK
 bK
 bP
-bJ
-bJ
-bJ
-bJ
-bJ
+YF
+YF
+YF
+YF
+YF
 bO
 bO
 bO
@@ -62905,7 +62913,7 @@ bO
 bO
 bO
 bO
-bJ
+YF
 bK
 bK
 bK
@@ -63097,13 +63105,13 @@ aa
 bK
 bK
 bQ
-bJ
-bJ
+YF
+YF
 bP
-bJ
-bJ
-bJ
-bJ
+YF
+YF
+YF
+YF
 bO
 bO
 bO
@@ -63162,7 +63170,7 @@ bO
 bO
 bO
 bO
-bJ
+YF
 bK
 bK
 bK
@@ -63354,13 +63362,13 @@ aa
 bK
 bK
 bQ
-bJ
-bJ
+YF
+YF
 bQ
-bJ
-bJ
-bJ
-bJ
+YF
+YF
+YF
+YF
 bO
 bO
 bO
@@ -63419,7 +63427,7 @@ bO
 bO
 bO
 bO
-bJ
+YF
 bK
 bK
 bK
@@ -63611,14 +63619,14 @@ aa
 bK
 bK
 bQ
-bJ
+YF
 bT
 bQ
-bJ
-bJ
-bJ
-bJ
-bJ
+YF
+YF
+YF
+YF
+YF
 bK
 bK
 bK
@@ -63656,9 +63664,9 @@ bK
 bK
 bK
 bK
-bJ
-bJ
-bJ
+YF
+YF
+YF
 bO
 bO
 bO
@@ -63676,7 +63684,7 @@ bO
 bO
 bO
 bO
-bJ
+YF
 bK
 bK
 bK
@@ -63871,11 +63879,11 @@ bR
 bS
 bS
 bQ
-bJ
-bJ
+YF
+YF
 cq
-bJ
-bJ
+YF
+YF
 bK
 bK
 bK
@@ -63910,12 +63918,12 @@ bK
 bK
 bK
 bK
-bJ
-bJ
-bJ
-bJ
-bJ
-bJ
+YF
+YF
+YF
+YF
+YF
+YF
 bO
 bO
 bO
@@ -63933,7 +63941,7 @@ bO
 bO
 bO
 bO
-bJ
+YF
 bK
 bK
 bK
@@ -64128,12 +64136,12 @@ bR
 bT
 bY
 bR
-bJ
-bJ
-bJ
-bJ
-bJ
-bJ
+YF
+YF
+YF
+YF
+YF
+YF
 bK
 bK
 bK
@@ -64167,12 +64175,12 @@ bK
 bK
 bK
 bK
-bJ
-bJ
-bJ
-bJ
+YF
+YF
+YF
+YF
 cq
-bJ
+YF
 bO
 bO
 bO
@@ -64190,7 +64198,7 @@ bO
 bO
 bO
 bO
-bJ
+YF
 bK
 bK
 bK
@@ -64385,13 +64393,13 @@ bQ
 bT
 bT
 bR
-bJ
-bJ
-bJ
-bJ
-bJ
-bJ
-bJ
+YF
+YF
+YF
+YF
+YF
+YF
+YF
 bK
 bN
 bN
@@ -64408,29 +64416,29 @@ bK
 bK
 bK
 bK
-bJ
-bJ
+YF
+YF
 cq
-bJ
-bJ
-bJ
-bJ
-bJ
+YF
+YF
+YF
+YF
+YF
 bK
 bK
 bK
-bJ
-bJ
-bJ
-bJ
-bJ
-bJ
-bJ
-bJ
-bJ
-bJ
-bJ
-bJ
+YF
+YF
+YF
+YF
+YF
+YF
+YF
+YF
+YF
+YF
+YF
+YF
 bO
 bO
 bO
@@ -64445,9 +64453,9 @@ bO
 bO
 bO
 bO
-bJ
-bJ
-bJ
+YF
+YF
+YF
 bK
 bK
 bK
@@ -64644,14 +64652,14 @@ bT
 bQ
 bK
 bK
-bJ
-bJ
+YF
+YF
 cL
-bJ
-bJ
-bJ
-bJ
-bJ
+YF
+YF
+YF
+YF
+YF
 bK
 bN
 bN
@@ -64665,31 +64673,31 @@ bK
 bK
 bK
 bK
-bJ
-bJ
-bJ
+YF
+YF
+YF
 cU
-bJ
-bJ
-bJ
-bJ
+YF
+YF
+YF
+YF
 bK
 bK
 bK
 fw
-bJ
-bJ
+YF
+YF
 cq
-bJ
+YF
 bK
 bK
 bK
 bK
 bK
 bK
-bJ
-bJ
-bJ
+YF
+YF
+YF
 bO
 bO
 bO
@@ -64702,7 +64710,7 @@ bO
 bO
 bO
 bO
-bJ
+YF
 bK
 bK
 bK
@@ -64902,42 +64910,42 @@ bQ
 bK
 bK
 bK
-bJ
-bJ
-bJ
+YF
+YF
+YF
 cU
-bJ
-bJ
-bJ
-bJ
-bJ
-bJ
-bJ
-bJ
+YF
+YF
+YF
+YF
+YF
+YF
+YF
+YF
 bK
 bK
 bK
 bK
-bJ
-bJ
-bJ
-bJ
-bJ
-bJ
-bJ
-bJ
+YF
+YF
+YF
+YF
+YF
+YF
+YF
+YF
 bK
-bJ
-bJ
-bJ
+YF
+YF
+YF
 fe
 fk
 fn
 fd
-bJ
-bJ
-bJ
-bJ
+YF
+YF
+YF
+YF
 bK
 bK
 bK
@@ -64945,21 +64953,21 @@ bK
 bK
 bK
 bK
-bJ
-bJ
-bJ
-bJ
-bJ
-bJ
-bJ
+YF
+YF
+YF
+YF
+YF
+YF
+YF
 cq
-bJ
+YF
 bO
 bO
 bO
 bO
 bO
-bJ
+YF
 bK
 bK
 bK
@@ -65160,39 +65168,39 @@ bK
 bK
 bK
 bK
-bJ
-bJ
-bJ
-bJ
-bJ
-bJ
-bJ
-bJ
-bJ
-bJ
-bJ
-bJ
-bJ
-bJ
-bJ
-bJ
-bJ
-bJ
-bJ
+YF
+YF
+YF
+YF
+YF
+YF
+YF
+YF
+YF
+YF
+YF
+YF
+YF
+YF
+YF
+YF
+YF
+YF
+YF
 bK
 bK
 bK
 bK
 bK
-bJ
-bJ
+YF
+YF
 fc
-bJ
+YF
 fl
 fo
-bJ
+YF
 fF
-bJ
+YF
 bK
 bK
 bK
@@ -65210,13 +65218,13 @@ bK
 bK
 bK
 bK
-bJ
-bJ
-bJ
-bJ
-bJ
-bJ
-bJ
+YF
+YF
+YF
+YF
+YF
+YF
+YF
 bK
 bK
 bK
@@ -65426,12 +65434,12 @@ bK
 bK
 bK
 bK
-bJ
-bJ
-bJ
+YF
+YF
+YF
 cq
 cU
-bJ
+YF
 bK
 bK
 bK
@@ -65441,15 +65449,15 @@ bK
 bK
 bK
 bK
-bJ
-bJ
-bJ
+YF
+YF
+YF
 fd
-bJ
-bJ
-bJ
-bJ
-bJ
+YF
+YF
+YF
+YF
+YF
 bK
 bK
 bK
@@ -65683,12 +65691,12 @@ bK
 bK
 bK
 bK
-bJ
-bJ
-bJ
-bJ
-bJ
-bJ
+YF
+YF
+YF
+YF
+YF
+YF
 bK
 bK
 bK

--- a/html/changelogs/FlufflyCthulu-Caves.yml
+++ b/html/changelogs/FlufflyCthulu-Caves.yml
@@ -1,0 +1,4 @@
+author: "FlufflyCthulu"
+delete-after: True
+changes: 
+  - bugfix: "The caves away mission now has air."

--- a/russstation/code/game/turfs/simulated/minerals.dm
+++ b/russstation/code/game/turfs/simulated/minerals.dm
@@ -1,0 +1,11 @@
+/turf/closed/mineral/random/low_chance/volcanic
+	environment_type = "basalt"
+	turf_type = /turf/open/floor/plating/asteroid/basalt/lava_land_surface
+	baseturfs = /turf/open/floor/plating/asteroid/basalt/lava_land_surface
+	initial_gas_mix = LAVALAND_DEFAULT_ATMOS
+	defer_change = 1
+	mineralSpawnChanceList = list(
+		/turf/closed/mineral/uranium/volcanic = 2, /turf/closed/mineral/diamond/volcanic = 1, /turf/closed/mineral/gold/volcanic = 4, /turf/closed/mineral/titanium/volcanic = 4,
+		/turf/closed/mineral/silver/volcanic = 6, /turf/closed/mineral/plasma/volcanic = 15, /turf/closed/mineral/iron/volcanic = 40,
+		/turf/closed/mineral/gibtonite/volcanic = 2, /turf/closed/mineral/bscrystal/volcanic = 1)
+


### PR DESCRIPTION
## About The Pull Request

The caves away mission atmos was setup wrong and the entire lava filled cavern was just over absolute zero.

## Why It's Good For The Game

You no longer need a space suit in an underground cavern.

## Changelog
:cl:
bugfix: The caves away mission now has air.
/:cl:
