### PR TITLE
Add setting for lobby music volume

### DIFF
--- a/RussStation.dme
+++ b/RussStation.dme
@@ -4330,6 +4330,7 @@
 #include "russstation\code\modules\admin\verbs\randomverbs.dm"
 #include "russstation\code\modules\antagonists\nukeop\equipment\pinpointer.dm"
 #include "russstation\code\modules\cargo\packs.dm"
+#include "russstation\code\modules\client\preferences\sound.dm"
 #include "russstation\code\modules\client\preferences\species_features\skaven.dm"
 #include "russstation\code\modules\clothing\clothing.dm"
 #include "russstation\code\modules\clothing\dwarf_clothes.dm"

--- a/code/game/sound.dm
+++ b/code/game/sound.dm
@@ -200,6 +200,7 @@ distance_multiplier - Can be used to multiply the distance at which the sound is
 	UNTIL(SSticker.login_music) //wait for SSticker init to set the login music
 
 	if(prefs && (prefs.toggles & SOUND_LOBBY))
+		vol = prefs.read_preference(/datum/preference/numeric/lobby_music_volume) // honk: allow control of lobby music volume
 		SEND_SOUND(src, sound(SSticker.login_music, repeat = 0, wait = 0, volume = vol, channel = CHANNEL_LOBBYMUSIC)) // MAD JAMS
 
 /proc/get_rand_frequency()

--- a/russstation/code/modules/client/preferences/sound.dm
+++ b/russstation/code/modules/client/preferences/sound.dm
@@ -1,0 +1,14 @@
+/datum/preference/numeric/lobby_music_volume
+	category = PREFERENCE_CATEGORY_GAME_PREFERENCES
+	savefile_key = "lobby_music_volume"
+	savefile_identifier = PREFERENCE_PLAYER
+
+	minimum = 0
+	maximum = 100
+
+/datum/preference/numeric/lobby_music_volume/create_default_value()
+	return 85
+
+/datum/preference/numeric/lobby_music_volume/apply_to_client_updated(client/client, value)
+	if(client.mob)
+		client.mob.set_sound_channel_volume(CHANNEL_LOBBYMUSIC, value)

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/game_preferences/sound.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/game_preferences/sound.tsx
@@ -1,0 +1,7 @@
+import { FeatureNumberInput, FeatureNumeric } from "../base";
+
+export const lobby_music_volume: FeatureNumeric = {
+  name: "Lobby music volume",
+  category: "SOUND",
+  component: FeatureNumberInput,
+};


### PR DESCRIPTION
## What is changing?

Able to change the volume of lobby (and round end) music.

### Changes

* add lobby music volume to game preferences

## Why these changes?

Lobby music is LOUD and hurts my ears but I wanna listen to the jams.

If you think I should just submit this upstream instead I can do that, or we can trial it here and then do that, or whatever.