### PR TITLE
Heretic slurring

### DIFF
--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -510,7 +510,7 @@
 
 	if(iscarbon(owner))
 		var/mob/living/carbon/carbon_owner = owner
-		carbon_owner.silent += 4
+		carbon_owner.silent += 5
 
 	return ..()
 

--- a/code/modules/antagonists/heretic/knowledge/void_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/void_lore.dm
@@ -89,7 +89,7 @@
 	var/turf/open/target_turf = get_turf(carbon_target)
 	target_turf.TakeTemperature(-20)
 	carbon_target.adjust_bodytemperature(-40)
-	carbon_target.silent += 4
+	carbon_target.silent += 5
 
 /datum/heretic_knowledge/cold_snap
 	name = "Aristocrat's Way"

--- a/code/modules/antagonists/heretic/magic/mansus_grasp.dm
+++ b/code/modules/antagonists/heretic/magic/mansus_grasp.dm
@@ -90,6 +90,7 @@
 	hit.adjustBruteLoss(10)
 	if(iscarbon(hit))
 		var/mob/living/carbon/carbon_hit = hit
+		carbon_hit.cultslurring += 2
 		carbon_hit.AdjustKnockdown(5 SECONDS)
 		carbon_hit.adjustStaminaLoss(80)
 


### PR DESCRIPTION
Mirrors the changes in https://github.com/tgstation/tgstation/pull/65440
I was waiting for this PR to be merged upstream before performing a merge myself, but now that we just got one, I don't want to have to go through the whole process again so soon. I didn't add any honk comments so the files should be overwritten anyways next merge, just to give our future selves less of a headache.

Mansus grasp now applies a few seconds of cult slurring on touch, to give early game heretics a slight boost in effectiveness.
Void path's silence is just a bit longer to compensate.