### PR TITLE
Typing Indicator

### DIFF
--- a/RussStation.dme
+++ b/RussStation.dme
@@ -3016,6 +3016,7 @@
 #include "russstation\code\modules\mining\smelter.dm"
 #include "russstation\code\modules\mining\equipment\kinetic_crusher.dm"
 #include "russstation\code\modules\mob\mob.dm"
+#include "russstation\code\modules\mob\say.dm"
 #include "russstation\code\modules\mob\dead\new_player\sprite_accessories.dm"
 #include "russstation\code\modules\mob\living\carbon\emote.dm"
 #include "russstation\code\modules\mob\living\carbon\human\species_types\diona.dm"

--- a/code/controllers/subsystem/input.dm
+++ b/code/controllers/subsystem/input.dm
@@ -23,7 +23,7 @@ SUBSYSTEM_DEF(input)
 	"Any" = "\"KeyDown \[\[*\]\]\"",
 	"Any+UP" = "\"KeyUp \[\[*\]\]\"",
 	"O" = "ooc",
-	"T" = "say",
+	"T" = ".say", //honk - calls a say wrapper to allow for the typing indicator
 	"M" = "me",
 	"Back" = "\".winset \\\"input.text=\\\"\\\"\\\"\"",
 	"Tab" = "\".winset \\\"input.focus=true?map.focus=true input.background-color=[COLOR_INPUT_DISABLED]:input.focus=true input.background-color=[COLOR_INPUT_ENABLED]\\\"\"", 

--- a/html/changelogs/Fluffly-Typing_Indicator.yml
+++ b/html/changelogs/Fluffly-Typing_Indicator.yml
@@ -1,0 +1,6 @@
+author: "Fluffly Cthulu"
+
+delete-after: True
+
+changes:
+  - rscadd: "Readded the typing indicator."

--- a/russstation/code/modules/mob/say.dm
+++ b/russstation/code/modules/mob/say.dm
@@ -1,0 +1,31 @@
+//Credit to Yozr for his work on the old version of typing indicators
+
+/mob/verb/say_wrapper()
+	set name = ".say"
+	set hidden = TRUE
+
+	var/image/typing_indicator = image('icons/mob/talk.dmi', src, "default0", FLY_LAYER)
+	if(isliving(src)) //only living mobs have the bubble_icon var
+		var/mob/living/L = src
+		typing_indicator = image('icons/mob/talk.dmi', src, L.bubble_icon + "0", FLY_LAYER) //get unique speech bubble icons for different species
+
+	typing_indicator.appearance_flags = APPEARANCE_UI_IGNORE_ALPHA
+
+	overlays += typing_indicator
+
+	if(ishuman(src))
+		var/mob/living/carbon/human/H = src
+
+		if(H.dna.check_mutation(MUT_MUTE) || H.silent) //Check for mute or silent, remove the overlay if true
+			overlays -= typing_indicator
+			return
+
+	if(client)
+		if(stat != CONSCIOUS || is_muzzled())
+			overlays -= typing_indicator
+
+	var/message = input("", "Say \"text\"") as null|text
+
+	overlays -= typing_indicator
+
+	say_verb(message)


### PR DESCRIPTION
## About The Pull Request

Re-adds the typing indicator now that we have moved to TG's system of keybindings. The new version uses TG's icons for speech bubbles which means that some mobs such as xenos and slimes will have unique typing indicators.

Issues that may be addressed in future pr's
- [ ] input window can't be closed with escape.
- [x] ~~maybe a preference setting on whether to show the indicator or not?~~

## Why It's Good For The Game

On this server where there is _no_ powergaming typing indicators allow players to know when someone else is talking. This allows for more intuitive player interactions and arrpee.

## Changelog
:cl:
add: Readded the typing indicator.
/:cl:
