### PR TITLE
New confetti smites

### DIFF
--- a/RussStation.dme
+++ b/RussStation.dme
@@ -4398,6 +4398,8 @@
 #include "russstation\code\game\turfs\open\open.dm"
 #include "russstation\code\game\turfs\open\stone_floor.dm"
 #include "russstation\code\game\turfs\simulated\minerals.dm"
+#include "russstation\code\modules\admin\smites\confetti.dm"
+#include "russstation\code\modules\admin\smites\confetti_gib.dm"
 #include "russstation\code\modules\admin\verbs\randomverbs.dm"
 #include "russstation\code\modules\antagonists\ert.dm"
 #include "russstation\code\modules\antagonists\nukeop\equipment\pinpointer.dm"

--- a/russstation/code/modules/admin/smites/confetti.dm
+++ b/russstation/code/modules/admin/smites/confetti.dm
@@ -1,0 +1,8 @@
+/// Confetti around the target
+/datum/smite/confetti
+	name = "Confetti"
+
+/datum/smite/confetti/effect(client/user, mob/living/target)
+	. = ..()
+	var/turf/T = get_turf(target)
+	new /obj/effect/gibspawner/confetti(T, target)

--- a/russstation/code/modules/admin/smites/confetti_gib.dm
+++ b/russstation/code/modules/admin/smites/confetti_gib.dm
@@ -1,0 +1,9 @@
+// Confetti + Gib smites combined
+/datum/smite/confetti_gib
+	name = "Confetti Gib"
+
+/datum/smite/confetti_gib/effect(client/user, mob/living/target)
+	. = ..()
+	var/turf/T = get_turf(target)
+	new /obj/effect/gibspawner/confetti(T, target)
+	target.gib(/* no_brain = */ FALSE)


### PR DESCRIPTION
<!-- Fill out each section with text below the header. 
 You can view https://github.com/RussStation/RussStation/wiki/Contributing for a detailed description of the pull request process. -->

## What is changing?
Added new admin smites based around the existing confetti gib.
<!-- Briefly describe the Pull Request. Screenshots are recommended for new content.
 Include descriptions of interactions (such as new recipes or interfaces) so we know what the experience will be like.
 Example: Adds a new gas called "fartium". It is like miasma but doesn't make you as sick. It can be created by mixing super heated miasma with hydrogen in a 5:1 ratio. It degrades slowly when exposed to nitrogen. -->

### Changes

- Added 'Confetti' smite which just causes confetti to spawn at targeted player's location
- Added 'Confetti Gib' smite which spawns confetti and also does the normal 'Gib' smite

<!-- Itemized list of what was changed/added/removed. They should generally represent how a player might be affected by the changes so everyone understands the impact. 
 Example:
 * Added fartium gas
 * Added fartium gas containers to our maps as maint loot
 * Farts release fartium instead of miasma now -->

<!-- ### Wiki -->

<!-- If our wiki needs updated to document the changed content, uncomment this header and provide text that can be used on the wiki to help players learn more about this content. Use the our wiki and the tg wiki as references for how you might describe your content. -->

## Why these changes?
Cake asked for it 
<!-- Please add a short description of why you think these changes would benefit the game.
 If you can't justify it in words, it might not be worth adding.
 If code is modified in tg files (outside russstation/ folder) explain why that is necessary.
 Example: I like smelling my farts but I don't want my character to get so ill from it. This lets us fart more without poisoning everyone. -->
