### PR TITLE
Brain damage gives borgs ion laws

### DIFF
--- a/RussStation.dme
+++ b/RussStation.dme
@@ -137,6 +137,7 @@
 #include "code\__DEFINES\~russ_defines\construction.dm"
 #include "code\__DEFINES\~russ_defines\is_helpers.dm"
 #include "code\__DEFINES\~russ_defines\keybinding.dm"
+#include "code\__DEFINES\~russ_defines\robots.dm"
 #include "code\__HELPERS\_lists.dm"
 #include "code\__HELPERS\_logging.dm"
 #include "code\__HELPERS\_string_lists.dm"

--- a/code/__DEFINES/~russ_defines/robots.dm
+++ b/code/__DEFINES/~russ_defines/robots.dm
@@ -1,0 +1,1 @@
+#define BRAIN_DAMAGE_LAWID "brain_damage"

--- a/code/modules/events/ion_storm.dm
+++ b/code/modules/events/ion_storm.dm
@@ -28,7 +28,7 @@
 
 /datum/round_event/ion_storm/start()
 	//AI laws
-	for(var/mob/living/silicon/ai/M in GLOB.alive_mob_list)
+	for(var/mob/living/silicon/M in GLOB.alive_mob_list) // honk - apply ion storm to borgs too
 		M.laws_sanity_check()
 		if(M.stat != DEAD && M.see_in_dark != 0)
 			if(prob(replaceLawsetChance))

--- a/code/modules/mob/living/brain/MMI.dm
+++ b/code/modules/mob/living/brain/MMI.dm
@@ -92,6 +92,11 @@
 		else
 			braintype = "Cyborg"
 
+		// honk start - damaged brains get ion laws; check amount so we don't keep adding more laws every time the brain is put in
+		if(brain.damage > BRAIN_DAMAGE_MILD && laws.get_law_amount(list(LAW_ION = 1) == 0))
+			laws.add_ion_law(generate_ion_law())
+		// honk end
+
 		SSblackbox.record_feedback("amount", "mmis_filled", 1)
 
 		log_game("[key_name(user)] has put the brain of [key_name(brainmob)] into an MMI at [AREACOORD(src)]")

--- a/code/modules/mob/living/brain/MMI.dm
+++ b/code/modules/mob/living/brain/MMI.dm
@@ -92,9 +92,11 @@
 		else
 			braintype = "Cyborg"
 
-		// honk start - damaged brains get ion laws; check amount so we don't keep adding more laws every time the brain is put in
-		if(brain.damage > BRAIN_DAMAGE_MILD && laws.get_law_amount(list(LAW_ION = 1) == 0))
-			laws.add_ion_law(generate_ion_law())
+		// honk start - damaged brains get ion laws; check id so we don't keep adding more laws every time the brain is put in
+		if(brain.damage > BRAIN_DAMAGE_MILD && laws.id == DEFAULT_AI_LAWID)
+			laws.replace_random_law(generate_ion_law(), list(LAW_INHERENT))
+			laws.id = "brain_damage" // id has to change or ion laws won't copy into borgs
+			log_game("Damaged brain of [key_name(B)] inserted into MMI with the laws [english_list(laws.get_law_list(TRUE, TRUE))]")
 		// honk end
 
 		SSblackbox.record_feedback("amount", "mmis_filled", 1)

--- a/code/modules/mob/living/brain/MMI.dm
+++ b/code/modules/mob/living/brain/MMI.dm
@@ -93,9 +93,9 @@
 			braintype = "Cyborg"
 
 		// honk start - damaged brains get ion laws; check id so we don't keep adding more laws every time the brain is put in
-		if(brain.damage > BRAIN_DAMAGE_MILD && laws.id == DEFAULT_AI_LAWID)
+		if(brain.damage > BRAIN_DAMAGE_MILD && laws.id != BRAIN_DAMAGE_LAWID)
 			laws.replace_random_law(generate_ion_law(), list(LAW_INHERENT))
-			laws.id = "brain_damage" // id has to change or ion laws won't copy into borgs
+			laws.id = BRAIN_DAMAGE_LAWID // id has to change or ion laws won't copy into borgs
 			log_game("Damaged brain of [key_name(B)] inserted into MMI with the laws [english_list(laws.get_law_list(TRUE, TRUE))]")
 		// honk end
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Isn't it weird that a messed up brain can get borged and suddenly you have a lucid crew member? Not anymore! Having at least mild brain damage will apply an ion law to an MMI.

Also fixed ion storms to apply to borgs because right now they're pointless.

## Why It's Good For The Game

laws are stupid, ion laws are less stupid, muh RP

## Changelog
:cl:
tweak: damaged brain gets ion laws in MMI
fix: ion storm applies to borgs
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
