### PR TITLE
Roundstart vamp + no ventcrawling

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/vampire.dm
+++ b/code/modules/mob/living/carbon/human/species_types/vampire.dm
@@ -22,9 +22,9 @@
 	var/obj/effect/proc_holder/spell/targeted/shapeshift/bat/batform //attached to the datum itself to avoid cloning memes, and other duplicates
 
 /datum/species/vampire/check_roundstart_eligible()
-	if(SSevents.holidays && SSevents.holidays[HALLOWEEN])
-		return TRUE
-	return FALSE
+	// honk start -- Remove holiday events check and just make it return true always
+	return TRUE
+	//honk end
 
 /datum/species/vampire/on_species_gain(mob/living/carbon/human/C, datum/species/old_species)
 	. = ..()

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/bat.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/bat.dm
@@ -40,7 +40,9 @@
 	. = ..()
 	AddElement(/datum/element/simple_flying)
 	ADD_TRAIT(src, TRAIT_SPACEWALK, INNATE_TRAIT)
+	/* honk start -- remove bat ventcrawling for balance
 	ADD_TRAIT(src, TRAIT_VENTCRAWLER_ALWAYS, INNATE_TRAIT)
+	honk end */
 
 /mob/living/simple_animal/hostile/retaliate/bat/sgt_araneus //Despite being a bat for... reasons, this is now a spider, and is one of the HoS' pets.
 	name = "Sergeant Araneus"

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/bat.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/bat.dm
@@ -70,3 +70,4 @@
 /mob/living/simple_animal/hostile/retaliate/bat/sgt_araneus/Initialize()
 	. = ..()
 	AddElement(/datum/element/pet_bonus, "chitters proudly!")
+	ADD_TRAIT(src, TRAIT_VENTCRAWLER_ALWAYS, INNATE_TRAIT) // honk -- add ventcrawler to araneus subtype so it can still ventcrawl


### PR DESCRIPTION
## What is changing?

Vampire is now a roundstart race and their bat form no longer has ventcrawling capabilities

### Changes

*Vampires can now be selected in character preferences
*Vampire bats can no longer ventcrawl

## Why these changes?

Some people want vampire as a roundstart race for roleplaying stuff (ex: a medical doctor who performs leech medicine on sick people by draining their blood) or other vamp shenanigans. The only real concern was with vampire bat form being able to ventcrawl (was way too strong) so ventcrawling has been removed from them.

## Changelog

🆑
add: Vampire is now a roundstart race
removal: Vampire bat form can no longer ventcrawl
/🆑