### PR TITLE
More Lima Updates - July 2020 Edition

### DIFF
--- a/_maps/map_files/LimaStation/Lima.dmm
+++ b/_maps/map_files/LimaStation/Lima.dmm
@@ -12341,7 +12341,7 @@
 /area/crew_quarters/kitchen)
 "aCp" = (
 /obj/machinery/door/window/eastright{
-	name = "Hydroponics Delivery";
+	name = "Kitchen Delivery";
 	req_access_txt = "35"
 	},
 /obj/effect/turf_decal/delivery,
@@ -30085,10 +30085,13 @@
 /turf/open/floor/plasteel,
 /area/hydroponics/garden)
 "cYZ" = (
-/obj/structure/rack,
-/obj/item/clothing/suit/hazardvest,
+/obj/machinery/door/airlock/engineering/glass{
+	name = "Engineering-Atmospherics";
+	req_access_txt = "11;24"
+	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/engineering)
 "dam" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 9
@@ -30428,7 +30431,7 @@
 	},
 /obj/machinery/door/airlock/engineering/glass/critical{
 	name = "Supermatter Engine Room";
-	req_access = "10;24"
+	req_one_access_txt = "10;24"
 	},
 /turf/open/floor/engine,
 /area/engine/supermatter)
@@ -30898,6 +30901,7 @@
 	name = "Engineering RC";
 	pixel_y = -30
 	},
+/obj/structure/closet/crate/solarpanel_small,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "dTw" = (
@@ -32897,7 +32901,7 @@
 	},
 /obj/structure/cable/layer1,
 /obj/structure/cable,
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel,
 /area/engine/engine_smes)
 "gye" = (
 /obj/item/clothing/under/rank/prisoner,
@@ -40673,10 +40677,10 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "rbm" = (
-/obj/structure/closet/crate/solarpanel_small,
-/obj/machinery/light,
+/obj/structure/rack,
+/obj/item/clothing/suit/hazardvest,
 /turf/open/floor/plasteel,
-/area/engine/engineering)
+/area/engine/atmos)
 "rbo" = (
 /obj/effect/landmark/blobstart,
 /turf/open/floor/grass,
@@ -41178,6 +41182,7 @@
 "rLj" = (
 /obj/structure/table,
 /obj/item/pipe_dispenser,
+/obj/machinery/light,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "rLM" = (
@@ -43149,7 +43154,7 @@
 	},
 /obj/machinery/door/airlock/engineering/glass/critical{
 	name = "Supermatter Engine Room";
-	req_access = "10;24"
+	req_one_access_txt = "10;24"
 	},
 /turf/open/floor/engine,
 /area/engine/supermatter)
@@ -59367,9 +59372,9 @@ pVl
 iPs
 xUm
 awC
-rbm
-pVl
+uVd
 cYZ
+fLc
 btT
 bgW
 nJG
@@ -60397,7 +60402,7 @@ lly
 awD
 rHu
 bZw
-fLc
+rbm
 btT
 bha
 aTE

--- a/_maps/map_files/LimaStation/Lima.dmm
+++ b/_maps/map_files/LimaStation/Lima.dmm
@@ -1478,11 +1478,11 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
-/obj/structure/sign/poster/official/random{
-	pixel_y = 32
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 8
+	},
+/obj/machinery/airalarm{
+	pixel_y = 24
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
@@ -23811,8 +23811,14 @@
 	name = "First-Aid Supplies";
 	req_access_txt = "5"
 	},
-/obj/item/storage/firstaid/regular,
-/obj/item/storage/firstaid/regular,
+/obj/item/storage/firstaid/regular{
+	pixel_x = 4;
+	pixel_y = -4
+	},
+/obj/item/storage/firstaid/regular{
+	pixel_x = 4;
+	pixel_y = -4
+	},
 /obj/item/storage/firstaid/regular,
 /obj/item/storage/firstaid/regular,
 /turf/open/floor/plasteel/white,
@@ -27274,6 +27280,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/keycard_auth{
+	pixel_y = -24
+	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/heads/cmo)
 "bjR" = (
@@ -28218,8 +28227,14 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/item/storage/firstaid/o2,
-/obj/item/storage/firstaid/o2,
+/obj/item/storage/firstaid/o2{
+	pixel_x = 4;
+	pixel_y = -4
+	},
+/obj/item/storage/firstaid/o2{
+	pixel_x = 4;
+	pixel_y = -4
+	},
 /obj/item/storage/firstaid/toxin,
 /obj/item/storage/firstaid/toxin,
 /turf/open/floor/plasteel/white,
@@ -28251,8 +28266,14 @@
 /area/medical/storage)
 "brp" = (
 /obj/structure/table,
-/obj/item/storage/firstaid/brute,
-/obj/item/storage/firstaid/brute,
+/obj/item/storage/firstaid/brute{
+	pixel_x = 4;
+	pixel_y = -4
+	},
+/obj/item/storage/firstaid/brute{
+	pixel_x = 4;
+	pixel_y = -4
+	},
 /obj/item/storage/firstaid/fire,
 /obj/item/storage/firstaid/fire,
 /turf/open/floor/plasteel/white,
@@ -30434,12 +30455,12 @@
 /turf/open/floor/plasteel/dark,
 /area/security/courtroom)
 "duS" = (
-/obj/machinery/door/airlock/engineering/glass{
-	name = "Supermatter Engine Room";
-	req_access_txt = "10;24"
-	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
+	},
+/obj/machinery/door/airlock/engineering/glass/critical{
+	name = "Supermatter Engine Room";
+	req_access = "10;24"
 	},
 /turf/open/floor/engine,
 /area/engine/supermatter)
@@ -38511,6 +38532,10 @@
 /obj/effect/turf_decal/bot_red,
 /turf/open/floor/plasteel/dark,
 /area/gateway)
+"obj" = (
+/obj/machinery/portable_atmospherics/canister/air,
+/turf/open/floor/engine/air,
+/area/engine/atmos)
 "obk" = (
 /turf/closed/wall,
 /area/crew_quarters/dorms)
@@ -41260,7 +41285,9 @@
 /turf/closed/wall,
 /area/crew_quarters/heads/hop)
 "rQi" = (
-/obj/structure/closet/emcloset,
+/obj/structure/closet/emcloset{
+	anchored = 1
+	},
 /turf/open/floor/plating,
 /area/maintenance/port)
 "rRR" = (
@@ -43133,12 +43160,12 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "uou" = (
-/obj/machinery/door/airlock/engineering/glass{
-	name = "Supermatter Engine Room";
-	req_access_txt = "10;24"
-	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
+	},
+/obj/machinery/door/airlock/engineering/glass/critical{
+	name = "Supermatter Engine Room";
+	req_access = "10;24"
 	},
 /turf/open/floor/engine,
 /area/engine/supermatter)
@@ -45781,6 +45808,12 @@
 	},
 /turf/open/floor/plating,
 /area/quartermaster/sorting)
+"xBP" = (
+/obj/structure/sign/poster/official/random{
+	pixel_x = -32
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/central)
 "xCc" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -60647,7 +60680,7 @@ aUm
 hmr
 aUk
 aUj
-aUr
+aWV
 aWG
 aUr
 lXJ
@@ -62450,7 +62483,7 @@ aYA
 dcJ
 vSM
 csU
-csU
+obj
 csU
 vSM
 fsz
@@ -76534,7 +76567,7 @@ kzr
 adz
 adt
 adt
-fVE
+xBP
 aDi
 aCN
 fVE

--- a/_maps/map_files/LimaStation/Lima.dmm
+++ b/_maps/map_files/LimaStation/Lima.dmm
@@ -5829,6 +5829,9 @@
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 27
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "anA" = (
@@ -22596,10 +22599,6 @@
 /obj/structure/lattice,
 /turf/open/space/basic,
 /area/space/nearstation)
-"baf" = (
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/space)
 "bag" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -26922,6 +26921,9 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/blue,
+/obj/structure/extinguisher_cabinet{
+	pixel_y = -30
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/exam_room)
 "bjp" = (
@@ -27468,9 +27470,6 @@
 /obj/machinery/chem_heater,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
-"bke" = (
-/turf/closed/wall/r_wall,
-/area/space)
 "bkf" = (
 /obj/structure/window/reinforced{
 	dir = 1;
@@ -27637,12 +27636,6 @@
 "bku" = (
 /turf/closed/wall,
 /area/quartermaster/storage)
-"bkv" = (
-/turf/closed/wall/r_wall/rust,
-/area/space)
-"bkw" = (
-/turf/open/floor/plating/airless,
-/area/space)
 "bkx" = (
 /obj/effect/decal/cleanable/shreds,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -27701,50 +27694,17 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/airless,
 /area/space)
-"bkI" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating/airless,
-/area/space)
-"bkJ" = (
-/turf/open/floor/plasteel/airless,
-/area/space)
-"bkK" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/closed/wall/r_wall,
-/area/space)
 "bkL" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/closed/wall/r_wall/rust,
-/area/space)
-"bkM" = (
-/obj/effect/decal/cleanable/oil,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/airless,
-/area/space)
+/area/space/nearstation)
 "bkN" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/item/a_gift/anything{
 	name = "A Surprise"
 	},
 /turf/open/floor/plasteel/airless,
-/area/space)
-"bkO" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/barricade/wooden,
-/turf/open/floor/plating/airless,
-/area/space)
-"bkP" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating/airless,
-/area/space)
-"bkQ" = (
-/obj/structure/barricade/wooden,
-/turf/open/floor/plating/airless,
-/area/space)
-"bkR" = (
-/obj/effect/decal/fakelattice,
-/turf/open/space/basic,
-/area/space)
+/area/space/nearstation)
 "bkS" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/table/reinforced,
@@ -28568,6 +28528,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 8
 	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 27
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bsW" = (
@@ -28649,6 +28612,9 @@
 "btv" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 27
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
@@ -33208,6 +33174,10 @@
 /mob/living/simple_animal/butterfly,
 /turf/open/floor/grass,
 /area/security/prison)
+"gQP" = (
+/obj/machinery/portable_atmospherics/canister/air,
+/turf/open/floor/engine/air,
+/area/engine/atmos)
 "gQU" = (
 /turf/closed/wall,
 /area/library)
@@ -36781,6 +36751,12 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
+"lJr" = (
+/obj/structure/sign/poster/official/random{
+	pixel_x = -32
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/central)
 "lJW" = (
 /turf/open/floor/plasteel,
 /area/maintenance/central)
@@ -38532,10 +38508,6 @@
 /obj/effect/turf_decal/bot_red,
 /turf/open/floor/plasteel/dark,
 /area/gateway)
-"obj" = (
-/obj/machinery/portable_atmospherics/canister/air,
-/turf/open/floor/engine/air,
-/area/engine/atmos)
 "obk" = (
 /turf/closed/wall,
 /area/crew_quarters/dorms)
@@ -39620,6 +39592,14 @@
 /obj/machinery/vending/games,
 /turf/open/floor/plasteel,
 /area/storage/art)
+"pBE" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 27
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/central)
 "pBK" = (
 /obj/structure/window,
 /turf/open/floor/carpet/green,
@@ -45808,12 +45788,6 @@
 	},
 /turf/open/floor/plating,
 /area/quartermaster/sorting)
-"xBP" = (
-/obj/structure/sign/poster/official/random{
-	pixel_x = -32
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/central)
 "xCc" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -53977,10 +53951,10 @@ gfQ
 gfQ
 gfQ
 gfQ
-baf
+fsz
 gfQ
 gfQ
-baf
+fsz
 gfQ
 gfQ
 nab
@@ -61622,7 +61596,7 @@ fsz
 fsz
 fsz
 fsz
-baf
+fsz
 gfQ
 gfQ
 eoG
@@ -62483,7 +62457,7 @@ aYA
 dcJ
 vSM
 csU
-obj
+gQP
 csU
 vSM
 fsz
@@ -62621,7 +62595,7 @@ gfQ
 gfQ
 gfQ
 gfQ
-baf
+fsz
 fsz
 gfQ
 fsz
@@ -63136,7 +63110,7 @@ gfQ
 gfQ
 gfQ
 fsz
-baf
+fsz
 fsz
 gks
 gfQ
@@ -64939,7 +64913,7 @@ gfQ
 fsz
 gfQ
 fsz
-baf
+fsz
 fsz
 gks
 eWe
@@ -76567,7 +76541,7 @@ kzr
 adz
 adt
 adt
-xBP
+lJr
 aDi
 aCN
 fVE
@@ -76824,7 +76798,7 @@ aGY
 bcy
 bcy
 bcy
-bcy
+pBE
 bdb
 bto
 aIg
@@ -79364,7 +79338,7 @@ gfQ
 gfQ
 fsz
 fsz
-baf
+fsz
 gfQ
 kQm
 oCD
@@ -85507,18 +85481,18 @@ gfQ
 gfQ
 gfQ
 gfQ
-pCh
-pCh
-pCh
-pCh
-pCh
-pCh
-pCh
-pCh
-pCh
-pCh
-pCh
-pCh
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
 gfQ
 gfQ
 gfQ
@@ -85764,18 +85738,18 @@ gfQ
 gfQ
 gfQ
 gfQ
-pCh
-pCh
-pCh
-pCh
-pCh
-pCh
-pCh
-pCh
-pCh
-pCh
-pCh
-pCh
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
 gfQ
 gfQ
 gfQ
@@ -85798,7 +85772,7 @@ gfQ
 gfQ
 fsz
 fsz
-baf
+fsz
 gfQ
 ucx
 avA
@@ -86008,18 +85982,18 @@ gfQ
 gfQ
 gfQ
 gfQ
-pCh
-pCh
-pCh
-pCh
-pCh
-pCh
-pCh
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
 oKW
-bke
-bkv
-bkv
-bke
+oKW
+rOI
+rOI
+oKW
 rOI
 rOI
 rOI
@@ -86027,16 +86001,16 @@ oKW
 oKW
 rOI
 oKW
-pCh
-pCh
-pCh
-pCh
-pCh
-pCh
-pCh
-pCh
-pCh
-pCh
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
 gfQ
 gfQ
 gfQ
@@ -86264,14 +86238,14 @@ gfQ
 gfQ
 gfQ
 gfQ
-pCh
-pCh
-pCh
-pCh
-pCh
-pCh
-pCh
-pCh
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
 rOI
 oWT
 oWT
@@ -86284,16 +86258,16 @@ oWT
 oWT
 oWT
 rOI
-pCh
-pCh
-pCh
-pCh
-pCh
-pCh
-pCh
-pCh
-pCh
-pCh
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
 gfQ
 gfQ
 gfQ
@@ -86516,18 +86490,18 @@ gfQ
 gfQ
 gfQ
 gfQ
-bkv
-bkv
-bkv
-bke
+rOI
+rOI
+rOI
+oKW
 oKW
 oKW
 rOI
 oKW
-pCh
-pCh
-pCh
-pCh
+gfQ
+gfQ
+gfQ
+gfQ
 oKW
 rOI
 oKW
@@ -86545,12 +86519,12 @@ oKW
 rif
 rif
 rif
-pCh
-pCh
-pCh
-pCh
-pCh
-pCh
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
 gfQ
 gfQ
 gfQ
@@ -86772,11 +86746,11 @@ gfQ
 gfQ
 gfQ
 gfQ
-bke
-bke
-bkv
-bke
-bke
+oKW
+oKW
+rOI
+oKW
+oKW
 rOI
 rOI
 oKW
@@ -86802,14 +86776,14 @@ rOI
 rOI
 rif
 rif
-pCh
-pCh
-pCh
-pCh
-pCh
-pCh
-pCh
-pCh
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
 gfQ
 gfQ
 gfQ
@@ -87028,12 +87002,12 @@ gfQ
 gfQ
 gfQ
 gfQ
-bke
-bke
-bkw
-bkH
-bkH
-bkv
+oKW
+oKW
+fkv
+hmI
+hmI
+rOI
 rOI
 hmI
 hmI
@@ -87059,14 +87033,14 @@ hmI
 rOI
 tUB
 hnG
-pCh
-pCh
-pCh
-pCh
-pCh
-pCh
-pCh
-pCh
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
 gfQ
 gfQ
 gfQ
@@ -87285,12 +87259,12 @@ gfQ
 gfQ
 gfQ
 gfQ
-bkv
-bkv
-bkH
-bkI
-bkM
-bkH
+rOI
+rOI
+hmI
+oWT
+qIL
+hmI
 hmI
 oWT
 hmI
@@ -87318,12 +87292,12 @@ uLe
 hnG
 fuD
 akq
-pCh
-pCh
-pCh
-pCh
-pCh
-pCh
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
 gfQ
 gfQ
 gfQ
@@ -87542,11 +87516,11 @@ gfQ
 gfQ
 gfQ
 gfQ
-bke
-bkv
-bkH
-bkH
-bkH
+oKW
+rOI
+hmI
+hmI
+hmI
 bkH
 hmI
 oWT
@@ -87575,12 +87549,12 @@ uLe
 akq
 uMD
 akq
-pCh
-pCh
-pCh
-pCh
-pCh
-pCh
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
 gfQ
 gfQ
 gfQ
@@ -87799,12 +87773,12 @@ gfQ
 gfQ
 gfQ
 gfQ
-bkv
-bke
-bkH
-bkH
-bke
-bkv
+rOI
+oKW
+hmI
+hmI
+oKW
+rOI
 oKW
 gyP
 oWT
@@ -87832,12 +87806,12 @@ uLe
 uLe
 ijL
 akq
-pCh
-pCh
-pCh
-pCh
-pCh
-pCh
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
 gfQ
 gfQ
 gfQ
@@ -88056,12 +88030,12 @@ gfQ
 gfQ
 gfQ
 gfQ
-bkv
-bke
-bkI
-bkK
-bkv
-bke
+rOI
+oKW
+oWT
+fnK
+rOI
+oKW
 rOI
 oKW
 oWT
@@ -88089,12 +88063,12 @@ fkv
 fkv
 hXq
 akq
-pCh
-pCh
-pCh
-pCh
-pCh
-pCh
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
 gfQ
 gfQ
 gfQ
@@ -88313,11 +88287,11 @@ gfQ
 gfQ
 gfQ
 gfQ
-bke
-bke
-bkJ
+oKW
+oKW
+uLe
 bkL
-bkK
+fnK
 bkN
 rOI
 bkx
@@ -88346,12 +88320,12 @@ uLe
 uLe
 uLe
 hnG
-pCh
-pCh
-pCh
-pCh
-pCh
-pCh
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
 gfQ
 gfQ
 gfQ
@@ -88570,12 +88544,12 @@ gfQ
 gfQ
 gfQ
 gfQ
-bkv
-bkv
-bkH
+rOI
+rOI
+hmI
 bkL
-bkv
-bkv
+rOI
+rOI
 oKW
 oKW
 hmI
@@ -88603,12 +88577,12 @@ fkv
 uLe
 uLe
 hnG
-pCh
-pCh
-pCh
-pCh
-pCh
-pCh
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
 gfQ
 gfQ
 gfQ
@@ -88827,12 +88801,12 @@ gfQ
 gfQ
 gfQ
 gfQ
-bke
-bke
-bkH
-bkH
+oKW
+oKW
+hmI
+hmI
 bkL
-bke
+oKW
 oKW
 bFs
 oWT
@@ -88860,8 +88834,8 @@ uLe
 uLe
 fkv
 rOI
-pCh
-pCh
+gfQ
+gfQ
 gfQ
 gfQ
 gfQ
@@ -89084,12 +89058,12 @@ gfQ
 gfQ
 gfQ
 gfQ
-bke
-bkv
-bkI
-bkH
-bkH
-bkH
+oKW
+rOI
+oWT
+hmI
+hmI
+hmI
 hmI
 oWT
 oWT
@@ -89117,8 +89091,8 @@ oKW
 oKW
 rOI
 rOI
-pCh
-pCh
+gfQ
+gfQ
 gfQ
 gfQ
 gfQ
@@ -89138,7 +89112,7 @@ gfQ
 gfQ
 gfQ
 fsz
-baf
+fsz
 fsz
 ucx
 cQk
@@ -89341,13 +89315,13 @@ gfQ
 gfQ
 gfQ
 gfQ
-bke
-bke
-bkH
-bkH
-bkH
-bkH
-bkI
+oKW
+oKW
+hmI
+hmI
+hmI
+hmI
+oWT
 oWT
 hmI
 hmI
@@ -89370,12 +89344,12 @@ hAK
 oWT
 hmI
 oKW
-pCh
-pCh
-pCh
-pCh
-pCh
-pCh
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
 gfQ
 gfQ
 gfQ
@@ -89598,14 +89572,14 @@ gfQ
 gfQ
 gfQ
 gfQ
-bkv
-bkv
-bkw
-bkH
-bkH
-bke
-bke
-bkH
+rOI
+rOI
+fkv
+hmI
+hmI
+oKW
+oKW
+hmI
 hmI
 fkv
 rOI
@@ -89614,10 +89588,10 @@ rOI
 oKW
 oKW
 hAK
-bkI
-bkw
-bkP
-bkR
+oWT
+fkv
+akq
+mRi
 mRi
 mRi
 mRi
@@ -89627,11 +89601,11 @@ hmI
 oWT
 oWT
 rOI
-pCh
-pCh
-pCh
-pCh
-pCh
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
 gfQ
 gfQ
 gfQ
@@ -89718,7 +89692,7 @@ edn
 fsz
 fsz
 fsz
-gfQ
+fsz
 gfQ
 gfQ
 fsz
@@ -89856,26 +89830,26 @@ gfQ
 gfQ
 gfQ
 gfQ
-bkv
-bke
-bkv
-bkv
-bkv
-bke
-bke
-bkv
-bke
-bkv
-bkv
-bke
-bkv
-bkv
-bkH
-bkH
-bkw
-bkQ
-bkR
-bkR
+rOI
+oKW
+rOI
+rOI
+rOI
+oKW
+oKW
+rOI
+oKW
+rOI
+rOI
+oKW
+rOI
+rOI
+hmI
+hmI
+fkv
+hnG
+mRi
+mRi
 mRi
 mRi
 mRi
@@ -89884,10 +89858,10 @@ hmI
 ddR
 rOI
 rOI
-pCh
-pCh
-pCh
-pCh
+gfQ
+gfQ
+gfQ
+gfQ
 gfQ
 gfQ
 gfQ
@@ -90114,25 +90088,25 @@ gfQ
 gfQ
 gfQ
 gfQ
-bke
-bke
-bkv
-bkv
-bke
-bkv
-bkv
-bke
+oKW
+oKW
+rOI
+rOI
+oKW
+rOI
+rOI
+oKW
 gfQ
 gfQ
 gfQ
 gfQ
-bke
-bke
-bkv
-bkO
-bke
-bke
-bkv
+oKW
+oKW
+rOI
+bIx
+oKW
+oKW
+rOI
 rOI
 oKW
 rOI
@@ -90140,11 +90114,11 @@ oKW
 bIx
 oKW
 oKW
-pCh
-pCh
-pCh
-pCh
-pCh
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
 gfQ
 gfQ
 gfQ
@@ -90384,18 +90358,18 @@ gfQ
 gfQ
 gfQ
 gfQ
-bke
-bkI
-bkI
-bkI
-bkI
-bkI
-bkI
-bkI
-bkI
-bkI
-bkI
-bkv
+oKW
+oWT
+oWT
+oWT
+oWT
+oWT
+oWT
+oWT
+oWT
+oWT
+oWT
+rOI
 gfQ
 gfQ
 gfQ
@@ -90423,7 +90397,7 @@ gfQ
 gfQ
 gfQ
 gfQ
-baf
+fsz
 fsz
 ucx
 avA
@@ -90641,18 +90615,18 @@ gfQ
 gfQ
 gfQ
 gfQ
-bke
-bkv
-bkv
-bkv
-bkv
-bkv
-bke
-bke
-bke
-bkv
-bkv
-bke
+oKW
+rOI
+rOI
+rOI
+rOI
+rOI
+oKW
+oKW
+oKW
+rOI
+rOI
+oKW
 gfQ
 gfQ
 gfQ
@@ -91464,7 +91438,7 @@ gfQ
 fsz
 fsz
 fsz
-gfQ
+fsz
 gfQ
 gfQ
 fsz
@@ -94328,7 +94302,7 @@ gfQ
 gfQ
 gfQ
 fsz
-baf
+fsz
 fsz
 gks
 iyE
@@ -95355,7 +95329,7 @@ gfQ
 gfQ
 gfQ
 fsz
-baf
+fsz
 gfQ
 fsz
 gks
@@ -97412,7 +97386,7 @@ gfQ
 gfQ
 gfQ
 gfQ
-baf
+fsz
 fsz
 gfQ
 gfQ
@@ -97433,7 +97407,7 @@ gfQ
 fsz
 gfQ
 fsz
-baf
+fsz
 gfQ
 gfQ
 gfQ
@@ -97675,7 +97649,7 @@ gfQ
 gfQ
 gfQ
 fsz
-baf
+fsz
 fsz
 gks
 fWk
@@ -97931,7 +97905,7 @@ gfQ
 gfQ
 gfQ
 fsz
-baf
+fsz
 fsz
 fsz
 gfQ

--- a/_maps/map_files/LimaStation/Lima.dmm
+++ b/_maps/map_files/LimaStation/Lima.dmm
@@ -5743,7 +5743,9 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "anq" = (
-/obj/structure/closet/emcloset,
+/obj/structure/closet/emcloset{
+	anchored = 1
+	},
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
 "anr" = (
@@ -39446,7 +39448,9 @@
 /turf/closed/wall/r_wall,
 /area/engine/engine_smes)
 "psZ" = (
-/obj/structure/closet/emcloset,
+/obj/structure/closet/emcloset{
+	anchored = 1
+	},
 /turf/open/floor/plating,
 /area/engine/engineering)
 "ptc" = (
@@ -44706,6 +44710,12 @@
 /obj/structure/cable/layer1,
 /turf/open/floor/engine,
 /area/engine/engineering)
+"wqy" = (
+/obj/structure/closet/emcloset{
+	anchored = 1
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard)
 "wqO" = (
 /obj/machinery/modular_computer/console/preset/engineering{
 	dir = 1
@@ -91981,7 +91991,7 @@ gfQ
 gfQ
 gfQ
 vqr
-vEU
+wqy
 pkV
 amV
 vqr

--- a/_maps/map_files/LimaStation/Lima.dmm
+++ b/_maps/map_files/LimaStation/Lima.dmm
@@ -26788,7 +26788,6 @@
 "bja" = (
 /obj/structure/flora/junglebush/b,
 /obj/structure/flora/ausbushes/brflowers,
-/obj/machinery/light,
 /mob/living/carbon/monkey{
 	name = "Banjo"
 	},
@@ -27308,6 +27307,7 @@
 /area/maintenance/central/secondary)
 "bjT" = (
 /obj/structure/flora/ausbushes/ywflowers,
+/obj/machinery/light,
 /turf/open/floor/grass,
 /area/science/genetics)
 "bjU" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

I'm slowly turning into a map maintainer, apparently. Small fixes this time around. 

• Supermatter chamber doors shouldn't be impacted by Gr3y.T1d3 any more (Thank you, Tosha)
• Fixes a pipe color in atmospherics. (Thanks MrMelbert)
• Anchors down O2 closets in airlocks - north supermatter chamber, arrivals pods, and above the starboard solars.
• CMO office gets a keycard authentication device.
• Medbay lobby gets an air alarm. How many air alarms does a station need, anyway?
• Nudged the first aid kits around in medbay storage to better show there are multiple medkits stacked on top of each other.
• Medbay has fire extinguishers. Probably helpful for people who are on fire. (Thank you, Lord Lizardbane)
• Fixed a bunch of /area/space/nearstation/ that wasn't placed when I adjusted a bunch of space lattices previously.
• Added a shortcut between engineering proper and atmospherics, uses `req_access_txt = "11;24"` to open, so on lowpop situations, both station engineers and atmospheric techs can freely walk through from one department to the other instead of having to take a detour out into the hallway or through the supermatter chamber, but on standard population scenarios, they'll stay sectioned off and only the CE (or others who have innate engineering+atmos access) can go through.

## Why It's Good For The Game

QOL stuff.

## Changelog
:cl:
tweak: QOL fixes for Lima.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
