### PR TITLE
code segregation refactor

### DIFF
--- a/RussStation.dme
+++ b/RussStation.dme
@@ -2902,7 +2902,6 @@
 #include "interface\menu.dm"
 #include "interface\stylesheet.dm"
 #include "interface\skin.dmf"
-#include "russstation\code\init.dm"
 #include "russstation\code\__HELPERS\mobs.dm"
 #include "russstation\code\__HELPERS\names.dm"
 #include "russstation\code\__HELPERS\text.dm"

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -138,7 +138,10 @@ SUBSYSTEM_DEF(ticker)
 	else if(CONFIG_GET(flag/shift_time_realtime))
 		gametime_offset = world.timeofday
 
-	russ_initialize() //honk -- gets config values
+	initial_delay = CONFIG_GET(number/transfer_delay_initial) // honk start -- gets config values
+	subsequent_delay = CONFIG_GET(number/transfer_delay_subsequent)
+	SSvote.shuttle_refuel_delay = CONFIG_GET(number/shuttle_refuel_delay)
+	SSvote.transfer_vote_config = CONFIG_GET(flag/transfer_vote) // honk end
 	return ..()
 
 /datum/controller/subsystem/ticker/fire()

--- a/code/controllers/subsystem/vote.dm
+++ b/code/controllers/subsystem/vote.dm
@@ -336,10 +336,12 @@ SUBSYSTEM_DEF(vote)
 		if("restart")
 			if(CONFIG_GET(flag/allow_vote_restart) || usr.client.holder)
 				initiate_vote("restart",usr.key)
-		//honk start -- makes the admin button for calling a crew transfer vote work
-		if("crew transfer")
-			russ_Topic()
-		//honk end
+		if("crew transfer") // honk start -- crew transfer vote
+			if(transfer_vote_config || usr.client.holder) 
+				if(shuttle_refuel_delay < world.time)
+					initiate_vote("crew transfer",usr.key)
+				else
+					to_chat(usr, "<span style='boldannounce'>Shuttle call can only initiate after [DisplayTimeText(shuttle_refuel_delay - (world.time - SSticker.round_start_time))].</span>") // honk end
 		if("gamemode")
 			if(CONFIG_GET(flag/allow_vote_mode) || usr.client.holder)
 				initiate_vote("gamemode",usr.key)

--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -49,7 +49,7 @@ GLOBAL_VAR(restart_counter)
 		world.log = file("[GLOB.log_directory]/dd.log") //not all runtimes trigger world/Error, so this is the only way to ensure we can see all of them.
 #endif
 
-	russ_initialize() // honk -- for loading added content on initialize
+	init_sprite_accessory_subtypes(/datum/sprite_accessory/diona_hair, GLOB.diona_hair_list, roundstart = TRUE)  // honk -- creates a list of diona hair options()
 	LoadVerbs(/datum/verbs/menu)
 	if(CONFIG_GET(flag/usewhitelist))
 		load_whitelist()

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -477,7 +477,14 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 					dat += "</td>"
 					mutant_category = 0
 
-			dat = add_russ_choices(dat) //honk -- SOMEONE FORGOT TO LABEL THIS >:(
+			if("diona_hair" in pref_species.mutant_bodyparts) // honk start -- adds a button for customising added race's hair/additional body parts
+				dat += "<td valign='top' width='7%'>"
+				
+				dat += "<h3>Hair</h3>"
+				
+				dat += "<a href='?_src_=prefs;preference=diona_hair;task=input'>[features["diona_hair"]]</a><BR>"
+				
+				dat += "</td>" // honk end
 			//Adds a thing to select which phobia because I can't be assed to put that in the quirks window
 			if("Phobia" in all_quirks)
 				dat += "<h3>Phobia</h3>"
@@ -1105,7 +1112,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 				SetQuirks(user)
 			else
 				SetQuirks(user)
-		return TRUE
+		return TRUE			
 
 	switch(href_list["task"])
 		if("random")
@@ -1150,6 +1157,11 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 
 
 			switch(href_list["preference"])
+				if("diona_hair") // honk start -- diona hair options
+					var/new_diona_hair
+					new_diona_hair = input(user, "Choose your character's hair:", "Character Preference") as null|anything in GLOB.diona_hair_list
+					if(new_diona_hair)
+						features["diona_hair"] = new_diona_hair // honk end
 				if("ghostform")
 					if(unlock_content)
 						var/new_form = input(user, "Thanks for supporting BYOND - Choose your ghostly form:","Thanks for supporting BYOND",null) as null|anything in GLOB.ghost_forms
@@ -1637,7 +1649,6 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 				if("reset_bindings")
 					reset_keybindings()
 				// honk end
-	process_russ_link(user, href_list) //honk -- checks for russ station links and handles those
 	ShowChoices(user)
 	return 1
 

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -1112,7 +1112,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 				SetQuirks(user)
 			else
 				SetQuirks(user)
-		return TRUE			
+		return TRUE
 
 	switch(href_list["task"])
 		if("random")

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -329,6 +329,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	S["feature_lizard_legs"]			>> features["legs"]
 	S["feature_moth_wings"]				>> features["moth_wings"]
 	S["feature_moth_markings"]			>> features["moth_markings"]
+	S["feature_diona_hair"] 			>> features["diona_hair"] // honk -- diona hair feature
 	if(!CONFIG_GET(flag/join_with_mutant_humans))
 		features["tail_human"] = "none"
 		features["ears"] = "none"
@@ -416,7 +417,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	features["feature_lizard_legs"]	= sanitize_inlist(features["legs"], GLOB.legs_list, "Normal Legs")
 	features["moth_wings"] 	= sanitize_inlist(features["moth_wings"], GLOB.moth_wings_list, "Plain")
 	features["moth_markings"] 	= sanitize_inlist(features["moth_markings"], GLOB.moth_markings_list, "None")
-	russ_character_pref_load(S) // honk -- loads character customization preferences
+	features["diona_hair"] 	= sanitize_inlist(features["diona_hair"], GLOB.diona_hair_list) // honk -- add diona hair features
 	joblessrole	= sanitize_integer(joblessrole, 1, 3, initial(joblessrole))
 	//Validate job prefs
 	for(var/j in job_preferences)
@@ -481,7 +482,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 
 	//Jobs
 	WRITE_FILE(S["joblessrole"]		, joblessrole)
-	russ_character_pref_save(S) // honk -- saves character customization preferences
+	S["feature_diona_hair"] << features["diona_hair"] // honk -- save diona_hair
 	//Write prefs
 	WRITE_FILE(S["job_preferences"] , job_preferences)
 

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -626,7 +626,9 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 			bodyparts_to_add -= "wings_open"
 		else if ("wings" in mutant_bodyparts)
 			bodyparts_to_add -= "wings_open"
-	russ_handle_hiding_bodyparts(bodyparts_to_add, HD, H) // honk -- hide our shit
+	if("diona_hair" in mutant_bodyparts) // honk start -- diona hair
+		if((human.wear_mask && (human.wear_mask.flags_inv & HIDEFACE)) || (human.head && (human.head.flags_inv & HIDEFACE)) || !head || head.status == BODYPART_ROBOTIC)
+			bodyparts_adding -= "diona_hair" // honk end
 
 	//Digitigrade legs are stuck in the phantom zone between true limbs and mutant bodyparts. Mainly it just needs more agressive updating than most limbs.
 	var/update_needed = FALSE
@@ -697,8 +699,8 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 					S = GLOB.moth_markings_list[H.dna.features["moth_markings"]]
 				if("caps")
 					S = GLOB.caps_list[H.dna.features["caps"]]
-				else // honk start -- our species mutant bodyparts such as diona hair
-					S = russ_mutant_bodyparts(bodypart, H) // honk end
+				if("diona_hair") // honk start -- add diona_gair to their DNA
+					S = GLOB.diona_hair_list[H.dna.features["diona_hair"]] // honk end
 			if(!S || S.icon_state == "none")
 				continue
 

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -699,7 +699,7 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 					S = GLOB.moth_markings_list[H.dna.features["moth_markings"]]
 				if("caps")
 					S = GLOB.caps_list[H.dna.features["caps"]]
-				if("diona_hair") // honk start -- add diona_gair to their DNA
+				if("diona_hair") // honk start -- add diona_hair to their DNA
 					S = GLOB.diona_hair_list[H.dna.features["diona_hair"]] // honk end
 			if(!S || S.icon_state == "none")
 				continue

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -627,8 +627,8 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 		else if ("wings" in mutant_bodyparts)
 			bodyparts_to_add -= "wings_open"
 	if("diona_hair" in mutant_bodyparts) // honk start -- diona hair
-		if((human.wear_mask && (human.wear_mask.flags_inv & HIDEFACE)) || (human.head && (human.head.flags_inv & HIDEFACE)) || !head || head.status == BODYPART_ROBOTIC)
-			bodyparts_adding -= "diona_hair" // honk end
+		if((H.wear_mask && (H.wear_mask.flags_inv & HIDEFACE)) || (H.head && (H.head.flags_inv & HIDEFACE)) || !HD || HD.status == BODYPART_ROBOTIC)
+			bodyparts_to_add -= "diona_hair" // honk end
 
 	//Digitigrade legs are stuck in the phantom zone between true limbs and mutant bodyparts. Mainly it just needs more agressive updating than most limbs.
 	var/update_needed = FALSE

--- a/russstation/code/controllers/subsystem/ticker.dm
+++ b/russstation/code/controllers/subsystem/ticker.dm
@@ -3,12 +3,6 @@
 	var/subsequent_delay = 18000
 	var/transfer_votes = 0
 
-/datum/controller/subsystem/ticker/proc/russ_initialize()
-	initial_delay = CONFIG_GET(number/transfer_delay_initial)
-	subsequent_delay = CONFIG_GET(number/transfer_delay_subsequent)
-	SSvote.shuttle_refuel_delay = CONFIG_GET(number/shuttle_refuel_delay)
-	SSvote.transfer_vote_config = CONFIG_GET(flag/transfer_vote)
-
 /datum/controller/subsystem/ticker/proc/votetimer()
 	if(world.time - (initial_delay + (subsequent_delay * transfer_votes)) >= 0)
 		if(SSshuttle.emergency.timeLeft() >= 6000 || SSshuttle.emergency.mode == SHUTTLE_IDLE || SSshuttle.emergency.mode == SHUTTLE_RECALL)

