### PR TITLE
Lube uplink

### DIFF
--- a/RussStation.dme
+++ b/RussStation.dme
@@ -2958,6 +2958,7 @@
 #include "russstation\code\modules\reagents\chemistry\reagents\other_reagents.dm"
 #include "russstation\code\modules\reagents\chemistry\recipes\others.dm"
 #include "russstation\code\modules\shuttle\emergency.dm"
+#include "russstation\code\modules\uplink\uplink_items.dm"
 #include "russstation\code\modules\vehicles\wheelchair.dm"
 #include "russstation\code\modules\vending\_vending.dm"
 #include "russstation\code\modules\vending\wardrobes.dm"

--- a/html/changelogs/AngryKnees-ClusterlubeUplink.yml
+++ b/html/changelogs/AngryKnees-ClusterlubeUplink.yml
@@ -1,0 +1,6 @@
+author: "AngryKnees"
+
+delete-after: True
+
+changes: 
+  - rscadd: "Added the lube clusterbang to the uplink as a clown-specific item"

--- a/russstation/code/modules/uplink/uplink_items.dm
+++ b/russstation/code/modules/uplink/uplink_items.dm
@@ -1,0 +1,6 @@
+/datum/uplink_item/role_restricted/lube_clusterbang
+	name = "Lubestorm Clusterbang"
+	desc = "A clusterbang grenade with unmatched lubrication potential."
+	item = /obj/item/grenade/clusterbuster/lube
+	cost = 5
+	restricted_roles = list("Clown")


### PR DESCRIPTION
## About The Pull Request
Adds the lube clusterbang grenade to the role-restricted section of the syndicate uplink for 5 TC. Can only be purchased by the Clown.

## Why It's Good For The Game
_**Honk**_

:cl: AngryKnees
add: Added the lube clusterbang to the uplink as a clown-specific item
/:cl:
