### PR TITLE
Skaven render fixes/updates

### DIFF
--- a/russstation/code/modules/mob/living/carbon/human/species_types/skaven.dm
+++ b/russstation/code/modules/mob/living/carbon/human/species_types/skaven.dm
@@ -2,19 +2,19 @@
 	name = "Skaven"
 	id = "skaven"
 	say_mod = "jitters"
-	default_color = "2E2E2E"
+	default_color = "#2E2E2E"
+	mutant_bodyparts = list("tail_skaven" = "Skaven")
+	mutantears = /obj/item/organ/ears/skaven
+	mutantlungs = /obj/item/organ/lungs/skaven
+	mutanttongue = /obj/item/organ/tongue/skaven
+	mutant_organs = list(/obj/item/organ/tail/skaven)
 	species_traits = list(MUTCOLORS, AGENDER, EYECOLOR, LIPS, HAS_FLESH, HAS_BONE)
 	inherent_traits = list(
 		TRAIT_ADVANCEDTOOLUSER,
 		TRAIT_CAN_STRIP,
 	)
 	inherent_biotypes = MOB_ORGANIC|MOB_HUMANOID
-	mutant_bodyparts = list("tail_skaven" = "Skaven")
 	external_organs = list(/obj/item/organ/external/horns = "None", /obj/item/organ/external/snout = "Round")
-	mutantears = /obj/item/organ/ears/skaven
-	mutantlungs = /obj/item/organ/lungs/skaven
-	mutanttongue = /obj/item/organ/tongue/skaven
-	mutant_organs = list(/obj/item/organ/tail/skaven)
 	payday_modifier = 0.25 //Might as well be a slave
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_PRIDE | MIRROR_MAGIC | RACE_SWAP | ERT_SPAWN | SLIME_EXTRACT
 	attack_verb = "claw"
@@ -64,7 +64,7 @@
 /datum/species/skaven/spec_death(gibbed, mob/living/carbon/human/H)
 	if(H)
 		stop_wagging_tail(H)
-	. = ..()
+	// . = ..()
 
 /datum/species/skaven/spec_stun(mob/living/carbon/human/H, amount)
 	if(H)
@@ -93,14 +93,18 @@
 	var/mob/living/carbon/human/skaven = C
 	var/real_tail_type = skaven.dna.features["tail_skaven"] // hold onto tail until parent proc finished?
 
+	. = ..()
+
+	// Special handler for loading preferences. If we're doing it from a preference load, we'll want
+	// to make sure we give the appropriate lizard tail AFTER we call the parent proc, as the parent
+	// proc will overwrite the lizard tail. Species code at its finest.
 	if(!pref_load)
 		if(skaven.dna.features["ears"] == "None")
 			skaven.dna.features["ears"] = "Skaven"
+
 	if(skaven.dna.features["ears"] == "Skaven")
 		var/obj/item/organ/ears/skaven/ears = new
 		ears.Insert(skaven, drop_if_replaced = FALSE)
-
-	. = ..()
 
 	//Loads tail preferences.
 	if(pref_load)
@@ -112,7 +116,7 @@
 		var/obj/item/organ/tail/skaven/new_tail = new /obj/item/organ/tail/skaven()
 
 		new_tail.tail_type = skaven.dna.features["tail_skaven"]
-		new_tail.Insert(skaven, TRUE, FALSE)
+		new_tail.Insert(skaven, special = TRUE, drop_if_replaced = FALSE)
 
 	// ensure colors are synchronized
 	default_color = skaven.dna.features["mcolor"] = skaven.dna.features["skaven_color"]

--- a/russstation/code/modules/surgery/organs/ears.dm
+++ b/russstation/code/modules/surgery/organs/ears.dm
@@ -2,18 +2,19 @@
 	name = "skaven ears"
 	icon = 'russstation/icons/obj/clothing/hats.dmi'
 	icon_state = "skaven"
+	visual = TRUE
 
 /obj/item/organ/ears/skaven/Insert(mob/living/carbon/human/ear_owner, special = 0, drop_if_replaced = TRUE)
-	. = ..()
+	..()
 	if(istype(ear_owner))
 		color = ear_owner.dna.features["skaven_color"]
 		ear_owner.dna.features["ears"] = ear_owner.dna.species.mutant_bodyparts["ears"] = "Skaven"
+		ear_owner.dna.update_uf_block(DNA_EARS_BLOCK)
 		ear_owner.update_body()
 
 /obj/item/organ/ears/skaven/Remove(mob/living/carbon/human/ear_owner,  special = 0)
-	. = ..()
+	..()
 	if(istype(ear_owner))
 		color = ear_owner.hair_color
-		ear_owner.dna.features["ears"] = "None"
 		ear_owner.dna.species.mutant_bodyparts -= "ears"
 		ear_owner.update_body()

--- a/russstation/code/modules/surgery/species_parts/skaven_bodyparts.dm
+++ b/russstation/code/modules/surgery/species_parts/skaven_bodyparts.dm
@@ -1,32 +1,50 @@
 /obj/item/bodypart/head/skaven
-	icon_greyscale = 'russstation/icons/mob/human_parts_greyscale.dmi'
+	icon = 'russstation/icons/mob/human_parts_greyscale.dmi'
+	icon_state = "skaven_head"
+	icon_static = 'russstation/icons/mob/human_parts_greyscale.dmi'
 	limb_id = "skaven"
-	uses_mutcolor = TRUE
+	should_draw_greyscale = FALSE
 	is_dimorphic = FALSE
+	uses_mutcolor = TRUE
 	bodytype = BODYTYPE_HUMANOID | BODYTYPE_ORGANIC | BODYTYPE_SNOUTED //This is temporary. Ideally the "snout" external organ adds to this.
 
 /obj/item/bodypart/chest/skaven
-	icon_greyscale = 'russstation/icons/mob/human_parts_greyscale.dmi'
-	uses_mutcolor = TRUE
+	icon = 'russstation/icons/mob/human_parts_greyscale.dmi'
+	icon_state = "skaven_chest"
+	icon_static = 'russstation/icons/mob/human_parts_greyscale.dmi'
 	limb_id = "skaven"
+	should_draw_greyscale = FALSE
+	uses_mutcolor = TRUE
 	is_dimorphic = FALSE
 
 /obj/item/bodypart/l_arm/skaven
-	icon_greyscale = 'russstation/icons/mob/human_parts_greyscale.dmi'
-	uses_mutcolor = TRUE
+	icon = 'russstation/icons/mob/human_parts_greyscale.dmi'
+	icon_state = "skaven_l_arm"
+	icon_static = 'russstation/icons/mob/human_parts_greyscale.dmi'
 	limb_id = "skaven"
+	should_draw_greyscale = FALSE
+	uses_mutcolor = TRUE
 
 /obj/item/bodypart/r_arm/skaven
-	icon_greyscale = 'russstation/icons/mob/human_parts_greyscale.dmi'
-	uses_mutcolor = TRUE
+	icon = 'russstation/icons/mob/human_parts_greyscale.dmi'
+	icon_state = "skaven_r_arm"
+	icon_static = 'russstation/icons/mob/human_parts_greyscale.dmi'
 	limb_id = "skaven"
+	should_draw_greyscale = FALSE
+	uses_mutcolor = TRUE
 
 /obj/item/bodypart/l_leg/skaven
-	icon_greyscale = 'russstation/icons/mob/human_parts_greyscale.dmi'
-	uses_mutcolor = TRUE
+	icon = 'russstation/icons/mob/human_parts_greyscale.dmi'
+	icon_state = "skaven_l_leg"
+	icon_static = 'russstation/icons/mob/human_parts_greyscale.dmi'
 	limb_id = "skaven"
+	should_draw_greyscale = FALSE
+	uses_mutcolor = TRUE
 
 /obj/item/bodypart/r_leg/skaven
-	icon_greyscale = 'russstation/icons/mob/human_parts_greyscale.dmi'
-	uses_mutcolor = TRUE
+	icon = 'russstation/icons/mob/human_parts_greyscale.dmi'
+	icon_state = "skaven_r_leg"
+	icon_static = 'russstation/icons/mob/human_parts_greyscale.dmi'
 	limb_id = "skaven"
+	should_draw_greyscale = FALSE
+	uses_mutcolor = TRUE


### PR DESCRIPTION
## What is changing?
Skaven bodyparts updated to match new implementation (correctly override icons)

### Changes
- Use similar setup for bodyparts as moths (static icons and no greyscale to override icons)
- Tweak the Skaven procs to match similar species' updates
- Mimic Felinid ears in Skaven ears implementation
- Display skaven ears (not sure if this is a new flag or was intentionally disabled, if intentional just remove the line)

## Why these changes?
Ensures that the icons being used are the correct icons for Skaven bodyparts