### PR TITLE
give dwarves virus immunity because of lavaland miasma

### DIFF
--- a/russstation/code/modules/mob/living/carbon/human/species_types/dwarf.dm
+++ b/russstation/code/modules/mob/living/carbon/human/species_types/dwarf.dm
@@ -9,6 +9,7 @@
 		TRAIT_NOBREATH,
 		TRAIT_ADVANCEDTOOLUSER,
 		TRAIT_CAN_STRIP,
+		TRAIT_VIRUSIMMUNE, // lavaland has miasma
 	)
 	mutant_bodyparts = list("wings" = "None")
 	limbs_id = "human"


### PR DESCRIPTION
## What is changing?

give dwarves virus immunity to tolerate potential miasma in lavaland atmos. might want to revert this if we ever implement dwarven medicine.

### Changes

* prevent dwarves getting sick from miasma

## Why these changes?

quality of life
