### PR TITLE
Stealth pirates

### DIFF
--- a/code/game/objects/structures/ghost_role_spawners.dm
+++ b/code/game/objects/structures/ghost_role_spawners.dm
@@ -565,7 +565,9 @@
 	density = FALSE
 	show_flavour = FALSE //Flavour only exists for spawners menu
 	short_desc = "You are a space pirate."
-	flavour_text = "The station refused to pay for your protection, protect the ship, siphon the credits from the station and raid it for even more loot."
+	flavour_text = "This station was identified as a potentially profitable target. \
+	Announcing your presence and demanding money may make the job easier but it's been known to backfire. \
+	However you decide to do it, the booty is the top priority." //honk -- update description text
 	assignedrole = "Space Pirate"
 	var/rank = "Mate"
 

--- a/code/game/objects/structures/ghost_role_spawners.dm
+++ b/code/game/objects/structures/ghost_role_spawners.dm
@@ -565,9 +565,11 @@
 	density = FALSE
 	show_flavour = FALSE //Flavour only exists for spawners menu
 	short_desc = "You are a space pirate."
+	//honk start -- update description to fit removal of the announcement
 	flavour_text = "This station was identified as a potentially profitable target. \
 	Announcing your presence and demanding money may make the job easier but it's been known to backfire. \
-	However you decide to do it, the booty is the top priority." //honk -- update description text
+	However you decide to do it, the booty is the top priority."
+	//honk end
 	assignedrole = "Space Pirate"
 	var/rank = "Mate"
 

--- a/code/modules/events/pirates.dm
+++ b/code/modules/events/pirates.dm
@@ -14,56 +14,21 @@
 	return ..()
 
 /datum/round_event/pirates
-	startWhen = 60 //2 minutes to answer
-	var/datum/comm_message/threat
-	var/payoff = 0
-	var/payoff_min = 20000
-	var/paid_off = FALSE
+	//honk -- remove announcement
 	var/ship_name = "Space Privateers Association"
-	var/shuttle_spawned = FALSE
+	fakeable = FALSE
 
 /datum/round_event/pirates/setup()
 	ship_name = pick(strings(PIRATE_NAMES_FILE, "ship_names"))
 
-/datum/round_event/pirates/announce(fake)
-	priority_announce("Incoming subspace communication. Secure channel opened at all communication consoles.", "Incoming Message", 'sound/ai/commandreport.ogg')
-	if(fake)
-		return
-	threat = new
-	var/datum/bank_account/D = SSeconomy.get_dep_account(ACCOUNT_CAR)
-	if(D)
-		payoff = max(payoff_min, FLOOR(D.account_balance * 0.80, 1000))
-	threat.title = "Business proposition"
-	threat.content = "This is [ship_name]. Pay up [payoff] credits or you'll walk the plank."
-	threat.possible_answers = list("We'll pay.","No way.")
-	threat.answer_callback = CALLBACK(src,.proc/answered)
-	SScommunications.send_message(threat,unique = TRUE)
-
-/datum/round_event/pirates/proc/answered()
-	if(threat && threat.answered == 1)
-		var/datum/bank_account/D = SSeconomy.get_dep_account(ACCOUNT_CAR)
-		if(D)
-			if(D.adjust_money(-payoff))
-				priority_announce("Thanks for the credits, landlubbers.",sender_override = ship_name)
-				paid_off = TRUE
-				return
-			else
-				priority_announce("Trying to cheat us? You'll regret this!",sender_override = ship_name)
-	if(!shuttle_spawned)
-		spawn_shuttle()
-	else
-		priority_announce("Too late to beg for mercy!",sender_override = ship_name)
+//honk -- remove announcement
 
 /datum/round_event/pirates/start()
-	if(threat && !threat.answered)
-		threat.possible_answers = list("Too late")
-		threat.answered = 1
-	if(!paid_off && !shuttle_spawned)
-		spawn_shuttle()
+	//honk -- remove announcement
+	spawn_shuttle()
 
 /datum/round_event/pirates/proc/spawn_shuttle()
-	shuttle_spawned = TRUE
-
+	//honk -- remove announcement
 	var/list/candidates = pollGhostCandidates("Do you wish to be considered for pirate crew?", ROLE_TRAITOR)
 	shuffle_inplace(candidates)
 
@@ -87,8 +52,7 @@
 				announce_to_ghosts(M)
 			else
 				announce_to_ghosts(spawner)
-
-	priority_announce("Unidentified armed ship detected near the station.")
+	//honk -- remove pirate announcement
 
 //Shuttle equipment
 

--- a/code/modules/events/pirates.dm
+++ b/code/modules/events/pirates.dm
@@ -14,21 +14,63 @@
 	return ..()
 
 /datum/round_event/pirates
-	//honk -- remove announcement
+	/* honk -- remove announcement
+	startWhen = 60 //2 minutes to answer
+	var/datum/comm_message/threat
+	var/payoff = 0
+	var/payoff_min = 20000
+	var/paid_off = FALSE
+	honk end */
 	var/ship_name = "Space Privateers Association"
