### PR TITLE
More missed merge stuff

### DIFF
--- a/_maps/map_files/CubeStation/Cube.dmm
+++ b/_maps/map_files/CubeStation/Cube.dmm
@@ -10106,6 +10106,10 @@
 /obj/structure/chair/stool/directional/west,
 /turf/open/floor/carpet/black,
 /area/commons/dorms)
+"fqW" = (
+/obj/machinery/power/energy_accumulator/tesla_coil,
+/turf/open/floor/iron,
+/area/engineering/engine_smes)
 "fre" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/corner{
@@ -23011,10 +23015,6 @@
 "mjS" = (
 /turf/open/floor/carpet/black,
 /area/commons/dorms)
-"mkg" = (
-/obj/machinery/rnd/server/master,
-/turf/open/floor/circuit/telecomms/server,
-/area/science/server)
 "mlf" = (
 /obj/effect/turf_decal/box/white{
 	color = "#EFB341"
@@ -43210,10 +43210,10 @@
 /turf/open/floor/plating,
 /area/science/lab)
 "wbt" = (
-/obj/machinery/field/generator,
 /obj/machinery/light/small{
 	dir = 1
 	},
+/obj/machinery/power/energy_accumulator/tesla_coil,
 /turf/open/floor/iron,
 /area/engineering/engine_smes)
 "wbG" = (
@@ -45601,6 +45601,10 @@
 /obj/effect/turf_decal/tile,
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
+"xeS" = (
+/obj/machinery/rnd/server/master,
+/turf/open/floor/circuit/telecomms/server,
+/area/science/server)
 "xeT" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -67887,7 +67891,7 @@ scx
 qAP
 jIb
 uos
-mkg
+xeS
 ydV
 fSl
 pRn
@@ -79930,7 +79934,7 @@ bsl
 fQP
 olq
 wbt
-otj
+fqW
 otj
 llU
 olq

--- a/_maps/map_files/CubeStation/Cube.dmm
+++ b/_maps/map_files/CubeStation/Cube.dmm
@@ -14130,7 +14130,7 @@
 	},
 /obj/effect/turf_decal/stripes/line,
 /mob/living/simple_animal/bot/secbot/beepsky/armsky{
-	icon_state = "secbot1";
+	icon_state = "secbot1"
 	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
@@ -23011,6 +23011,10 @@
 "mjS" = (
 /turf/open/floor/carpet/black,
 /area/commons/dorms)
+"mkg" = (
+/obj/machinery/rnd/server/master,
+/turf/open/floor/circuit/telecomms/server,
+/area/science/server)
 "mlf" = (
 /obj/effect/turf_decal/box/white{
 	color = "#EFB341"
@@ -67883,7 +67887,7 @@ scx
 qAP
 jIb
 uos
-cIM
+mkg
 ydV
 fSl
 pRn

--- a/_maps/map_files/EchoStation/EchoStation.dmm
+++ b/_maps/map_files/EchoStation/EchoStation.dmm
@@ -47287,6 +47287,10 @@
 /obj/effect/turf_decal/tile/purple,
 /turf/open/floor/iron/showroomfloor,
 /area/medical/chemistry)
+"ydD" = (
+/obj/machinery/power/energy_accumulator/tesla_coil,
+/turf/open/floor/plating,
+/area/engineering/main)
 "ydF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
@@ -88241,7 +88245,7 @@ ohR
 rvA
 aVk
 aVk
-tks
+ydD
 kKT
 jjW
 fxX

--- a/_maps/map_files/EchoStation/EchoStation.dmm
+++ b/_maps/map_files/EchoStation/EchoStation.dmm
@@ -16124,7 +16124,7 @@
 /turf/open/floor/iron/showroomfloor,
 /area/commons/vacant_room/office)
 "iBt" = (
-/obj/machinery/rnd/server,
+/obj/machinery/rnd/server/master,
 /turf/open/floor/plating{
 	icon_state = "platingdmg1"
 	},

--- a/_maps/map_files/LimaStation/Lima.dmm
+++ b/_maps/map_files/LimaStation/Lima.dmm
@@ -6349,6 +6349,10 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
+"bIy" = (
+/obj/machinery/rnd/server/master,
+/turf/open/floor/circuit/airless,
+/area/science/server)
 "bIA" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -94565,7 +94569,7 @@ dot
 bWJ
 fGx
 hlk
-iAt
+bIy
 fGe
 vhn
 vhn

--- a/_maps/map_files/LimaStation/Lima.dmm
+++ b/_maps/map_files/LimaStation/Lima.dmm
@@ -4487,6 +4487,10 @@
 /obj/effect/landmark/start/cyborg,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/ai_upload)
+"baQ" = (
+/obj/machinery/power/energy_accumulator/tesla_coil,
+/turf/open/floor/plating,
+/area/engineering/storage)
 "bbb" = (
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
@@ -6349,10 +6353,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
-"bIy" = (
-/obj/machinery/rnd/server/master,
-/turf/open/floor/circuit/airless,
-/area/science/server)
 "bIA" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -13303,6 +13303,10 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/office)
+"eVA" = (
+/obj/machinery/rnd/server/master,
+/turf/open/floor/circuit/airless,
+/area/science/server)
 "eVT" = (
 /obj/machinery/status_display/supply{
 	pixel_y = -30
@@ -64233,8 +64237,8 @@ aMv
 nBY
 nBY
 aYr
-nBY
-nBY
+baQ
+baQ
 wth
 rnq
 eim
@@ -94569,7 +94573,7 @@ dot
 bWJ
 fGx
 hlk
-bIy
+eVA
 fGe
 vhn
 vhn

--- a/config/config.txt
+++ b/config/config.txt
@@ -91,8 +91,14 @@ LOG_ADMIN
 ## log admin chat
 LOG_ADMINCHAT
 
+## log asset debug logs
+#LOG_ASSET
+
 ## log client access (logon/logoff)
 LOG_ACCESS
+
+## Enables log entries for logins that failed due to suspicious circumstances (banned player, CID randomiser, spoofed BYOND version, etc.) to a dedicated file.
+LOG_SUSPICIOUS_LOGIN
 
 ## log game actions (start of round, results, etc.)
 LOG_GAME
@@ -118,13 +124,13 @@ LOG_TELECOMMS
 ## log prayers
 LOG_PRAYER
 
-## log lawchanges
-LOG_LAW
+## log silocns
+LOG_SILICON
 
 ## log economy actions
 LOG_ECON
 
-## log crew manifest to seperate file
+## log crew manifest to separate file
 LOG_MANIFEST
 
 ## log job divide debugging information
@@ -151,6 +157,9 @@ LOG_CLONING
 
 ## log shuttle actions
 LOG_SHUTTLE
+
+## Log all timers on timer auto reset
+# LOG_TIMERS_ON_BUCKET_RESET
 
 ##Log camera pictures - Must have picture logging enabled
 PICTURE_LOGGING_CAMERA
@@ -275,9 +284,9 @@ BANAPPEALS https://discord.gg/honk
 ## Uncomment this to forbid admins from possessing the singularity.
 #FORBID_SINGULO_POSSESSION
 
-## Uncomment to show a popup 'reply to' window to every non-admin that receives an adminPM.
-## The intention is to make adminPMs more visible. (although I fnd popups annoying so this defaults to off)
-#POPUP_ADMIN_PM
+## Uncomment to give admins the ability to send a maptext popup to players.
+## Only fires when an admin requests it, not every ahelp.
+POPUP_ADMIN_PM
 
 ## Uncomment to allow special 'Easter-egg' events on special holidays such as seasonal holidays and stuff like 'Talk Like a Pirate Day' :3 YAARRR
 ALLOW_HOLIDAYS
@@ -307,6 +316,9 @@ TICKLAG 1
 NOTE_FRESH_DAYS 91.31055
 ## Notes older then this will be completely faded out.
 NOTE_STALE_DAYS 365.2422
+
+## Uncomment to allow drastic performence enhancemet measures to turn on automatically once there are equal or more clients than the configured amount (will also prompt admin for veto)
+#AUTO_LAG_SWITCH_POP 75
 
 ##Note: all population caps can be used with each other if desired.
 
@@ -515,6 +527,11 @@ DEFAULT_VIEW_SQUARE 15x15
 ## If enabled, only bans from these servers will be shown to admins using CentCom. The default sources list is an example.
 #CENTCOM_SOURCE_WHITELIST Beestation MRP,TGMC,FTL13
 
+## If uncommented, this will enable admin 2FA (two-factor authentication).
+## The URL admins will be asked to go to will be here, with %ID% being the ID
+## of their connection attempt.
+#ADMIN_2FA_URL https://example.com/id/%ID%
+
 #### DISCORD STUFFS ####
 ## MAKE SURE ALL SECTIONS OF THIS ARE FILLED OUT BEFORE ENABLING
 ## Discord IDs can be obtained by following this guide: https://support.discord.com/hc/en-us/articles/206346498-Where-can-I-find-my-User-Server-Message-ID-
@@ -530,3 +547,34 @@ DEFAULT_VIEW_SQUARE 15x15
 
 ## Add the ID of the role you want assigning here
 #DISCORD_ROLEID 000000000000000000
+
+## How long in seconds after which a hard delete is treated as causing lag. This can be a float and supports a precision as low as nanoseconds.
+#HARD_DELETES_OVERRUN_THRESHOLD 0.5
+
+## Once a typepath causes overrun from hard deletes this many times, stop hard deleting it on garbage collection failures. (set to 0 to disable)
+#HARD_DELETES_OVERRUN_LIMIT 0
+
+## The URL to the webhook for adminhelps to relay the urgent ahelp message to
+## If not set, will disable urgent ahelps.
+#ADMINHELP_WEBHOOK_URL
+
+## The urgent ahelp cooldown for a given player if they're alone on a server and need to send an urgent ahelp.
+URGENT_AHELP_COOLDOWN 300
+
+## The message that is sent to the discord if an urgent ahelp is sent. Useful for sending a role ping.
+#URGENT_AHELP_MESSAGE Ban ban ban ban
+
+## The message that the player receives whenever prompted whether they want to send an urgent ahelp or not.
+#URGENT_AHELP_USER_PROMPT This'll ping the admins!
+
+## The URL for the pfp of the webhook
+#ADMINHELP_WEBHOOK_PFP
+
+## The name of the webhook
+#ADMINHELP_WEBHOOK_NAME
+
+## Sets an MOTD of the server.
+## You can use this multiple times, and the MOTDs will be appended in order.
+## Based on config directory, so "motd.txt" points to "config/motd.txt"
+MOTD motd.txt
+#MOTD motd_extra.txt

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -152,13 +152,15 @@ ALLOW_AI_MULTICAM
 ## Uncomment to load the virtual reality hub map
 VIRTUAL_REALITY
 
-## Uncomment to load one of the missions from awaymissionconfig.txt at roundstart.
+## Uncomment to load one of the missions from awaymissionconfig.txt or away_missions/ at roundstart.
 ROUNDSTART_AWAY
 
 ## How long the delay is before the Away Mission gate opens. Default is half an hour.
 ## 600 is one minute.
 GATEWAY_DELAY 18000
 
+## The probability of the gateway mission being a config one
+CONFIG_GATEWAY_CHANCE 0
 
 ## ACCESS ###
 
@@ -294,6 +296,8 @@ SILICON_MAX_LAW_AMOUNT 12
 ##-------------------------------------------------------------------------------------------
 ## Uncommenting races will allow them to be choosen at roundstart while join_with_muntant_race is on. You'll need at least one.
 
+## See code/__DEFINES/DNA.dm for more options than the ones below.
+
 ## You probably want humans on your space station, but technically speaking you can turn them off without any ill effect
 ROUNDSTART_RACES human
 
@@ -309,15 +313,36 @@ ROUNDSTART_RACES skaven
 
 ## Races that are better than humans in some ways, but worse in others
 #ROUNDSTART_RACES jelly
-#ROUNDSTART_RACES golem
-#ROUNDSTART_RACES adamantine
-#ROUNDSTART_RACES plasma
-#ROUNDSTART_RACES diamond
-#ROUNDSTART_RACES gold
-#ROUNDSTART_RACES silver
-#ROUNDSTART_RACES uranium
 ROUNDSTART_RACES abductor
 #ROUNDSTART_RACES synth
+
+## Including all the various golem subtypes that are better than humans in some ways, but worse in others
+#ROUNDSTART_RACES iron_golem
+#ROUNDSTART_RACES adamantine_golem
+#ROUNDSTART_RACES plasma_golem
+#ROUNDSTART_RACES diamond_golem
+#ROUNDSTART_RACES gold_golem
+#ROUNDSTART_RACES silver_golem
+#ROUNDSTART_RACES uranium_golem
+#ROUNDSTART_RACES plasteel_golem
+#ROUNDSTART_RACES titanium_golem
+#ROUNDSTART_RACES plastitanium_golem
+#ROUNDSTART_RACES alloy_golem
+#ROUNDSTART_RACES wood_golem
+#ROUNDSTART_RACES sand_golem
+#ROUNDSTART_RACES glass_golem
+#ROUNDSTART_RACES bluespace_golem
+#ROUNDSTART_RACES bananium_golem
+#ROUNDSTART_RACES runic_golem
+#ROUNDSTART_RACES cloth_golem
+#ROUNDSTART_RACES plastic_golem
+#ROUNDSTART_RACES bronze_golem
+#ROUNDSTART_RACES cardboard_golem
+#ROUNDSTART_RACES leather_golem
+#ROUNDSTART_RACES durathread_golem
+#ROUNDSTART_RACES bone_golem
+#ROUNDSTART_RACES snow_golem
+#ROUNDSTART_RACES metallic_hydrogen_golem
 
 ## Races that are straight upgrades. If these are on expect powergamers to always pick them
 #ROUNDSTART_RACES diona
@@ -333,9 +358,6 @@ ROUNDSTART_RACES abductor
 ## Roundstart no-reset races
 ## Races defined here will not cause existing characters to be reset to human if they currently have a non-roundstart species defined.
 #ROUNDSTART_NO_HARD_CHECK felinid
-
-## Uncomment to give players the choice of joining as a human with mutant bodyparts before they join the game
-JOIN_WITH_MUTANT_HUMANS
 
 ##Overflow job. Default is assistant
 OVERFLOW_JOB Assistant
@@ -436,3 +458,11 @@ MAXFINE 2000
 
 ## How many played hours of DRONE_REQUIRED_ROLE required to be a Maintenance Done
 #DRONE_ROLE_PLAYTIME 40
+
+## Uncomment to enable SDQL spells
+## Warning: SDQL is a powerful tool and can break many things or expose security sensitive information.
+## Giving players access to it has major security concerns, be careful and deliberate when using this feature.
+#SDQL_SPELLS
+
+## Whether native FoV is enabled for all people.
+#NATIVE_FOV

--- a/config/iceruinblacklist.txt
+++ b/config/iceruinblacklist.txt
@@ -17,9 +17,13 @@
 #_maps/RandomRuins/IceRuins/icemoon_surface_asteroid.dmm
 #_maps/RandomRuins/IceRuins/icemoon_surface_hotsprings.dmm
 #_maps/RandomRuins/IceRuins/icemoon_surface_engioutpost.dmm
+#_maps/RandomRuins/IceRuins/icemoon_surface_pizza.dmm
 #_maps/RandomRuins/IceRuins/icemoon_underground_puzzle.dmm
 #_maps/RandomRuins/IceRuins/icemoon_underground_abandoned_village.dmm
 #_maps/RandomRuins/IceRuins/icemoon_underground_library.dmm
 #_maps/RandomRuins/IceRuins/icemoon_underground_wrath.dmm
 #_maps/RandomRuins/IceRuins/icemoon_underground_bathhouse.dmm
 #_maps/RandomRuins/AnywhereRuins/fountain_hall.dmm
+#_maps/RandomRuins/IceRuins/icemoon_underground_abandoned_homestead.dmm
+#_maps/RandomRuins/IceRuins/icemoon_underground_abandoned_plasma_facility.dmm
+#_maps/RandomRuins/IceRuins/icemoon_underground_frozen_comms.dmm

--- a/russstation/code/game/objects/items/spiritboard.dm
+++ b/russstation/code/game/objects/items/spiritboard.dm
@@ -48,4 +48,4 @@
 				if(M.client)
 					// display descriptive message in chat, but just the selected word in runechat
 					to_chat(M, span_blue("<B>The board spells out a message ... \"[selected]\"</B>"))
-					M.create_chat_message(src, raw_message = selected)
+					M.create_chat_message(src, M.get_random_understood_language(), selected)

--- a/russstation/code/game/structures/ghost_role_spawners.dm
+++ b/russstation/code/game/structures/ghost_role_spawners.dm
@@ -15,6 +15,7 @@
 	flavour_text = "You have arrived. After a journey from the Mountainhomes into the forbidding wilderness beyond, \
 	your harsh trek has finally ended. Whether by bolt, plow or hook, provide for youselves, ere the local fauna get hungry. A new chapter of dwarven history begins here \
 	at this place, \"Hammerflames\". Strike the earth!"
+	important_info = "Do not leave Lavaland or sabotage the mining base."
 
 /obj/effect/mob_spawn/human/dwarf_dorm/special(mob/living/carbon/human/new_spawn)
 	new_spawn.fully_replace_character_name(null,dwarf_name())
@@ -25,4 +26,4 @@
 	. = ..()
 	var/area/A = get_area(src)
 	if(A)
-		notify_ghosts("A dwarven dorm was made and ready to use in \the [A.name].", source = src, action=NOTIFY_ATTACK, flashwindow = FALSE, ignore_key = POLL_IGNORE_DWARF)
+		notify_ghosts("A dwarven dorm was made and ready to use in \the [A.name].", source = src, action = NOTIFY_ATTACK, flashwindow = FALSE, ignore_key = POLL_IGNORE_DWARF)


### PR DESCRIPTION
<!-- Fill out each section with text below the header. 
 You can view https://github.com/RussStation/RussStation/wiki/Contributing for a detailed description of the pull request process. -->

## What is changing?

Forgot to check for new config changes, so here they are. Also a couple missed map thingies and behavioral warning text for dorfs. Config settings are copied as is from tg, but I'd like to request enabling SDQL spells for admemes.

### Changes

* some config options
* dorf spawner reminds players to stay on lavaland
* master R&D servers on our maps
* spare tesla coils in engie storage

## Why these changes?

upstream parity, get rid of annoying admin message about out-of-date configs