### PR TITLE
Suicide Hotkey

### DIFF
--- a/RussStation.dme
+++ b/RussStation.dme
@@ -3002,6 +3002,7 @@
 #include "russstation\code\datums\achievements\boss_achievements.dm"
 #include "russstation\code\datums\achievements\boss_scores.dm"
 #include "russstation\code\datums\components\crafting\smeltery.dm"
+#include "russstation\code\datums\keybinding\human.dm"
 #include "russstation\code\datums\ruins\lavaland.dm"
 #include "russstation\code\game\atmos.dm"
 #include "russstation\code\game\area\areas\ruins\lavaland.dm"

--- a/code/modules/client/verbs/suicide.dm
+++ b/code/modules/client/verbs/suicide.dm
@@ -21,32 +21,21 @@
 		if(mmi.brainmob)
 			mmi.brainmob.suiciding = suicide_state
 
-/* honk start - allow suicide to be triggered without requiring a confirmation
-/mob/living/carbon/human/verb/suicide()
-honk end */
-/mob/living/carbon/human/verb/suicide(intentional = FALSE as num)
+/mob/living/carbon/human/verb/suicide(intentional = FALSE as num) // honk -- added arg for intentional suicide via hotkey
 	set hidden = 1
 	if(!canSuicide())
 		return
 	var/oldkey = ckey
-	/* honk start - only ask for confirmation if intentional has not been set to true
-	var/confirm = alert("Are you sure you want to commit suicide?", "Confirm Suicide", "Yes", "No")
-	honk end */
 	// honk start - bypasses the confirmation if intentional is true
 	var/confirm = "No"
 	if(!intentional)
-		confirm = alert("Are you sure you want to commit suicide?", "Confirm Suicide", "Yes", "No")
+		confirm = alert("Are you sure you want to commit suicide?", "Confirm Suicide", "Yes", "No") // honk -- previous confirmation alert is moved here
 	// honk end
 	if(ckey != oldkey)
 		return
 	if(!canSuicide())
 		return
-	/* honk start - intentional is equivalent to saying yes on the confirmation
-	if(confirm == "Yes")
-	honk end */
-	// honk start - intentional is equivalent to saying yes on the confirmation
-	if(intentional || confirm == "Yes")
-	// honk end
+	if(intentional || confirm == "Yes") // honk -- intentional suicide does not require confirmation
 		set_suicide(TRUE) //need to be called before calling suicide_act as fuck knows what suicide_act will do with your suicider
 		var/obj/item/held_item = get_active_held_item()
 		if(held_item)

--- a/code/modules/client/verbs/suicide.dm
+++ b/code/modules/client/verbs/suicide.dm
@@ -21,17 +21,32 @@
 		if(mmi.brainmob)
 			mmi.brainmob.suiciding = suicide_state
 
+/* honk start - allow suicide to be triggered without requiring a confirmation
 /mob/living/carbon/human/verb/suicide()
+honk end */
+/mob/living/carbon/human/verb/suicide(intentional = FALSE as num)
 	set hidden = 1
 	if(!canSuicide())
 		return
 	var/oldkey = ckey
+	/* honk start - only ask for confirmation if intentional has not been set to true
 	var/confirm = alert("Are you sure you want to commit suicide?", "Confirm Suicide", "Yes", "No")
+	honk end */
+	// honk start - bypasses the confirmation if intentional is true
+	var/confirm = "No"
+	if(!intentional)
+		confirm = alert("Are you sure you want to commit suicide?", "Confirm Suicide", "Yes", "No")
+	// honk end
 	if(ckey != oldkey)
 		return
 	if(!canSuicide())
 		return
+	/* honk start - intentional is equivalent to saying yes on the confirmation
 	if(confirm == "Yes")
+	honk end */
+	// honk start - intentional is equivalent to saying yes on the confirmation
+	if(intentional || confirm == "Yes")
+	// honk end
 		set_suicide(TRUE) //need to be called before calling suicide_act as fuck knows what suicide_act will do with your suicider
 		var/obj/item/held_item = get_active_held_item()
 		if(held_item)

--- a/html/changelogs/Fluffly-Suicide-Hotline.yml
+++ b/html/changelogs/Fluffly-Suicide-Hotline.yml
@@ -1,0 +1,7 @@
+
+author: "Fluffly Cthulu"
+
+delete-after: True
+
+changes:
+  - rscadd: "Added a hotkey for suiciding. This hotkey will NOT ask for confirmation, use at your own risk."

--- a/russstation/code/datums/keybinding/human.dm
+++ b/russstation/code/datums/keybinding/human.dm
@@ -1,0 +1,10 @@
+/datum/keybinding/human/suicide
+	hotkey_keys = list("Unbound")
+	name = "suicide"
+	full_name = "Suicide"
+	description = "Kill yourself, <b style='color:red'>THERE IS NO CONFIRMATION</b>, use at your own risk"
+
+/datum/keybinding/human/suicide/down(client/user)
+	var/mob/living/carbon/human/H = user.mob
+	H.suicide(intentional = TRUE)
+	return TRUE


### PR DESCRIPTION
## About The Pull Request

This adds a new keybinding for players to quickly commit suicide (kys: keep yourself safe). This keybind does not ask for confirmation, if pressed the player will immediately attempt suicide. I do not take responsibility for any casualties that may occur as a result of this change.

## Why It's Good For The Game

Pleb can suicide with more flair... that's all I got.

## Changelog
:cl:
add: Added a hotkey for suiciding. This hotkey will NOT ask for confirmation, use at your own risk
/:cl:
