### PR TITLE
Dwarfs Can Now Strip Others

### DIFF
--- a/russstation/code/modules/mob/living/carbon/human/species_types/dwarf.dm
+++ b/russstation/code/modules/mob/living/carbon/human/species_types/dwarf.dm
@@ -4,7 +4,7 @@
 	id = "dwarf"
 	default_color = "FFFFFF"
 	species_traits = list(EYECOLOR,HAIR,FACEHAIR,LIPS)
-	inherent_traits = list(TRAIT_NOBREATH,TRAIT_ADVANCEDTOOLUSER) // tool use for areaeditor; is this too much power?
+	inherent_traits = list(TRAIT_NOBREATH,TRAIT_ADVANCEDTOOLUSER,TRAIT_CAN_STRIP) // tool use for areaeditor; is this too much power?
 	mutant_bodyparts = list("wings" = "None")
 	limbs_id = "human"
 	use_skintones = 1


### PR DESCRIPTION
## About The Pull Request

Added a trait that lets Dwarf's strip others. (tested it and worked)

## Why It's Good For The Game

We do a little stripping, its called, we do a little stripping.

## Changelog
:cl:
fix: dwarfs can now strip others
/:cl:
