### PR TITLE
Remove adamantine from caves

### DIFF
--- a/_maps/RandomZLevels/caves.dmm
+++ b/_maps/RandomZLevels/caves.dmm
@@ -1588,20 +1588,6 @@
 	initial_gas_mix = "n2=23;o2=14;TEMP=2.7"
 	},
 /area/awaymission/caves/bmp_asteroid)
-"fX" = (
-/obj/structure/closet/crate/miningcar{
-	name = "Mining cart"
-	},
-/obj/item/pickaxe/rusted{
-	pixel_x = 5
-	},
-/obj/item/stack/sheet/mineral/adamantine{
-	amount = 15
-	},
-/turf/open/floor/plating/asteroid/basalt{
-	initial_gas_mix = "n2=23;o2=14;TEMP=2.7"
-	},
-/area/awaymission/caves/bmp_asteroid/level_two)
 "fY" = (
 /obj/structure/table,
 /obj/machinery/microwave,
@@ -1628,8 +1614,8 @@
 /area/awaymission/caves/bmp_asteroid)
 "gd" = (
 /obj/item/toy/beach_ball{
-	name = "\proper wilson";
-	desc = "It's a beachball with a face crudely drawn onto it with some soot."
+	desc = "It's a beachball with a face crudely drawn onto it with some soot.";
+	name = "\proper wilson"
 	},
 /turf/open/floor/plating/asteroid/basalt{
 	initial_gas_mix = "n2=23;o2=14;TEMP=2.7"
@@ -61458,7 +61444,7 @@ bK
 bK
 bK
 bK
-fX
+cb
 bJ
 bJ
 bJ


### PR DESCRIPTION
Removes the adamantine from the caves gateway.
The skeleton spawner dies when crossing the gateway, as they aren't supposed to actually go on the station.
However, because they can make sentient minions that DONT die when crossing the gateway, they are able to cross the gateway and have their minions revive them, thus ensuring they can bone/ruin the station with the loot from the gateway.