### PR TITLE
Gives farting a cooldown

### DIFF
--- a/html/changelogs/Fluffly-Cool-Farts.yml
+++ b/html/changelogs/Fluffly-Cool-Farts.yml
@@ -3,5 +3,5 @@ author: "Fluffly Cthulu"
 delete-after: True
 
 changes:
-  - balance: "Farting now has a 30 second cooldown between uses."
-  - balance: "Clowns now fart confetti 100% of the time."
+  - balance: "Farting now has a 2 second cooldown, attempting to fart before the cooldown ends deals toxin damage and stuns."
+  - balance: "Clowns now fart confetti 50% of the time."

--- a/html/changelogs/Fluffly-Cool-Farts.yml
+++ b/html/changelogs/Fluffly-Cool-Farts.yml
@@ -1,0 +1,7 @@
+author: "Fluffly Cthulu"
+
+delete-after: True
+
+changes:
+  - balance: "Farting now has a 30 second cooldown between uses."
+  - balance: "Clowns now fart confetti 100% of the time."

--- a/russstation/code/modules/mob/living/carbon/emote.dm
+++ b/russstation/code/modules/mob/living/carbon/emote.dm
@@ -5,10 +5,11 @@
 	muzzle_ignore = TRUE
 	emote_type = EMOTE_AUDIBLE
 	vary = TRUE
+	cooldown = 30 SECONDS
 
 /datum/emote/living/carbon/fart/get_sound(mob/living/user)
 	if(ishuman(user))
-		if(user.mind.assigned_role == "Clown" && prob(25)) //clowns have a chance to fart confetti
+		if(user.mind.assigned_role == "Clown") //clowns fart confetti
 			var/turf/T = get_turf(user)
 			new /obj/effect/gibspawner/confetti(T, user)
 		return pick('russstation/sound/effects/mob_effects/poo1.ogg',

--- a/russstation/code/modules/mob/living/carbon/emote.dm
+++ b/russstation/code/modules/mob/living/carbon/emote.dm
@@ -5,11 +5,25 @@
 	muzzle_ignore = TRUE
 	emote_type = EMOTE_AUDIBLE
 	vary = TRUE
-	cooldown = 30 SECONDS
+	cooldown = 2 SECONDS
+
+/datum/emote/living/carbon/fart/check_cooldown(mob/user, intentional)
+	. = ..()
+	if(.) // If the emote is not intentional or off cooldown don't do anything
+		return
+	if(!can_run_emote(user, intentional=intentional)) // If you can't use the emote there is no effect
+		return
+	var/mob/living/carbon/U = user
+	if(U.IsStun())
+		return
+	U.adjustToxLoss(5)
+	U.Stun(1 SECONDS)
+	to_chat(U, "<span class='notice'>You feel a sharp pain in your stomach and fail to produce any flatulence.</span>")
+
 
 /datum/emote/living/carbon/fart/get_sound(mob/living/user)
 	if(ishuman(user))
-		if(user.mind.assigned_role == "Clown") //clowns fart confetti
+		if(user.mind.assigned_role == "Clown" && prob(50)) //clowns have a 50% chance to fart confetti
 			var/turf/T = get_turf(user)
 			new /obj/effect/gibspawner/confetti(T, user)
 		return pick('russstation/sound/effects/mob_effects/poo1.ogg',


### PR DESCRIPTION
## About The Pull Request

The fart emote is being spammed too much so this pr gives it a cooldown of 30 seconds between uses. To balance this nerf for clowns, clown farts now always produce confetti.

## Why It's Good For The Game

The station will smell far better.

## Changelog
:cl:
balance: Farting now has a 2 second cooldown, attempting to fart before the cooldown ends deals toxin damage and stuns.
balance: Clowns now fart confetti 50% of the time.
/:cl:
