### PR TITLE
Lima SM canister fix

### DIFF
--- a/_maps/map_files/LimaStation/Lima.dmm
+++ b/_maps/map_files/LimaStation/Lima.dmm
@@ -20889,6 +20889,9 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/engine,
 /area/engine/engineering)
@@ -22787,9 +22790,6 @@
 /area/maintenance/central/secondary)
 "bav" = (
 /obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -30666,6 +30666,16 @@
 /obj/structure/filingcabinet/security,
 /turf/open/floor/vault,
 /area/security/nuke_storage)
+"fxc" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/engine,
+/area/engine/engineering)
 "fxo" = (
 /turf/open/floor/engine/co2,
 /area/engine/atmos)
@@ -37538,16 +37548,6 @@
 "nSF" = (
 /turf/open/floor/carpet/cyan,
 /area/hallway/primary/port)
-"nTj" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 4
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
 "nTk" = (
 /obj/machinery/ore_silo,
 /turf/open/floor/vault,
@@ -55073,15 +55073,15 @@ xRI
 eif
 akP
 aYZ
-jyy
-bTT
+aYZ
+aYZ
 aZo
 aZj
 aYK
 aZj
 aZo
-aYZ
-aYZ
+jyy
+bTT
 aZj
 aZB
 aYT
@@ -55331,14 +55331,14 @@ aJw
 aTp
 aUQ
 aVN
-nTj
+aVN
 avb
 ePQ
 bPo
 pwC
 ays
 bav
-bav
+fxc
 baw
 aZC
 amD
@@ -55587,15 +55587,15 @@ xRI
 aJx
 aTP
 aZc
-iJf
-etf
+aYR
+aYR
 fng
 xAc
 duS
 xAc
 fng
-aYR
-aYR
+iJf
+etf
 bax
 aYS
 ljQ
@@ -55844,15 +55844,15 @@ xRI
 aJx
 aUu
 aZe
-hhi
-hhi
+xxv
+xxv
 xAc
 sfs
 sfs
 sfs
 xAc
-xxv
-xxv
+hhi
+hhi
 bax
 aZD
 ljQ

--- a/html/changelogs/Fluffly-Lima-SM-Fix.yml
+++ b/html/changelogs/Fluffly-Lima-SM-Fix.yml
@@ -1,0 +1,7 @@
+
+author: "Fluffly Cthulu"
+
+delete-after: True
+
+changes:
+  - bugfix: "Swapped the canister connections for Lima's SM."


### PR DESCRIPTION
## About The Pull Request

![image](https://user-images.githubusercontent.com/2520037/79672120-3ce96a00-819d-11ea-9959-4c40fb6412f4.png)

## Why It's Good For The Game

Gasses produced by the SM can be filtered to canisters prior to the waste filters.


## Changelog
:cl:
bugfix: Swapped the canister connections for Lima's SM.
/:cl:
