### PR TITLE
make talk bubble visible over HUD

### DIFF
--- a/russstation/code/modules/mob/say.dm
+++ b/russstation/code/modules/mob/say.dm
@@ -4,10 +4,11 @@
 	set name = ".say"
 	set hidden = TRUE
 
-	var/image/typing_indicator = image('icons/mob/talk.dmi', src, "default0", FLY_LAYER)
+	var/image/typing_indicator = image('icons/mob/talk.dmi', src, "default0", ABOVE_HUD_PLANE)
 	if(isliving(src)) //only living mobs have the bubble_icon var
 		var/mob/living/L = src
-		typing_indicator = image(L.bubble_file, src, L.bubble_icon + "0", FLY_LAYER) //get unique speech bubble icons for different species
+		//get unique speech bubble icons for different species
+		typing_indicator = image(L.bubble_file, src, L.bubble_icon + "0", ABOVE_HUD_PLANE)
 
 	typing_indicator.appearance_flags = APPEARANCE_UI_IGNORE_ALPHA
 


### PR DESCRIPTION
## What is changing?

Lift talking indicator bubble above player HUD so that it's more visible. Moved to the `ABOVE_HUD_PLANE` layer.

![text](https://user-images.githubusercontent.com/6422050/134234695-bec63a0c-fe07-4d81-9a34-f7b7158328b1.png)

### Changes

* make talk bubble more visible

## Why these changes?

HUD glasses obscure the talking bubble. I wanna know when people are typing.