### PR TITLE
Disable Organ Failure Events

### DIFF
--- a/code/modules/events/heart_attack.dm
+++ b/code/modules/events/heart_attack.dm
@@ -1,7 +1,7 @@
 /datum/round_event_control/heart_attack
 	name = "Random Heart Attack"
 	typepath = /datum/round_event/heart_attack
-	weight = 20
+	weight = 0 // honk - changed from 20 to 0 players found it too annoying
 	max_occurrences = 2
 	min_players = 40 // To avoid shafting lowpop
 

--- a/code/modules/events/heart_attack.dm
+++ b/code/modules/events/heart_attack.dm
@@ -1,8 +1,8 @@
 /datum/round_event_control/heart_attack
 	name = "Random Heart Attack"
 	typepath = /datum/round_event/heart_attack
-	weight = 0 // honk - changed from 20 to 0 players found it too annoying
-	max_occurrences = 2
+	weight = 20
+	max_occurrences = 0 // honk - 2 -> 0 disabled for low pop reasons
 	min_players = 40 // To avoid shafting lowpop
 
 /datum/round_event/heart_attack/start()

--- a/code/modules/events/spontaneous_appendicitis.dm
+++ b/code/modules/events/spontaneous_appendicitis.dm
@@ -1,8 +1,8 @@
 /datum/round_event_control/spontaneous_appendicitis
 	name = "Spontaneous Appendicitis"
 	typepath = /datum/round_event/spontaneous_appendicitis
-	weight = 0 // honk - changed from 20 to 0 players found it too annoying 
-	max_occurrences = 4
+	weight = 20
+	max_occurrences = 0 // honk - 2 -> 0 disabled for low pop reasons
 	earliest_start = 10 MINUTES
 	min_players = 5 // To make your chance of getting help a bit higher.
 

--- a/code/modules/events/spontaneous_appendicitis.dm
+++ b/code/modules/events/spontaneous_appendicitis.dm
@@ -1,7 +1,7 @@
 /datum/round_event_control/spontaneous_appendicitis
 	name = "Spontaneous Appendicitis"
 	typepath = /datum/round_event/spontaneous_appendicitis
-	weight = 20
+	weight = 0 // honk - changed from 20 to 0 players found it too annoying 
 	max_occurrences = 4
 	earliest_start = 10 MINUTES
 	min_players = 5 // To make your chance of getting help a bit higher.

--- a/html/changelogs/FlufflyCthulu-Organ-Events-Disable.yml
+++ b/html/changelogs/FlufflyCthulu-Organ-Events-Disable.yml
@@ -1,0 +1,7 @@
+
+author: "FlufflyCthulu"
+
+delete-after: True
+
+changes: 
+  - balance: "Disabled heart attack and appendicitis events."


### PR DESCRIPTION
## About The Pull Request

Disables the heart attack and appendicitis random events.

## Why It's Good For The Game

Due to having event player minimums disabled organ failure's are often guaranteed death on low pop. The events aren't particularly enjoyable on high pop either and better ways of getting players to medbay would be preferred.

## Changelog
:cl:
balance: Disabled heart attack and appendicitis events.
/:cl:
