### PR TITLE
put metastation back in rotation

### DIFF
--- a/config/maps.txt
+++ b/config/maps.txt
@@ -14,7 +14,7 @@ Format:
 endmap
 
 map metastation
-	minplayers 25
+	votable
 endmap
 
 map deltastation


### PR DESCRIPTION
## What is changing?

Title

## Why these changes?

Now that we've had a couple weeks of IceCube exposure, it would be nice to have one more map in rotation. When more than 10 people are on Echo is out leaving only three maps, two of which are Cube. Meta seems to be the most popular /tg/ map.