### PR TITLE
Five Finger Fillet but with Farts

### DIFF
--- a/html/changelogs/AngryKnees-Fart-Rework.yml
+++ b/html/changelogs/AngryKnees-Fart-Rework.yml
@@ -1,0 +1,6 @@
+author: "AngryKnees and FlufflyCthulu"
+
+delete-after: True
+
+changes:
+  - balance: "Farting now has a 0.5 second hard cooldown, and a 2 second soft cooldown."

--- a/russstation/code/modules/mob/living/carbon/emote.dm
+++ b/russstation/code/modules/mob/living/carbon/emote.dm
@@ -5,6 +5,10 @@
 	muzzle_ignore = TRUE
 	emote_type = EMOTE_AUDIBLE
 	vary = TRUE
+	cooldown = 0.5 SECONDS
+	var/safe_cooldown = 2 SECONDS
+	var/fail_chance = 20
+	var/stink_damage = 5
 
 /datum/emote/living/carbon/fart/get_sound(mob/living/user)
 	if(ishuman(user))
@@ -15,3 +19,20 @@
 						'russstation/sound/effects/mob_effects/poo2.ogg',
 						'russstation/sound/effects/mob_effects/poo3.ogg',
 						'russstation/sound/effects/mob_effects/poo4.ogg')
+
+/datum/emote/living/carbon/fart/check_cooldown(mob/user, intentional)
+	var/mob/living/carbon/U = user
+	if (U.IsStun())
+		return FALSE
+
+	var/previous_usage = user.emotes_used && user.emotes_used[src] // the base version changes user.emotes_used, so store it for later
+
+	. = ..() // standard cooldown check
+
+	if (!.) // if the cooldown check failed
+		U.adjustToxLoss(stink_damage)
+		U.Stun(1 SECONDS)
+		to_chat(U, "<span class='notice'>You feel a sharp pain in your stomach and fail to produce any flatulence.</span>")
+	else if (world.time - previous_usage < safe_cooldown && prob(fail_chance)) // if you're under the safe limit and failed a chance
+		U.adjustToxLoss(stink_damage)
+		to_chat(U, "<span class='notice'>You let out some gas, but it felt like something came with it.</span>")


### PR DESCRIPTION
## About The Pull Request

Gives the fart emote a two second soft cooldown and a half second hard cooldown. If you break the hard cooldown, you get stunned for a second and take some toxin damage. If you break the soft cooldown, you run a 20% chance of taking toxin damage.

## Why It's Good For The Game

Limits people's ability to spam fart, while introducing a gimmick for speed farting.

If you jam a hotkey as fast as you can, you'd take a lot of damage and about twice as slow as you can now. If you can hold the beat well enough, you can actually fart somewhat faster than you can now, but you'll slowly be taking toxin damage, preventing you from farting fast and forever.

## Changelog
:cl: AngryKnees and FlufflyChthulu
balance: Farting now has a 0.5 second hard cooldown, and a 2 second soft cooldown.
/:cl: