### PR TITLE
add bread suicide similar to the smite

### DIFF
--- a/RussStation.dme
+++ b/RussStation.dme
@@ -4380,6 +4380,7 @@
 #include "russstation\code\game\objects\items\toys.dm"
 #include "russstation\code\game\objects\items\weaponry.dm"
 #include "russstation\code\game\objects\items\devices\radio\intercom.dm"
+#include "russstation\code\game\objects\items\food\bread.dm"
 #include "russstation\code\game\objects\items\food\meat.dm"
 #include "russstation\code\game\objects\items\food\misc.dm"
 #include "russstation\code\game\objects\items\grenades\chem_grenade.dm"

--- a/russstation/code/game/objects/items/food/bread.dm
+++ b/russstation/code/game/objects/items/food/bread.dm
@@ -1,0 +1,16 @@
+#define BREADIFY_TIME (1 SECONDS)
+// shorter breadify time than smite
+
+/obj/item/food/bread/suicide_act(mob/user)
+	// remove the held bread so there's not two of em
+	qdel(src)
+	user.visible_message(span_suicide("[user] is becoming one with the [src]! It looks like [user.p_theyre()] trying to commit breadicide!"))
+	// copied from admin smite
+	var/mutable_appearance/bread_appearance = mutable_appearance('icons/obj/food/burgerbread.dmi', "bread")
+	var/mutable_appearance/transform_scanline = mutable_appearance('icons/effects/effects.dmi', "transform_effect")
+	user.transformation_animation(bread_appearance,time = BREADIFY_TIME, transform_overlay=transform_scanline, reset_after=TRUE)
+	addtimer(CALLBACK(GLOBAL_PROC, .proc/breadify, user), BREADIFY_TIME)
+	// doesn't actually kill, but bread ain't lasting long
+	return SHAME
+
+#undef BREADIFY_TIME


### PR DESCRIPTION
## What is changing?

add suicide action to bread loaves that's basically the same as the breadify admin smite, ie you become the bread. you don't even die, you just bread.

### Changes

* add bread suicide

## Why these changes?

because funny. thanks coen for the suggestion