-	fakeable = FALSE
+	var/shuttle_spawned = FALSE
 
 /datum/round_event/pirates/setup()
 	ship_name = pick(strings(PIRATE_NAMES_FILE, "ship_names"))
 
-//honk -- remove announcement
+/* honk start -- remove announcement
+/datum/round_event/pirates/announce(fake)
+	priority_announce("Incoming subspace communication. Secure channel opened at all communication consoles.", "Incoming Message", 'sound/ai/commandreport.ogg')
+	if(fake)
+		return
+	threat = new
+	var/datum/bank_account/D = SSeconomy.get_dep_account(ACCOUNT_CAR)
+	if(D)
+		payoff = max(payoff_min, FLOOR(D.account_balance * 0.80, 1000))
+	threat.title = "Business proposition"
+	threat.content = "This is [ship_name]. Pay up [payoff] credits or you'll walk the plank."
+	threat.possible_answers = list("We'll pay.","No way.")
+	threat.answer_callback = CALLBACK(src,.proc/answered)
+	SScommunications.send_message(threat,unique = TRUE)
+
+/datum/round_event/pirates/proc/answered()
+	if(threat && threat.answered == 1)
+		var/datum/bank_account/D = SSeconomy.get_dep_account(ACCOUNT_CAR)
+		if(D)
+			if(D.adjust_money(-payoff))
+				priority_announce("Thanks for the credits, landlubbers.",sender_override = ship_name)
+				paid_off = TRUE
+				return
+			else
+				priority_announce("Trying to cheat us? You'll regret this!",sender_override = ship_name)
+	if(!shuttle_spawned)
+		spawn_shuttle()
+	else
+		priority_announce("Too late to beg for mercy!",sender_override = ship_name)
+honk end */
 
 /datum/round_event/pirates/start()
-	//honk -- remove announcement
-	spawn_shuttle()
+	/* honk start -- remove announcement
+	if(threat && !threat.answered)
+		threat.possible_answers = list("Too late")
+		threat.answered = 1
+	if(!paid_off && !shuttle_spawned)
+	honk end */
+	spawn_shuttle() //honk -- remove tab
 
 /datum/round_event/pirates/proc/spawn_shuttle()
-	//honk -- remove announcement
+	/* honk start -- remove announcement
+	shuttle_spawned = TRUE
+	honk end */
 	var/list/candidates = pollGhostCandidates("Do you wish to be considered for pirate crew?", ROLE_TRAITOR)
 	shuffle_inplace(candidates)
 
@@ -52,7 +94,10 @@
 				announce_to_ghosts(M)
 			else
 				announce_to_ghosts(spawner)
-	//honk -- remove pirate announcement
+
+	/* honk start -- remove announcement
+	priority_announce("Unidentified armed ship detected near the station.")
+	honk end */
 
 //Shuttle equipment
 

--- a/html/changelogs/Fluffly-Stealth-Pirates.yml
+++ b/html/changelogs/Fluffly-Stealth-Pirates.yml
@@ -1,0 +1,6 @@
+author: "Fluffly Cthulu"
+
+delete-after: True
+
+changes:
+  - balance: "Space pirates have upgraded their fleets with advanced stealth equipment and have begun attacking stations unanounced."

--- a/html/changelogs/example.yml
+++ b/html/changelogs/example.yml
@@ -6,7 +6,7 @@
 # Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
 # When it is, any changes listed below will disappear.
 #
-# Valid Prefixes: 
+# Valid Prefixes:
 #   bugfix
 #     - (fixes bugs)
 #   wip
@@ -45,8 +45,8 @@
 #     - (miscellaneous changes to server)
 #################################
 
-# Your name.  
-author: "
+# Your name.
+author: ""
 
 # Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
 delete-after: True
@@ -56,6 +56,6 @@ delete-after: True
 # SCREW THIS UP AND IT WON'T WORK.
 # Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
 # Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
-changes: 
+changes:
   - rscadd: "Added a changelog editing system that should cause fewer conflicts and more accurate timestamps."
   - rscdel: "Killed innocent kittens."


### PR DESCRIPTION
## About The Pull Request

Removes the announcements for the pirate event removing the ransom to prevent it and the delay before it spawns.

## Why It's Good For The Game

Every time the initial announcement for the event is made, before the pirates have even spawned, the crew immediately starts prepping for pirates and handing out weapons. This metagaming makes playing as pirate much less interesting and also causes the crew to be over prepared for other events such as blobs and admin events. This will happen even when there is no one that takes the pirate role or when the announcement is a false alarm. Removing the announcement should let the pirates have more choice in how to approach the role and also stop some of the metagaming involved.

## Changelog
:cl:
 balance: Space pirates have upgraded their fleets with advanced stealth equipment and have begun attacking stations unanounced.

/:cl:
