### PR TITLE
remove vision obscuration on skaven masks

### DIFF
--- a/russstation/code/modules/clothing/masks/gasmask.dm
+++ b/russstation/code/modules/clothing/masks/gasmask.dm
@@ -15,3 +15,4 @@
 	visor_flags_cover = NONE
 	resistance_flags = NONE
 	tint = 0
+	has_fov = FALSE


### PR DESCRIPTION
## What is changing?

title

## Why these changes?

Skavens have life hard enough as is, at least let them see behind themselves like clowns.