### PR TITLE
keep spiritboard on station & prevent its destruction, add to ghost orbit menu

### DIFF
--- a/russstation/code/game/objects/items/spiritboard.dm
+++ b/russstation/code/game/objects/items/spiritboard.dm
@@ -12,7 +12,6 @@
 	icon_state = "lboard"
 	inhand_icon_state = "clipboard"
 	w_class = WEIGHT_CLASS_NORMAL
-	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | ACID_PROOF
 	///Is the board ready for use? - Unused.
 	var/ready = TRUE
 	///How many users are nearby?

--- a/russstation/code/game/objects/items/spiritboard.dm
+++ b/russstation/code/game/objects/items/spiritboard.dm
@@ -12,12 +12,23 @@
 	icon_state = "lboard"
 	inhand_icon_state = "clipboard"
 	w_class = WEIGHT_CLASS_NORMAL
+	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | ACID_PROOF
 	///Is the board ready for use? - Unused.
 	var/ready = TRUE
 	///How many users are nearby?
 	var/list/users = list()
 	///Delay between each use
 	var/use_delay = 3 SECONDS
+
+/obj/item/spiritboard/Initialize(mapload)
+	. = ..()
+	// allow ghosts to orbit for easier haunting
+	SSpoints_of_interest.make_point_of_interest(src)
+
+/obj/item/spiritboard/ComponentInitialize()
+	. = ..()
+	// keep it on station so ghosts can keep using it
+	AddComponent(/datum/component/stationloving, TRUE, FALSE)
 
 /obj/item/spiritboard/attack_ghost(mob/dead/observer/user)
 	if(!isobserver(user))


### PR DESCRIPTION
## What is changing?

Give spiritboard the same protections that the nuke disk has so it's always somewhere on the station. Add it to points of interest (ghost orbit menu).

## Why these changes?

Spiritboard is a fun way for ghosts to interact with the living, but it can be destroyed or yeeted. Ensure it's around for use and make it easier for ghosts to find. Not sure if this is the best solution, open to alternative suggestions.