### PR TITLE
Remove bad varedits in dwarven ruin

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_dwarf.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_dwarf.dmm
@@ -1,69 +1,881 @@
-"a" = (/turf/template_noop,/area/template_noop)
-"b" = (/obj/structure/glowshroom/single,/turf/closed/mineral/volcanic/lava_land_surface,/area/lavaland/surface/outdoors/explored)
-"c" = (/turf/open/indestructible/necropolis,/area/lavaland/surface/outdoors/explored)
-"d" = (/turf/open/floor/plating/asteroid/basalt/lava_land_surface,/area/lavaland/surface/outdoors/explored)
-"e" = (/obj/structure/glowshroom/single,/turf/open/floor/plating/asteroid/basalt/lava_land_surface,/area/lavaland/surface/outdoors/explored)
-"f" = (/turf/closed/wall/mineral/wood,/area/lavaland/surface/dorf)
-"g" = (/obj/structure/mineral_door/wood,/turf/open/floor/plating/asteroid/basalt/lava_land_surface,/area/lavaland/surface/dorf)
-"h" = (/obj/structure/mineral_door/wood,/turf/open/indestructible/necropolis,/area/lavaland/surface/dorf)
-"i" = (/obj/structure/glowshroom/single,/turf/closed/wall/mineral/wood,/area/lavaland/surface/dorf)
-"j" = (/turf/open/floor/plating/asteroid/basalt/lava_land_surface,/area/lavaland/surface/dorf)
-"k" = (/obj/effect/mob_spawn/human/dwarf_dorm,/obj/structure/glowshroom/single,/turf/open/floor/plating/asteroid/basalt/lava_land_surface,/area/lavaland/surface/dorf)
-"l" = (/obj/structure/glowshroom/single,/turf/open/indestructible/necropolis,/area/lavaland/surface/dorf)
-"m" = (/turf/open/indestructible/necropolis,/area/lavaland/surface/dorf)
-"n" = (/obj/structure/glowshroom/single,/turf/open/floor/plating/asteroid/basalt/lava_land_surface,/area/lavaland/surface/dorf)
-"o" = (/obj/structure/table/wood,/obj/item/flashlight/lantern{step_x = 0; step_y = 0},/obj/item/flashlight/lantern{step_x = 0; step_y = 0},/obj/structure/glowshroom/single,/turf/open/indestructible/necropolis,/area/lavaland/surface/dorf)
-"p" = (/turf/open/floor/plating/asteroid,/area/lavaland/surface/dorf)
-"q" = (/obj/structure/mineral_door/wood,/obj/structure/glowshroom/single,/turf/open/floor/plating/asteroid/basalt/lava_land_surface,/area/lavaland/surface/dorf)
-"r" = (/obj/machinery/smelter,/turf/open/floor/plating/asteroid/basalt/lava_land_surface,/area/lavaland/surface/dorf)
-"s" = (/obj/machinery/anvil,/turf/open/floor/plating/asteroid/basalt/lava_land_surface,/area/lavaland/surface/dorf)
-"t" = (/obj/structure/table/wood,/obj/item/melee/smith_hammer{step_x = -2; step_y = 2},/obj/item/melee/smith_hammer{step_x = -2; step_y = 2},/turf/open/indestructible/necropolis,/area/lavaland/surface/dorf)
-"u" = (/obj/structure/table/wood,/obj/item/pickaxe,/obj/item/pickaxe,/turf/open/indestructible/necropolis,/area/lavaland/surface/dorf)
-"v" = (/obj/structure/glowshroom/single,/turf/open/floor/plating/asteroid,/area/lavaland/surface/dorf)
-"w" = (/obj/structure/table/wood,/obj/item/shovel,/obj/item/shovel,/turf/open/floor/plating/asteroid/basalt/lava_land_surface,/area/lavaland/surface/dorf)
-"x" = (/obj/structure/glowshroom/single,/turf/open/indestructible/necropolis,/area/lavaland/surface/outdoors/explored)
-"y" = (/obj/item/hatchet,/obj/item/hatchet,/turf/open/floor/plating/asteroid,/area/lavaland/surface/dorf)
-"z" = (/obj/structure/sink/puddle,/turf/open/floor/plating/asteroid,/area/lavaland/surface/dorf)
-"A" = (/obj/item/cultivator,/obj/item/cultivator,/turf/open/floor/plating/asteroid,/area/lavaland/surface/dorf)
-"B" = (/obj/structure/chair/wood{step_y = 0},/turf/open/floor/plating/asteroid/basalt/lava_land_surface,/area/lavaland/surface/dorf)
-"C" = (/obj/structure/table/wood,/obj/item/grown/log/tree,/obj/item/grown/log/tree,/obj/item/grown/log/tree,/obj/item/grown/log/tree,/obj/item/grown/log/tree,/turf/open/floor/plating/asteroid/basalt/lava_land_surface,/area/lavaland/surface/dorf)
-"D" = (/obj/effect/mob_spawn/human/dwarf_dorm,/turf/open/floor/plating/asteroid/basalt/lava_land_surface,/area/lavaland/surface/dorf)
-"E" = (/obj/item/reagent_containers/glass/bucket,/obj/item/reagent_containers/glass/bucket,/turf/open/floor/plating/asteroid,/area/lavaland/surface/dorf)
-"F" = (/obj/structure/table/wood,/obj/item/seeds/glowshroom,/obj/item/seeds/glowshroom,/obj/item/seeds/glowshroom,/obj/item/seeds/glowshroom,/obj/item/seeds/glowshroom,/obj/item/seeds/tower,/obj/item/seeds/tower,/obj/item/seeds/tower,/obj/item/seeds/tower,/obj/item/seeds/tower,/obj/structure/glowshroom/single,/turf/open/floor/plating/asteroid,/area/lavaland/surface/dorf)
-"G" = (/obj/structure/table/wood,/obj/item/reagent_containers/food/drinks/wooden_mug{step_x = 0; step_y = 0},/obj/item/reagent_containers/food/drinks/wooden_mug{step_x = 0; step_y = 0},/obj/item/reagent_containers/food/drinks/wooden_mug{step_x = 0; step_y = 0},/obj/item/reagent_containers/food/drinks/wooden_mug{step_x = 0; step_y = 0},/obj/item/reagent_containers/food/drinks/wooden_mug{step_x = 0; step_y = 0},/obj/item/reagent_containers/food/drinks/wooden_mug{step_x = 0; step_y = 0},/obj/item/reagent_containers/food/drinks/wooden_mug{step_x = 0; step_y = 0},/turf/open/floor/plating/asteroid/basalt/lava_land_surface,/area/lavaland/surface/dorf)
-"H" = (/obj/structure/fermenting_barrel,/turf/open/indestructible/necropolis,/area/lavaland/surface/dorf)
-"I" = (/obj/structure/table/wood,/obj/item/reagent_containers/food/snacks/grown/mushroom/plumphelmet,/obj/item/reagent_containers/food/snacks/grown/mushroom/plumphelmet,/obj/item/reagent_containers/food/snacks/grown/mushroom/plumphelmet{step_x = 9; step_y = 4},/obj/item/reagent_containers/food/snacks/grown/mushroom/plumphelmet{step_x = 9; step_y = 18},/obj/item/reagent_containers/food/snacks/grown/mushroom/plumphelmet{step_x = 7; step_y = 13},/obj/item/reagent_containers/food/snacks/grown/mushroom/plumphelmet{step_x = 11; step_y = 5},/obj/item/reagent_containers/food/snacks/grown/mushroom/plumphelmet{step_x = 15; step_y = 7},/obj/item/reagent_containers/food/snacks/grown/mushroom/plumphelmet{step_x = 5; step_y = 3},/obj/item/reagent_containers/food/snacks/grown/mushroom/plumphelmet{step_x = 3; step_y = 10},/turf/open/floor/plating/asteroid/basalt/lava_land_surface,/area/lavaland/surface/dorf)
-"J" = (/obj/structure/table/wood,/obj/item/crucible_tongs,/obj/item/reagent_containers/glass/bucket/iron_crucible_bucket,/turf/open/floor/plating/asteroid/basalt/lava_land_surface,/area/lavaland/surface/dorf)
-"K" = (/obj/structure/glowshroom/single,/mob/living/simple_animal/cow/lavaland,/turf/open/floor/plating/asteroid/basalt/lava_land_surface,/area/lavaland/surface/dorf)
-"L" = (/turf/closed/mineral/volcanic/lava_land_surface,/area/lavaland/surface/outdoors/explored)
-"M" = (/mob/living/simple_animal/cow/lavaland,/turf/open/floor/plating/asteroid/basalt/lava_land_surface,/area/lavaland/surface/dorf)
-"N" = (/obj/item/storage/bag/plants/portaseeder,/turf/open/floor/plating/asteroid,/area/lavaland/surface/dorf)
-"Q" = (/turf/closed/mineral/volcanic/lava_land_surface,/area/template_noop)
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"a" = (
+/turf/template_noop,
+/area/template_noop)
+"b" = (
+/obj/structure/glowshroom/single,
+/turf/closed/mineral/volcanic/lava_land_surface,
+/area/lavaland/surface/outdoors/explored)
+"c" = (
+/turf/open/indestructible/necropolis,
+/area/lavaland/surface/outdoors/explored)
+"d" = (
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors/explored)
+"e" = (
+/obj/structure/glowshroom/single,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors/explored)
+"f" = (
+/turf/closed/wall/mineral/wood,
+/area/lavaland/surface/dorf)
+"g" = (
+/obj/structure/mineral_door/wood,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/dorf)
+"h" = (
+/obj/structure/mineral_door/wood,
+/turf/open/indestructible/necropolis,
+/area/lavaland/surface/dorf)
+"i" = (
+/obj/structure/glowshroom/single,
+/turf/closed/wall/mineral/wood,
+/area/lavaland/surface/dorf)
+"j" = (
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/dorf)
+"k" = (
+/obj/effect/mob_spawn/human/dwarf_dorm,
+/obj/structure/glowshroom/single,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/dorf)
+"l" = (
+/obj/structure/glowshroom/single,
+/turf/open/indestructible/necropolis,
+/area/lavaland/surface/dorf)
+"m" = (
+/turf/open/indestructible/necropolis,
+/area/lavaland/surface/dorf)
+"n" = (
+/obj/structure/glowshroom/single,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/dorf)
+"o" = (
+/obj/structure/table/wood,
+/obj/item/flashlight/lantern,
+/obj/item/flashlight/lantern,
+/obj/structure/glowshroom/single,
+/turf/open/indestructible/necropolis,
+/area/lavaland/surface/dorf)
+"p" = (
+/turf/open/floor/plating/asteroid,
+/area/lavaland/surface/dorf)
+"q" = (
+/obj/structure/mineral_door/wood,
+/obj/structure/glowshroom/single,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/dorf)
+"r" = (
+/obj/machinery/smelter,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/dorf)
+"s" = (
+/obj/machinery/anvil,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/dorf)
+"t" = (
+/obj/structure/table/wood,
+/obj/item/melee/smith_hammer,
+/obj/item/melee/smith_hammer,
+/turf/open/indestructible/necropolis,
+/area/lavaland/surface/dorf)
+"u" = (
+/obj/structure/table/wood,
+/obj/item/pickaxe,
+/obj/item/pickaxe,
+/turf/open/indestructible/necropolis,
+/area/lavaland/surface/dorf)
+"v" = (
+/obj/structure/glowshroom/single,
+/turf/open/floor/plating/asteroid,
+/area/lavaland/surface/dorf)
+"w" = (
+/obj/structure/table/wood,
+/obj/item/shovel,
+/obj/item/shovel,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/dorf)
+"x" = (
+/obj/structure/glowshroom/single,
+/turf/open/indestructible/necropolis,
+/area/lavaland/surface/outdoors/explored)
+"y" = (
+/obj/item/hatchet,
+/obj/item/hatchet,
+/turf/open/floor/plating/asteroid,
+/area/lavaland/surface/dorf)
+"z" = (
+/obj/structure/sink/puddle,
+/turf/open/floor/plating/asteroid,
+/area/lavaland/surface/dorf)
+"A" = (
+/obj/item/cultivator,
+/obj/item/cultivator,
+/turf/open/floor/plating/asteroid,
+/area/lavaland/surface/dorf)
+"B" = (
+/obj/structure/chair/wood,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/dorf)
+"C" = (
+/obj/structure/table/wood,
+/obj/item/grown/log/tree,
+/obj/item/grown/log/tree,
+/obj/item/grown/log/tree,
+/obj/item/grown/log/tree,
+/obj/item/grown/log/tree,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/dorf)
+"D" = (
+/obj/effect/mob_spawn/human/dwarf_dorm,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/dorf)
+"E" = (
+/obj/item/reagent_containers/glass/bucket,
+/obj/item/reagent_containers/glass/bucket,
+/turf/open/floor/plating/asteroid,
+/area/lavaland/surface/dorf)
+"F" = (
+/obj/structure/table/wood,
+/obj/item/seeds/glowshroom,
+/obj/item/seeds/glowshroom,
+/obj/item/seeds/glowshroom,
+/obj/item/seeds/glowshroom,
+/obj/item/seeds/glowshroom,
+/obj/item/seeds/tower,
+/obj/item/seeds/tower,
+/obj/item/seeds/tower,
+/obj/item/seeds/tower,
+/obj/item/seeds/tower,
+/obj/structure/glowshroom/single,
+/turf/open/floor/plating/asteroid,
+/area/lavaland/surface/dorf)
+"G" = (
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/drinks/wooden_mug,
+/obj/item/reagent_containers/food/drinks/wooden_mug,
+/obj/item/reagent_containers/food/drinks/wooden_mug,
+/obj/item/reagent_containers/food/drinks/wooden_mug,
+/obj/item/reagent_containers/food/drinks/wooden_mug,
+/obj/item/reagent_containers/food/drinks/wooden_mug,
+/obj/item/reagent_containers/food/drinks/wooden_mug,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/dorf)
+"H" = (
+/obj/structure/fermenting_barrel,
+/turf/open/indestructible/necropolis,
+/area/lavaland/surface/dorf)
+"I" = (
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/snacks/grown/mushroom/plumphelmet,
+/obj/item/reagent_containers/food/snacks/grown/mushroom/plumphelmet,
+/obj/item/reagent_containers/food/snacks/grown/mushroom/plumphelmet,
+/obj/item/reagent_containers/food/snacks/grown/mushroom/plumphelmet,
+/obj/item/reagent_containers/food/snacks/grown/mushroom/plumphelmet,
+/obj/item/reagent_containers/food/snacks/grown/mushroom/plumphelmet,
+/obj/item/reagent_containers/food/snacks/grown/mushroom/plumphelmet,
+/obj/item/reagent_containers/food/snacks/grown/mushroom/plumphelmet,
+/obj/item/reagent_containers/food/snacks/grown/mushroom/plumphelmet,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/dorf)
+"J" = (
+/obj/structure/table/wood,
+/obj/item/crucible_tongs,
+/obj/item/reagent_containers/glass/bucket/iron_crucible_bucket,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/dorf)
+"K" = (
+/obj/structure/glowshroom/single,
+/mob/living/simple_animal/cow/lavaland,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/dorf)
+"L" = (
+/turf/closed/mineral/volcanic/lava_land_surface,
+/area/lavaland/surface/outdoors/explored)
+"M" = (
+/mob/living/simple_animal/cow/lavaland,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/dorf)
+"N" = (
+/obj/item/storage/bag/plants/portaseeder,
+/turf/open/floor/plating/asteroid,
+/area/lavaland/surface/dorf)
+"Q" = (
+/turf/closed/mineral/volcanic/lava_land_surface,
+/area/template_noop)
 
 (1,1,1) = {"
-aaaaaaaLaaaLddLaaaaaaaaaa
-aaaaLLLLLLLLddLLaaaaaaaaa
-aaLLLLLLLLLdddLLLaaaaaaaa
-aLLfffffffLdecLLaaaaaaaaa
-LLLfkgjgDfLdcbLaaaaaaaaaa
-aLLfffnfffLccLLLLaaaaaaaa
-aLLfDgngkffhiLLLLLLaaaaaa
-LLLfffnfffjjfiffffLLaaaaa
-LLLfDqjgljjjgmKjMfLLLLLLa
-dddfffffjmnnfjMjMfLLLLLLL
-LLdcdgjjmmjjffffiffcLLLLL
-aLLfffffojjjjjjNnnqdcxddL
-aaLfrstffujmjvjppjgexcddd
-aLLfjjmlfwmmnvyzApfLxeLLL
-aLLfBBjjjmmlnnvpppfLLLLLL
-aLLfCJjjjmmmjpEpppfLLLaLa
-aaLffflmjmjffjFffffLaaaaa
-aaLLLfhfGjHfjnffLLLLaaaaa
-aaaLLcdfImHfmffLLLaaaaaaa
-aLLLdddfffffgfLLLaaaaaaaa
-LLcccLLLLLLLcLLLQaaaaaaaa
-LdccLLLLLLLLdLLLLaaaaaaaa
-LddLLLaaaLLLddLLaaaaaaaaa
-ddLLLaaaaaaLLdLaaaaaaaaaa
-dLLLaaaaaaaaLdLLaaaaaaaaa
+a
+a
+a
+a
+L
+a
+a
+L
+L
+d
+L
+a
+a
+a
+a
+a
+a
+a
+a
+a
+L
+L
+L
+d
+d
+"}
+(2,1,1) = {"
+a
+a
+a
+L
+L
+L
+L
+L
+L
+d
+L
+L
+a
+L
+L
+L
+a
+a
+a
+L
+L
+d
+d
+d
+L
+"}
+(3,1,1) = {"
+a
+a
+L
+L
+L
+L
+L
+L
+L
+d
+d
+L
+L
+L
+L
+L
+L
+L
+a
+L
+c
+c
+d
+L
+L
+"}
+(4,1,1) = {"
+a
+a
+L
+f
+f
+f
+f
+f
+f
+f
+c
+f
+f
+f
+f
+f
+f
+L
+L
+L
+c
+c
+L
+L
+L
+"}
+(5,1,1) = {"
+a
+L
+L
+f
+k
+f
+D
+f
+D
+f
+d
+f
+r
+j
+B
+C
+f
+L
+L
+d
+c
+L
+L
+L
+a
+"}
+(6,1,1) = {"
+a
+L
+L
+f
+g
+f
+g
+f
+q
+f
+g
+f
+s
+j
+B
+J
+f
+f
+c
+d
+L
+L
+L
+a
+a
+"}
+(7,1,1) = {"
+a
+L
+L
+f
+j
+n
+n
+n
+j
+f
+j
+f
+t
+m
+j
+j
+l
+h
+d
+d
+L
+L
+a
+a
+a
+"}
+(8,1,1) = {"
+L
+L
+L
+f
+g
+f
+g
+f
+g
+f
+j
+f
+f
+l
+j
+j
+m
+f
+f
+f
+L
+L
+a
+a
+a
+"}
+(9,1,1) = {"
+a
+L
+L
+f
+D
+f
+k
+f
+l
+j
+m
+o
+f
+f
+j
+j
+j
+G
+I
+f
+L
+L
+a
+a
+a
+"}
+(10,1,1) = {"
+a
+L
+L
+f
+f
+f
+f
+f
+j
+m
+m
+j
+u
+w
+m
+m
+m
+j
+m
+f
+L
+L
+L
+a
+a
+"}
+(11,1,1) = {"
+a
+L
+L
+L
+L
+L
+f
+j
+j
+n
+j
+j
+j
+m
+m
+m
+j
+H
+H
+f
+L
+L
+L
+a
+a
+"}
+(12,1,1) = {"
+L
+L
+d
+d
+d
+c
+h
+j
+j
+n
+j
+j
+m
+m
+l
+m
+f
+f
+f
+f
+L
+L
+L
+L
+a
+"}
+(13,1,1) = {"
+d
+d
+d
+e
+c
+c
+i
+f
+g
+f
+f
+j
+j
+n
+n
+j
+f
+j
+m
+g
+c
+d
+d
+L
+L
+"}
+(14,1,1) = {"
+d
+d
+d
+c
+b
+L
+L
+i
+m
+j
+f
+j
+v
+v
+n
+p
+j
+n
+f
+f
+L
+L
+d
+d
+d
+"}
+(15,1,1) = {"
+L
+L
+L
+L
+L
+L
+L
+f
+K
+M
+f
+j
+j
+y
+v
+E
+F
+f
+f
+L
+L
+L
+L
+L
+L
+"}
+(16,1,1) = {"
+a
+L
+L
+L
+a
+L
+L
+f
+j
+j
+f
+N
+p
+z
+p
+p
+f
+f
+L
+L
+L
+L
+L
+a
+L
+"}
+(17,1,1) = {"
+a
+a
+L
+a
+a
+L
+L
+f
+M
+M
+i
+n
+p
+A
+p
+p
+f
+L
+L
+L
+Q
+L
+a
+a
+a
+"}
+(18,1,1) = {"
+a
+a
+a
+a
+a
+a
+L
+f
+f
+f
+f
+n
+j
+p
+p
+p
+f
+L
+L
+a
+a
+a
+a
+a
+a
+"}
+(19,1,1) = {"
+a
+a
+a
+a
+a
+a
+L
+L
+L
+L
+f
+q
+g
+f
+f
+f
+f
+L
+a
+a
+a
+a
+a
+a
+a
+"}
+(20,1,1) = {"
+a
+a
+a
+a
+a
+a
+a
+L
+L
+L
+c
+d
+e
+L
+L
+L
+L
+L
+a
+a
+a
+a
+a
+a
+a
+"}
+(21,1,1) = {"
+a
+a
+a
+a
+a
+a
+a
+a
+L
+L
+L
+c
+x
+x
+L
+L
+a
+a
+a
+a
+a
+a
+a
+a
+a
+"}
+(22,1,1) = {"
+a
+a
+a
+a
+a
+a
+a
+a
+L
+L
+L
+x
+c
+e
+L
+L
+a
+a
+a
+a
+a
+a
+a
+a
+a
+"}
+(23,1,1) = {"
+a
+a
+a
+a
+a
+a
+a
+a
+L
+L
+L
+d
+d
+L
+L
+a
+a
+a
+a
+a
+a
+a
+a
+a
+a
+"}
+(24,1,1) = {"
+a
+a
+a
+a
+a
+a
+a
+a
+L
+L
+L
+d
+d
+L
+L
+L
+a
+a
+a
+a
+a
+a
+a
+a
+a
+"}
+(25,1,1) = {"
+a
+a
+a
+a
+a
+a
+a
+a
+a
+L
+L
+L
+d
+L
+L
+a
+a
+a
+a
+a
+a
+a
+a
+a
+a
 "}


### PR DESCRIPTION
This fixes jerky movement when the dwarven ruin is present.
This is caused by maps having step_x and step_y varedits which break the movement system.