--- a/russstation/code/controllers/subsystem/vote.dm
+++ b/russstation/code/controllers/subsystem/vote.dm
@@ -1,14 +1,7 @@
 /datum/controller/subsystem/vote/
 	var/shuttle_refuel_delay = 0
 	var/transfer_vote_config = 0
-
-/datum/controller/subsystem/vote/proc/russ_Topic()
-	if(transfer_vote_config || usr.client.holder)
-		if(shuttle_refuel_delay < world.time)
-			initiate_vote("crew transfer",usr.key)
-		else
-			to_chat(usr, "<span style='boldannounce'>Shuttle call can only initiate after [DisplayTimeText(shuttle_refuel_delay - (world.time - SSticker.round_start_time))].</span>")
-
+	
 /datum/controller/subsystem/vote/proc/shuttlecall()
 	var/shuttle_timer = SSshuttle.emergency.timeLeft()
 	SSshuttle.block_recall(6000)

--- a/russstation/code/init.dm
+++ b/russstation/code/init.dm
@@ -1,5 +1,0 @@
-//This is the Russ Station init file, here we will initialize everything Russ Station where possible.
-//Create a proc to load something in the appropriate module file and call the proc here.
-
-/proc/russ_initialize()
-	init_sprite_accessory_subtypes(/datum/sprite_accessory/diona_hair, GLOB.diona_hair_list, roundstart = TRUE)  //creates a list of diona hair options

--- a/russstation/code/modules/client/preferences.dm
+++ b/russstation/code/modules/client/preferences.dm
@@ -11,23 +11,3 @@
 
 /datum/preferences/proc/reset_keybindings()
 	bindings.from_list(GLOB.keybinding_default)
-
-/datum/preferences/proc/add_russ_choices(dat)  //adds a button for customising added race's hair/additional body parts
-	if("diona_hair" in pref_species.mutant_bodyparts)
-		dat += "<td valign='top' width='7%'>"
-
-		dat += "<h3>Hair</h3>"
-
-		dat += "<a href='?_src_=prefs;preference=diona_hair;task=input'>[features["diona_hair"]]</a><BR>"
-
-		dat += "</td>"
-	return dat
-
-/datum/preferences/proc/process_russ_link(mob/user, list/href_list)  //handles added russ station links
-	switch(href_list["task"])
-		if("input")
-			if(href_list["preference"] == "diona_hair")
-				var/new_diona_hair
-				new_diona_hair = input(user, "Choose your character's hair:", "Character Preference") as null|anything in GLOB.diona_hair_list
-				if(new_diona_hair)
-					features["diona_hair"] = new_diona_hair

--- a/russstation/code/modules/client/preferences_savefile.dm
+++ b/russstation/code/modules/client/preferences_savefile.dm
@@ -9,12 +9,3 @@
 /datum/preferences/proc/save_keybindings(var/savefile/S)
 	WRITE_FILE(S["keybindings"], bindings.to_list())
 
-/datum/preferences/proc/russ_character_pref_load(savefile/S)  //loads added race's customization options
-	//diona
-	S["feature_diona_hair"] >> features["diona_hair"]
-	features["diona_hair"] 	= sanitize_inlist(features["diona_hair"], GLOB.diona_hair_list)
-
-/datum/preferences/proc/russ_character_pref_save(savefile/S)  //saves added race's customization options
-	//diona
-	S["feature_diona_hair"] << features["diona_hair"]
-

--- a/russstation/code/modules/mob/living/carbon/human/species_types/species.dm
+++ b/russstation/code/modules/mob/living/carbon/human/species_types/species.dm
@@ -13,14 +13,4 @@
 	else  //disables russ station icons for bodyparts
 		for(var/O in bodyparts)
 			var/obj/item/bodypart/B = O
-			B.should_draw_russ = FALSE
-
-/datum/species/proc/russ_mutant_bodyparts(bodypart, mob/living/carbon/human/H)
-	switch(bodypart)
-		if("diona_hair")
-			return GLOB.diona_hair_list[H.dna.features["diona_hair"]]
-
-/datum/species/proc/russ_handle_hiding_bodyparts(list/bodyparts_adding, obj/item/bodypart/head/head, mob/living/carbon/human/human)
-	if("diona_hair" in mutant_bodyparts)
-		if((human.wear_mask && (human.wear_mask.flags_inv & HIDEFACE)) || (human.head && (human.head.flags_inv & HIDEFACE)) || !head || head.status == BODYPART_ROBOTIC)
-			bodyparts_adding -= "diona_hair"
+			B.should_draw_russ = FALSE	


### PR DESCRIPTION
Removes code segregation where is serves no practical purpose. The patterns used in these cases still forced the file to be checked by hand when merge conflict arise, negating the usefulness of the pattern while increasing complexity.