### PR TITLE
Dwarven language changes

### DIFF
--- a/RussStation.dme
+++ b/RussStation.dme
@@ -3016,6 +3016,7 @@
 #include "russstation\code\modules\hydroponics\grown\citrus.dm"
 #include "russstation\code\modules\hydroponics\grown\mystery_pod.dm"
 #include "russstation\code\modules\language\dwarvish.dm"
+#include "russstation\code\modules\language\language_holder.dm"
 #include "russstation\code\modules\mining\lavaland_farm_animals.dm"
 #include "russstation\code\modules\mining\ores_coins.dm"
 #include "russstation\code\modules\mining\smelter.dm"

--- a/html/changelogs/Fluffly-Dwarvish.yml
+++ b/html/changelogs/Fluffly-Dwarvish.yml
@@ -1,0 +1,8 @@
+
+author: "Fluffly Cthulu"
+
+delete-after: True
+
+changes:
+  - rscadd: "Dwarves have reconnected with their roots and can now speak dwarvish."
+  - rscdel: "Dwarves can no longer speak or understand galactic common."

--- a/russstation/code/modules/language/language_holder.dm
+++ b/russstation/code/modules/language/language_holder.dm
@@ -1,0 +1,4 @@
+/datum/language_holder/dwarf
+	understood_languages = list(/datum/language/dwarvish = list(LANGUAGE_ATOM))
+	spoken_languages = list(/datum/language/dwarvish = list(LANGUAGE_ATOM))
+	blocked_languages = list(/datum/language/common = list(LANGUAGE_ATOM))

--- a/russstation/code/modules/mob/living/carbon/human/species_types/dwarf.dm
+++ b/russstation/code/modules/mob/living/carbon/human/species_types/dwarf.dm
@@ -15,6 +15,7 @@
 	coldmod = 0.85
 	punchdamagehigh = 11 //fist fighting with dorfs is very dangerous
 	mutanteyes = /obj/item/organ/eyes/night_vision
+	species_language_holder = /datum/language_holder/dwarf
 
 /datum/species/dwarf/on_species_gain(mob/living/carbon/human/C, datum/species/old_species, pref_load)
 	. = ..()
@@ -22,7 +23,6 @@
 	C.bubble_file = 'russstation/icons/mob/talk.dmi'
 	C.bubble_icon = "dwarf"
 	var/dwarf_hair = pick("Beard (Dwarf)", "Beard (Very Long)", "Beard (Full)")
-	C.grant_language(/datum/language/dwarvish)
 	C.facial_hairstyle = dwarf_hair
 	C.update_hair()
 


### PR DESCRIPTION
## About The Pull Request

Dwarves now properly receive the dwarvish language which was already implemented but not working. Dwarves can no longer understand or speak galactic common.

## Why It's Good For The Game

Dwarves should already have been speaking dwarvish and removing common should discourage them from going to the station.

## Changelog
:cl:
add: Dwarves have reconnected with their roots and can now speak dwarvish.
del: Dwarves can no longer speak or understand galactic common.
/:cl:
