### PR TITLE
prevent ice moon minor fauna messing up the station

### DIFF
--- a/RussStation.dme
+++ b/RussStation.dme
@@ -4179,6 +4179,7 @@
 #include "russstation\code\modules\mob\living\simple_animal\friendly\gondola.dm"
 #include "russstation\code\modules\mob\living\simple_animal\friendly\mouse.dm"
 #include "russstation\code\modules\mob\living\simple_animal\friendly\rabbit.dm"
+#include "russstation\code\modules\mob\living\simple_animal\hostile\ice_moon.dm"
 #include "russstation\code\modules\mob\living\simple_animal\hostile\megafauna\sif.dm"
 #include "russstation\code\modules\mob\living\simple_animal\hostile\retaliate\clown.dm"
 #include "russstation\code\modules\paperwork\paper_premade.dm"

--- a/russstation/code/modules/mob/living/simple_animal/hostile/ice_moon.dm
+++ b/russstation/code/modules/mob/living/simple_animal/hostile/ice_moon.dm
@@ -1,0 +1,21 @@
+// nerf ice moon minor fauna ability to destroy walls
+// reduce move force of strong mobs to prevent dislocating windows
+// STRONG force is just enough to push windows, so go one less to still push mobs
+
+/mob/living/simple_animal/hostile/asteroid/ice_whelp
+	environment_smash = ENVIRONMENT_SMASH_STRUCTURES
+	move_force = MOVE_FORCE_STRONG - 1
+
+/mob/living/simple_animal/hostile/asteroid/ice_demon
+	environment_smash = ENVIRONMENT_SMASH_STRUCTURES
+	move_force = MOVE_FORCE_STRONG - 1
+
+/mob/living/simple_animal/hostile/asteroid/polarbear
+	environment_smash = ENVIRONMENT_SMASH_STRUCTURES
+	move_force = MOVE_FORCE_STRONG - 1
+
+/mob/living/simple_animal/hostile/asteroid/wolf
+	environment_smash = ENVIRONMENT_SMASH_STRUCTURES
+
+/mob/living/simple_animal/hostile/asteroid/lobstrosity
+	environment_smash = ENVIRONMENT_SMASH_STRUCTURES


### PR DESCRIPTION
## What is changing?

Ice moon minor fauna (ice whelp, ice demon, polarbear, wolf, and lobstrosity) no longer able to break walls or push windows.

## Why these changes?

One of the biggest complaints about ice moon is how easily the station gets breached by wandering fauna. This prevents the small fry from breaking in effortlessly.