### PR TITLE
Heretic saccing consumes heart instead of gibbing

### DIFF
--- a/code/modules/antagonists/eldritch_cult/eldritch_knowledge.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_knowledge.dm
@@ -262,12 +262,12 @@
 			var/mob/living/carbon/human/current_target = heart.target
 			// honk start -- Replaces regular current_target.gib() code with code that qdels the heart if available, gibs if not.
 			var/obj/item/organ/heart/target_heart = current_target.getorganslot(ORGAN_SLOT_HEART)
-			if (!target_heart) {
-				current_target.gib()
-			} else {
+			if (target_heart)
 				qdel(target_heart)
 				current_target.visible_message(span_boldwarning("[current_target]'s heart is consumed!"))
-			}
+			else
+				current_target.gib()
+				current_target.visible_message(span_boldwarning("[current_target]'s body is consumed!"))
 			// honk end
 			heart.target = null
 			var/datum/antagonist/heretic/heretic_datum = carbon_user.mind.has_antag_datum(/datum/antagonist/heretic)

--- a/code/modules/antagonists/eldritch_cult/eldritch_knowledge.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_knowledge.dm
@@ -260,7 +260,15 @@
 		if(heart.target && heart.target.stat == DEAD)
 			to_chat(carbon_user,span_danger("Your patrons accepts your offer.."))
 			var/mob/living/carbon/human/current_target = heart.target
-			current_target.gib()
+			// honk start -- Replaces regular current_target.gib() code with code that qdels the heart if available, gibs if not.
+			var/obj/item/organ/heart/target_heart = current_target.getorganslot(ORGAN_SLOT_HEART)
+			if (!target_heart) {
+				current_target.gib()
+			} else {
+				qdel(target_heart)
+				current_target.visible_message(span_boldwarning("[current_target]'s heart is consumed!"))
+			}
+			// honk end
 			heart.target = null
 			var/datum/antagonist/heretic/heretic_datum = carbon_user.mind.has_antag_datum(/datum/antagonist/heretic)
 


### PR DESCRIPTION
## What is changing?

If you sacrifice your target as a heretic, it will now delete the targets heart if they have one, and will gib them if they don't.

### Changes

Heretic sacrifices no longer gib you into a head if you have a heart
Your heart will be removed upon being sacrificed
Will still gib you if there is no heart to remove

## Why these changes?

Heretics turning people into heads is super annoying -- if the heretic doesn't fullstrip their sacrifice target before sacrificing them, nearly all their items will be lost (including their entire backpack). It will also pretty much force a racechange to human for any non-human, since medbay will have to undergo the lengthy process of sourcing a humanized monkey, then transplanting your head onto said human body. This change makes it so that you are revivable in your normal corpse, but still requires some work on medbay's part other than standard wound tending + defib.

## Changelog

:cl:
qol: Heretics no longer gib sacrifice targets, instead their living heart will absorb the heart of the sacrifice victim.
/:cl: