### PR TITLE
swap in skaven supplies in survival boxes

### DIFF
--- a/RussStation.dme
+++ b/RussStation.dme
@@ -3880,6 +3880,7 @@
 #include "russstation\code\game\objects\items\grenades\clusterbuster.dm"
 #include "russstation\code\game\objects\items\stacks\sheets\leather.dm"
 #include "russstation\code\game\objects\items\stacks\sheets\mineral.dm"
+#include "russstation\code\game\objects\items\storage\boxes.dm"
 #include "russstation\code\game\objects\items\tanks\tank_types.dm"
 #include "russstation\code\game\objects\structures\plaques\static_plaques.dm"
 #include "russstation\code\game\objects\structures\signs\signs_maps.dm"

--- a/russstation/code/game/objects/items/storage/boxes.dm
+++ b/russstation/code/game/objects/items/storage/boxes.dm
@@ -1,0 +1,10 @@
+// easy hack for survival box, replace the vars that it instantiates.
+// tried making custom box type and it was a PAIN don't do it,
+// you'd have to assign new box on every outfit
+/obj/item/storage/box/survival/PopulateContents()
+	if(isskaven(loc))
+		name = "skaven survival box"
+		desc = "A box with the bare essentials of ensuring the survival of you and others. This one is labelled to contain supplies for Skavens."
+		mask_type = /obj/item/clothing/mask/gas/skaven
+		internal_type = /obj/item/tank/internals/skaven/belt/full
+	..()


### PR DESCRIPTION
## What is changing?

Survival boxes will have a Skaven mask and miasma tank if the player is Skaven.

## Why these changes?

Makes no sense for them to have spare oxygen tanks. Similar to how plasmamen work.