### PR TITLE
Pubby monastery rework

### DIFF
--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -912,7 +912,9 @@
 /area/ai_monitored/aisat/exterior)
 "adA" = (
 /obj/effect/spawner/random/maintenance,
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
 /area/maintenance/port/lesser)
 "adB" = (
 /obj/machinery/door/airlock/maintenance_hatch{
@@ -1101,32 +1103,12 @@
 /turf/open/floor/plating,
 /area/ai_monitored/aisat/exterior)
 "aej" = (
-/obj/item/assembly/prox_sensor{
-	pixel_x = -8;
-	pixel_y = 4
+/obj/item/stack/sheet/cardboard{
+	amount = 14
 	},
-/obj/item/assembly/prox_sensor{
-	pixel_x = -8;
-	pixel_y = 4
-	},
-/obj/item/assembly/prox_sensor{
-	pixel_x = -8;
-	pixel_y = 4
-	},
-/obj/item/assembly/prox_sensor{
-	pixel_x = -8;
-	pixel_y = 4
-	},
-/obj/item/stock_parts/cell/high,
-/obj/item/stock_parts/cell/high{
-	pixel_x = 5;
-	pixel_y = -5
-	},
-/obj/item/crowbar,
-/obj/structure/table,
-/obj/effect/turf_decal/tile/green/half/contrasted,
-/turf/open/floor/iron,
-/area/science/robotics/lab)
+/obj/item/vending_refill/cola,
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
 "aek" = (
 /obj/structure/closet/secure_closet/medical3,
 /obj/item/screwdriver,
@@ -1168,9 +1150,9 @@
 /turf/open/floor/iron/dark,
 /area/security/brig)
 "aeq" = (
-/obj/structure/barricade/wooden,
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
-/area/maintenance/department/medical)
+/area/science/genetics)
 "aer" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "Prison Gate";
@@ -1262,11 +1244,12 @@
 /turf/open/floor/iron/dark,
 /area/engineering/atmos)
 "aeI" = (
-/obj/structure/chair{
+/obj/structure/window/reinforced{
 	dir = 8
 	},
-/turf/open/floor/iron,
-/area/hallway/primary/central)
+/obj/structure/window/reinforced,
+/turf/open/space/basic,
+/area/space/nearstation)
 "aeJ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -1755,9 +1738,10 @@
 /area/security/brig)
 "agl" = (
 /obj/structure/cable,
+/obj/structure/chair/office/light,
+/obj/effect/landmark/start/psychologist,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/white,
+/turf/open/floor/carpet/purple,
 /area/medical/psychology)
 "agn" = (
 /obj/machinery/vending/cola,
@@ -2060,6 +2044,10 @@
 	pixel_y = -32
 	},
 /obj/effect/turf_decal/tile/blue/half/contrasted,
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "ahs" = (
@@ -2074,11 +2062,9 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "ahu" = (
-/obj/machinery/computer/med_data{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/blue/fourcorners,
 /obj/item/radio/intercom/directional/west,
+/obj/machinery/medical_kiosk,
 /turf/open/floor/iron/white,
 /area/medical/exam_room)
 "ahv" = (
@@ -3719,10 +3705,12 @@
 /turf/closed/wall,
 /area/security/execution/education)
 "amo" = (
-/obj/structure/closet/firecloset,
 /obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 8
 	},
+/obj/structure/table/glass,
+/obj/item/soap/deluxe,
+/obj/item/clothing/neck/stethoscope,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "amp" = (
@@ -5763,10 +5751,13 @@
 /turf/open/floor/iron,
 /area/security/brig)
 "atx" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/closed/wall,
-/area/commons/vacant_room/commissary)
+/obj/machinery/atmospherics/components/binary/pump/on/layer2{
+	name = "Virology Waste to Space"
+	},
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
+/area/maintenance/department/engine)
 "atA" = (
 /obj/machinery/door/window/brigdoor/security/cell{
 	id = "Cell 3";
@@ -8765,6 +8756,7 @@
 /obj/effect/turf_decal/tile/green{
 	dir = 1
 	},
+/obj/machinery/vending/drugs,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "aCG" = (
@@ -11067,7 +11059,10 @@
 	pixel_x = 29;
 	pixel_y = 1
 	},
-/turf/open/floor/carpet,
+/obj/structure/chair/comfy/brown{
+	dir = 8
+	},
+/turf/open/floor/carpet/purple,
 /area/medical/psychology)
 "aKb" = (
 /obj/machinery/door/firedoor,
@@ -13451,16 +13446,11 @@
 /turf/open/floor/iron,
 /area/cargo/storage)
 "aSr" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/virology/glass{
-	name = "Isolation A";
-	req_access_txt = "39"
+/obj/structure/cable,
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron/freezer,
-/area/medical/virology)
+/area/maintenance/department/engine)
 "aSu" = (
 /obj/item/wirecutters,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -17468,6 +17458,8 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /turf/open/floor/iron,
 /area/commons/vacant_room/commissary)
 "bgc" = (
@@ -17795,6 +17787,8 @@
 /obj/effect/turf_decal/tile/brown/half/contrasted{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /turf/open/floor/iron,
 /area/commons/vacant_room/commissary)
 "bgW" = (
@@ -17810,11 +17804,11 @@
 	specialfunctions = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
 /obj/effect/turf_decal/tile/brown/half/contrasted{
 	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
 	},
 /turf/open/floor/iron,
 /area/commons/vacant_room/commissary)
@@ -18999,10 +18993,11 @@
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
 "blE" = (
-/obj/machinery/smartfridge/petri/preloaded,
-/obj/machinery/firealarm/directional/south,
-/turf/open/floor/iron/dark,
-/area/science/xenobiology)
+/obj/structure/table,
+/obj/item/stack/cable_coil,
+/obj/item/extinguisher,
+/turf/open/floor/plating,
+/area/maintenance/department/medical)
 "blF" = (
 /obj/structure/chair/office/light{
 	dir = 1
@@ -19130,10 +19125,10 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "bmd" = (
-/obj/structure/cable,
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
-	},
+/obj/structure/table,
+/obj/item/flashlight/lamp,
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/turf/open/floor/iron/dark,
 /area/maintenance/department/engine)
 "bmf" = (
 /obj/structure/cable,
@@ -19946,9 +19941,12 @@
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "bpz" = (
-/obj/structure/chair/sofa/right,
+/obj/structure/chair/sofa/left,
 /obj/item/toy/plush/moth,
-/turf/open/floor/carpet,
+/obj/structure/sign/poster/official/help_others{
+	pixel_y = 32
+	},
+/turf/open/floor/carpet/purple,
 /area/medical/psychology)
 "bpD" = (
 /obj/structure/window/reinforced,
@@ -20590,11 +20588,11 @@
 /turf/open/floor/iron,
 /area/science/robotics/lab)
 "bry" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/science/robotics/lab)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/obj/machinery/meter/monitored/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
 "brz" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -20826,13 +20824,13 @@
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "bss" = (
-/obj/structure/chair/office/light,
-/obj/effect/landmark/start/psychologist,
-/turf/open/floor/iron/white,
+/turf/open/floor/carpet/purple,
 /area/medical/psychology)
 "bsu" = (
-/turf/open/floor/iron/white,
-/area/medical/psychology)
+/obj/structure/rack,
+/obj/effect/spawner/random/maintenance,
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
 "bsv" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -21283,13 +21281,8 @@
 /obj/structure/sign/poster/official/random{
 	pixel_y = -32
 	},
-/obj/machinery/vending/drugs,
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
+/turf/closed/wall/r_wall,
+/area/medical/virology)
 "bul" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/tile/blue/half/contrasted,
@@ -21821,10 +21814,10 @@
 /turf/open/floor/iron/white,
 /area/medical/surgery)
 "bwv" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/department/medical)
+/obj/structure/lattice/catwalk,
+/obj/structure/transit_tube,
+/turf/open/space/basic,
+/area/space/nearstation)
 "bwx" = (
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 4;
@@ -22808,7 +22801,9 @@
 /turf/open/floor/iron/white,
 /area/medical/exam_room)
 "bzT" = (
-/obj/machinery/medical_kiosk,
+/obj/machinery/computer/med_data{
+	dir = 1
+	},
 /turf/open/floor/iron/white,
 /area/medical/exam_room)
 "bzV" = (
@@ -23386,6 +23381,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
+/obj/machinery/vending/wallmed/directional/west,
 /turf/open/floor/iron/white,
 /area/medical/exam_room)
 "bCk" = (
@@ -23642,12 +23638,11 @@
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "bDf" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/transit_tube/crossing/horizontal{
-	dir = 1
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
 	},
-/turf/open/space/basic,
-/area/space/nearstation)
+/area/maintenance/department/medical)
 "bDg" = (
 /obj/effect/spawner/atmos_canister/air,
 /turf/open/floor/plating,
@@ -24393,15 +24388,13 @@
 /turf/open/floor/plating,
 /area/maintenance/department/science/xenobiology)
 "bFE" = (
-/obj/docking_port/stationary{
-	dwidth = 2;
-	height = 6;
-	id = "monastery_shuttle_asteroid";
-	name = "monastery";
-	width = 5
+/obj/effect/turf_decal/tile/purple/half/contrasted,
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/turf/open/space,
-/area/space/nearstation)
+/turf/open/floor/iron/white,
+/area/science/genetics)
 "bFF" = (
 /obj/machinery/atmospherics/components/tank/air{
 	dir = 1
@@ -24409,12 +24402,16 @@
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
 "bFI" = (
-/mob/living/carbon/human/species/monkey,
-/turf/open/floor/iron/freezer,
-/area/medical/virology)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/stool/directional/west,
+/turf/open/floor/plating,
+/area/maintenance/department/medical)
 "bFJ" = (
-/obj/effect/landmark/xeno_spawn,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/mob/living/carbon/human/species/monkey,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
 /turf/open/floor/iron/freezer,
 /area/medical/virology)
 "bFK" = (
@@ -24427,9 +24424,9 @@
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "bFL" = (
-/obj/machinery/light/small,
-/mob/living/carbon/human/species/monkey,
-/turf/open/floor/iron/freezer,
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
 /area/medical/virology)
 "bFM" = (
 /obj/structure/table,
@@ -25046,6 +25043,8 @@
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "bHT" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
 /obj/effect/spawner/random/trash/grille_or_waste,
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
@@ -25304,21 +25303,30 @@
 /turf/open/floor/iron/dark,
 /area/maintenance/department/engine)
 "bJi" = (
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
+"bJj" = (
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/item/kirbyplants{
 	icon_state = "plant-21"
 	},
-/turf/open/floor/plating,
-/area/maintenance/department/medical)
-"bJj" = (
-/turf/closed/wall/r_wall,
-/area/medical/psychology)
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/maintenance/department/engine)
 "bJk" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment,
-/obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/blue/line,
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "bJm" = (
@@ -25585,10 +25593,14 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "bKq" = (
-/obj/effect/spawner/structure/window,
-/obj/structure/sign/warning/deathsposal,
-/turf/open/floor/plating,
-/area/medical/virology)
+/obj/machinery/atmospherics/components/tank/air{
+	dir = 1;
+	piping_layer = 4
+	},
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
+/area/maintenance/department/engine)
 "bKr" = (
 /obj/machinery/vending/medical,
 /obj/effect/turf_decal/tile/blue/anticorner/contrasted{
@@ -25631,18 +25643,30 @@
 /turf/open/floor/iron/white,
 /area/medical/surgery)
 "bKH" = (
-/obj/structure/disposalpipe/sorting/mail/flip{
-	dir = 1;
-	sortType = 27
+/obj/structure/table,
+/obj/item/book/manual/wiki/robotics_cyborgs{
+	pixel_x = 6;
+	pixel_y = 5
 	},
-/obj/structure/disposalpipe/sorting/mail/flip{
-	dir = 1;
-	sortType = 27
+/obj/item/storage/belt/utility,
+/obj/item/reagent_containers/glass/beaker/large,
+/obj/item/radio/headset/headset_sci{
+	pixel_x = -3
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/department/engine)
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/button/door{
+	id = "robotics";
+	name = "Shutters Control Button";
+	pixel_x = -26;
+	pixel_y = 8;
+	req_access_txt = "29"
+	},
+/obj/machinery/light_switch{
+	pixel_x = -25;
+	pixel_y = -8
+	},
+/turf/open/floor/iron/dark,
+/area/science/robotics/lab)
 "bKI" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/tile/yellow{
@@ -25837,9 +25861,15 @@
 /turf/open/floor/engine,
 /area/maintenance/department/engine)
 "bLy" = (
-/obj/structure/mineral_door/wood{
-	name = "The Roosterdome"
+/obj/machinery/light/small{
+	dir = 1
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "bLz" = (
@@ -25888,10 +25918,10 @@
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "bLL" = (
-/obj/structure/closet/emcloset,
 /obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 8
 	},
+/obj/structure/closet/l3closet,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "bLM" = (
@@ -26388,14 +26418,10 @@
 /turf/open/floor/plating,
 /area/service/chapel/dock)
 "bNB" = (
-/obj/structure/transit_tube/horizontal,
-/obj/structure/window/reinforced{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/structure/lattice/catwalk,
-/turf/open/space,
-/area/space/nearstation)
+/obj/structure/rack,
+/obj/effect/spawner/random/entertainment/drugs,
+/turf/open/floor/plating,
+/area/maintenance/department/medical)
 "bNF" = (
 /obj/item/stack/medical/suture,
 /turf/open/floor/iron/dark,
@@ -26454,7 +26480,8 @@
 	name = "Psychology APC"
 	},
 /obj/structure/cable,
-/turf/open/floor/iron/white,
+/obj/structure/reagent_dispensers/water_cooler,
+/turf/open/floor/carpet/purple,
 /area/medical/psychology)
 "bNP" = (
 /obj/item/skub{
@@ -26503,8 +26530,11 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "bNX" = (
+/obj/structure/table,
 /obj/effect/spawner/random/maintenance,
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
 /area/maintenance/department/engine)
 "bNZ" = (
 /obj/machinery/door/airlock/maintenance{
@@ -26680,7 +26710,7 @@
 /area/medical/virology)
 "bOE" = (
 /obj/structure/cable,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/purple,
 /area/medical/psychology)
 "bOF" = (
 /obj/structure/disposalpipe/segment{
@@ -26694,12 +26724,20 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "bOG" = (
-/obj/structure/water_source/puddle,
-/obj/structure/flora/ausbushes/reedbush{
-	pixel_y = 6
+/obj/structure/table,
+/obj/structure/table,
+/obj/item/storage/box/beakers{
+	pixel_x = 4;
+	pixel_y = 4
 	},
-/turf/open/floor/grass,
-/area/medical/psychology)
+/obj/item/storage/box/syringes,
+/obj/item/reagent_containers/spray/cleaner,
+/obj/effect/turf_decal/tile/green/anticorner/contrasted{
+	dir = 1
+	},
+/obj/machinery/newscaster/directional/north,
+/turf/open/floor/iron/white,
+/area/medical/virology)
 "bOH" = (
 /obj/effect/landmark/blobstart,
 /obj/structure/cable,
@@ -26710,9 +26748,8 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "bOI" = (
-/obj/structure/flora/grass/jungle/b,
-/obj/structure/flora/ausbushes/lavendergrass,
-/turf/open/floor/grass,
+/obj/structure/sign/poster/official/love_ian,
+/turf/closed/wall,
 /area/medical/psychology)
 "bOK" = (
 /obj/structure/extinguisher_cabinet{
@@ -27115,7 +27152,9 @@
 /turf/open/space,
 /area/space/nearstation)
 "bQj" = (
-/obj/effect/landmark/blobstart,
+/mob/living/carbon/human/species/monkey,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/freezer,
 /area/medical/virology)
 "bQl" = (
@@ -27349,17 +27388,14 @@
 /turf/open/space,
 /area/space/nearstation)
 "bQS" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
-/obj/machinery/camera/directional/east{
-	c_tag = "Virology Isolation A";
-	network = list("ss13","medbay")
+/obj/machinery/door/airlock/external{
+	req_access_txt = "13"
 	},
-/turf/open/floor/iron/freezer,
-/area/medical/virology)
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
 "bQY" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -27822,10 +27858,13 @@
 /turf/open/floor/plating,
 /area/medical/psychology)
 "bSt" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
-/obj/machinery/meter/monitored/layer4,
-/turf/open/floor/plating,
-/area/maintenance/department/engine)
+/obj/structure/table/glass,
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 8
+	},
+/obj/item/clothing/gloves/color/latex,
+/turf/open/floor/iron/dark,
+/area/science/genetics)
 "bSu" = (
 /obj/item/broken_bottle,
 /obj/effect/spawner/random/maintenance,
@@ -28030,25 +28069,24 @@
 /turf/open/space,
 /area/space/nearstation)
 "bTa" = (
-/obj/structure/disposalpipe/segment{
-	dir = 6
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
 	},
-/obj/structure/lattice,
-/turf/open/space,
-/area/space/nearstation)
-"bTb" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/door/airlock/external{
+	req_access_txt = "13"
 	},
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
-"bTc" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/maintenance/department/engine)
+"bTb" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/hallway/secondary/entry)
+"bTc" = (
+/turf/open/floor/plating{
+	luminosity = 2
+	},
+/area/maintenance/department/medical)
 "bTd" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -28056,22 +28094,23 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "bTf" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
-/obj/machinery/atmospherics/components/binary/pump/on/layer2{
-	name = "Virology Waste to Space"
-	},
-/turf/open/floor/plating{
-	icon_state = "platingdmg1"
-	},
-/area/maintenance/department/engine)
-"bTg" = (
-/obj/machinery/atmospherics/components/binary/pump/on/layer2{
-	name = "Virology Waste to Space"
-	},
+/obj/effect/spawner/random/maintenance,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"bTg" = (
+/obj/machinery/meter/monitored/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/maintenance/department/engine)
 "bTh" = (
-/obj/machinery/atmospherics/pipe/layer_manifold/cyan/visible,
+/obj/effect/spawner/atmos_canister/nitrous_oxide,
+/obj/machinery/atmospherics/components/unary/portables_connector/visible/layer4{
+	dir = 4
+	},
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
@@ -28391,18 +28430,24 @@
 /turf/open/floor/engine/plasma,
 /area/engineering/atmos)
 "bTW" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/lattice,
-/turf/open/space,
-/area/space/nearstation)
+/obj/machinery/computer/pandemic,
+/obj/machinery/airalarm/directional/north,
+/obj/effect/turf_decal/tile/green/anticorner/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/medical/virology)
 "bTX" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "bUa" = (
-/obj/item/wrench,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "bUb" = (
@@ -28422,7 +28467,6 @@
 /area/maintenance/department/engine)
 "bUe" = (
 /obj/item/cigbutt/cigarbutt,
-/obj/effect/spawner/atmos_canister/air,
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
@@ -28602,25 +28646,30 @@
 /turf/open/misc/asteroid,
 /area/service/chapel/asteroid/monastery)
 "bUD" = (
-/obj/structure/lattice,
-/obj/structure/disposalpipe/segment{
-	dir = 6
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
 	},
-/turf/open/space,
-/area/space/nearstation)
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/science/genetics)
 "bUE" = (
-/obj/structure/lattice,
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/turf/open/space,
-/area/space/nearstation)
-"bUF" = (
 /obj/structure/table,
-/obj/item/stack/cable_coil,
-/obj/item/extinguisher,
+/obj/item/storage/box/lights/mixed,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"bUF" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "bUG" = (
 /obj/machinery/power/emitter,
 /turf/open/floor/plating,
@@ -28904,33 +28953,33 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "bVr" = (
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
-"bVs" = (
-/obj/structure/mopbucket,
-/obj/item/mop,
+/obj/structure/sign/warning/vacuum/external{
+	pixel_y = -32
+	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"bVs" = (
+/obj/effect/spawner/random/trash/janitor_supplies,
+/turf/open/floor/plating,
+/area/maintenance/department/medical)
 "bVu" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "bVv" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 8
-	},
-/obj/effect/spawner/atmos_canister/nitrous_oxide,
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
-/area/maintenance/department/engine)
+/area/maintenance/department/medical)
 "bVw" = (
-/obj/machinery/atmospherics/components/tank/air{
-	dir = 1
-	},
+/obj/effect/spawner/random/maintenance,
 /turf/open/floor/plating{
-	icon_state = "panelscorched"
+	icon_state = "platingdmg3"
 	},
 /area/maintenance/department/engine)
 "bVy" = (
@@ -28948,8 +28997,11 @@
 	},
 /area/maintenance/department/engine)
 "bVC" = (
-/obj/structure/reagent_dispensers/watertank,
-/turf/open/floor/plating,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating{
+	icon_state = "platingdmg2"
+	},
 /area/maintenance/department/engine)
 "bVD" = (
 /obj/machinery/button/door{
@@ -29185,11 +29237,10 @@
 /turf/open/misc/asteroid,
 /area/service/chapel/asteroid/monastery)
 "bWl" = (
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/engine)
+/obj/structure/lattice/catwalk,
+/obj/structure/transit_tube/crossing,
+/turf/open/space/basic,
+/area/space/nearstation)
 "bWn" = (
 /obj/structure/closet/secure_closet/engineering_chief,
 /obj/structure/extinguisher_cabinet{
@@ -29399,10 +29450,16 @@
 /turf/open/floor/iron,
 /area/engineering/main)
 "bWH" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/obj/machinery/atmospherics/components/binary/pump/on/general/visible/layer4{
+	dir = 1;
+	name = "Virology Air"
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
 /area/maintenance/department/engine)
 "bWI" = (
 /obj/machinery/light{
@@ -29717,10 +29774,10 @@
 /turf/open/floor/plating,
 /area/service/chapel/asteroid/monastery)
 "bXU" = (
-/obj/effect/spawner/random/maintenance,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plating{
-	icon_state = "platingdmg3"
+	icon_state = "platingdmg2"
 	},
 /area/maintenance/department/engine)
 "bXV" = (
@@ -30128,9 +30185,8 @@
 /area/service/chapel/monastery)
 "bZr" = (
 /obj/item/trash/tray,
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/junction,
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
@@ -30278,7 +30334,6 @@
 /area/maintenance/department/engine)
 "cad" = (
 /obj/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "cae" = (
@@ -33798,9 +33853,16 @@
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
 "cqy" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating/airless,
-/area/maintenance/department/engine)
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = 11
+	},
+/obj/effect/turf_decal/tile/green/half/contrasted{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron/white,
+/area/medical/virology)
 "cqz" = (
 /obj/effect/turf_decal/tile/green/half/contrasted,
 /turf/open/floor/iron,
@@ -33888,12 +33950,11 @@
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "cre" = (
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 8
+/obj/effect/spawner/random/trash/grime,
+/turf/open/floor/plating{
+	icon_state = "platingdmg2"
 	},
-/turf/open/space/basic,
-/area/space/nearstation)
+/area/maintenance/department/engine)
 "crg" = (
 /obj/structure/chair/wood,
 /turf/open/floor/iron/dark,
@@ -33935,10 +33996,32 @@
 /turf/open/floor/plating,
 /area/service/chapel/asteroid/monastery)
 "crm" = (
-/obj/structure/lattice,
-/obj/structure/disposalpipe/segment,
-/turf/open/space,
-/area/space/nearstation)
+/obj/item/assembly/prox_sensor{
+	pixel_x = -8;
+	pixel_y = 4
+	},
+/obj/item/assembly/prox_sensor{
+	pixel_x = -8;
+	pixel_y = 4
+	},
+/obj/item/assembly/prox_sensor{
+	pixel_x = -8;
+	pixel_y = 4
+	},
+/obj/item/assembly/prox_sensor{
+	pixel_x = -8;
+	pixel_y = 4
+	},
+/obj/item/stock_parts/cell/high,
+/obj/item/stock_parts/cell/high{
+	pixel_x = 5;
+	pixel_y = -5
+	},
+/obj/item/crowbar,
+/obj/structure/table,
+/obj/effect/turf_decal/tile/green/half/contrasted,
+/turf/open/floor/iron,
+/area/science/robotics/lab)
 "crt" = (
 /obj/structure/table/wood/fancy,
 /obj/item/folder,
@@ -33961,52 +34044,39 @@
 /turf/open/floor/iron/dark,
 /area/service/chapel/monastery)
 "cry" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/turf/open/space,
-/area/space/nearstation)
-"crz" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
-/obj/machinery/door/airlock/external{
-	req_access_txt = "13"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
+/obj/machinery/power/port_gen/pacman,
 /turf/open/floor/plating,
+/area/engineering/main)
+"crz" = (
+/obj/machinery/atmospherics/components/unary/outlet_injector/on/layer2{
+	dir = 4;
+	name = "Outlet injector"
+	},
+/turf/open/floor/plating/airless,
 /area/maintenance/department/engine)
 "crA" = (
-/obj/structure/sign/warning/vacuum/external{
-	pixel_y = 32
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "crB" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/obj/machinery/door/airlock/external{
-	req_access_txt = "13"
-	},
-/obj/structure/disposalpipe/segment{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
 	dir = 4
+	},
+/obj/structure/sign/warning/deathsposal{
+	pixel_y = 32
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "crC" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/structure/grille/broken,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "crD" = (
@@ -35698,7 +35768,10 @@
 /obj/structure/sign/poster/official/work_for_a_future{
 	pixel_y = 32
 	},
-/turf/open/floor/iron/white,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/carpet/purple,
 /area/medical/psychology)
 "cMl" = (
 /obj/machinery/conveyor{
@@ -35741,16 +35814,7 @@
 	},
 /area/maintenance/department/crew_quarters/dorms)
 "cPT" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/purple/anticorner/contrasted{
-	dir = 8
-	},
-/obj/machinery/airalarm/directional/south,
-/turf/open/floor/iron/white,
+/turf/closed/wall/r_wall,
 /area/science/genetics)
 "cQN" = (
 /obj/effect/spawner/structure/window,
@@ -35761,9 +35825,14 @@
 /turf/open/floor/plating,
 /area/maintenance/port/lesser)
 "cSf" = (
-/obj/machinery/holopad,
-/turf/open/floor/iron/white,
-/area/medical/psychology)
+/obj/machinery/door/airlock/atmos{
+	name = "Atmospherics Maintenance";
+	req_access_txt = "12;24"
+	},
+/obj/effect/mapping_helpers/airlock/abandoned,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
 "cSJ" = (
 /obj/machinery/light{
 	dir = 4
@@ -35941,16 +36010,9 @@
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "dlS" = (
-/obj/machinery/status_display/evac{
-	pixel_x = -32
-	},
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue/fourcorners,
-/turf/open/floor/iron/white,
-/area/medical/psychology)
+/obj/machinery/status_display/evac,
+/turf/closed/wall/r_wall,
+/area/medical/virology)
 "dma" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -35980,16 +36042,11 @@
 /area/medical/virology)
 "doo" = (
 /obj/structure/table,
-/obj/structure/table,
-/obj/item/storage/box/beakers{
-	pixel_x = 4;
-	pixel_y = 4
+/obj/machinery/reagentgrinder,
+/obj/effect/turf_decal/tile/green/half/contrasted{
+	dir = 8
 	},
-/obj/item/storage/box/syringes,
-/obj/item/reagent_containers/spray/cleaner,
-/obj/effect/turf_decal/tile/green/anticorner/contrasted{
-	dir = 1
-	},
+/obj/machinery/vending/wallmed/directional/west,
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "doQ" = (
@@ -36181,12 +36238,11 @@
 /turf/open/floor/iron/white,
 /area/medical/storage)
 "dAG" = (
-/obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden,
+/obj/structure/grille/broken,
 /turf/open/floor/plating{
-	icon_state = "platingdmg1"
+	icon_state = "panelscorched"
 	},
-/area/maintenance/department/engine)
+/area/maintenance/department/medical)
 "dBm" = (
 /obj/machinery/mineral/stacking_unit_console{
 	machinedir = 8;
@@ -36207,10 +36263,9 @@
 /turf/open/floor/iron/dark,
 /area/service/library/artgallery)
 "dES" = (
-/obj/structure/flora/grass/jungle,
-/mob/living/simple_animal/pet/dog/corgi,
-/turf/open/floor/grass,
-/area/medical/psychology)
+/obj/structure/closet/firecloset,
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
 "dGH" = (
 /obj/structure/chair{
 	dir = 4
@@ -36423,9 +36478,7 @@
 /turf/open/floor/engine,
 /area/engineering/main)
 "dXa" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "dZj" = (
@@ -36700,12 +36753,12 @@
 /turf/open/floor/plating,
 /area/engineering/main)
 "evR" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
+/obj/structure/window/reinforced{
+	dir = 8
 	},
-/turf/open/floor/iron,
-/area/science/robotics/lab)
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space/nearstation)
 "ewV" = (
 /turf/open/floor/carpet,
 /area/service/library/artgallery)
@@ -36824,13 +36877,17 @@
 /turf/open/floor/iron/dark,
 /area/hallway/secondary/exit/departure_lounge)
 "eNy" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
+/obj/effect/turf_decal/tile/purple/anticorner/contrasted{
+	dir = 8
 	},
-/area/maintenance/department/engine)
+/obj/machinery/airalarm/directional/south,
+/turf/open/floor/iron/white,
+/area/science/genetics)
 "eNF" = (
 /obj/structure/grille,
 /obj/structure/lattice,
@@ -37098,10 +37155,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/turf/open/floor/iron/white,
+/turf/open/floor/carpet/purple,
 /area/medical/psychology)
 "feU" = (
 /obj/effect/landmark/start/scientist,
@@ -37220,8 +37274,8 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "fov" = (
-/obj/effect/spawner/random/trash/grime,
-/turf/open/floor/plating,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/closed/wall,
 /area/maintenance/department/engine)
 "fow" = (
 /obj/structure/chair/office{
@@ -37304,16 +37358,11 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
 "fwg" = (
-/obj/item/stack/sheet/cardboard{
-	amount = 14
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating{
+	icon_state = "platingdmg2"
 	},
-/obj/item/vending_refill/cola,
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
-/turf/open/floor/plating,
-/area/maintenance/department/engine)
+/area/maintenance/department/medical)
 "fwi" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -37528,13 +37577,19 @@
 	dir = 1
 	},
 /obj/structure/extinguisher_cabinet/directional/north,
+/obj/structure/chair,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "fMm" = (
-/obj/structure/lattice,
-/obj/structure/grille,
-/turf/closed/wall,
-/area/space/nearstation)
+/obj/structure/flora/grass/jungle/b,
+/obj/structure/flora/ausbushes/lavendergrass,
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/machinery/door/window/left/directional/east{
+	dir = 1;
+	name = "Petting Garden"
+	},
+/turf/open/floor/grass,
+/area/medical/psychology)
 "fNv" = (
 /obj/structure/chair{
 	dir = 8
@@ -37545,19 +37600,10 @@
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "fNX" = (
-/obj/structure/table/wood,
-/obj/item/folder/white{
-	pixel_x = 14;
-	pixel_y = 3
-	},
-/obj/item/paper_bin/carbon{
-	pixel_x = -3;
-	pixel_y = 2
-	},
-/obj/item/pen,
-/obj/effect/turf_decal/tile/blue/half/contrasted,
-/turf/open/floor/iron/white,
-/area/medical/psychology)
+/obj/structure/table,
+/obj/effect/spawner/random/maintenance,
+/turf/open/floor/plating,
+/area/maintenance/department/medical)
 "fQd" = (
 /obj/machinery/conveyor{
 	id = "CargoLoad"
@@ -37632,14 +37678,21 @@
 	},
 /area/hallway/secondary/exit/departure_lounge)
 "fWl" = (
-/obj/effect/turf_decal/tile/green/half/contrasted{
-	dir = 4
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/obj/machinery/door/window/left/directional/east{
+	dir = 1;
+	name = "Monkey Pen";
+	req_one_access_txt = "39"
 	},
-/turf/open/floor/iron/white,
+/turf/open/floor/iron/freezer,
 /area/medical/virology)
 "fWq" = (
 /obj/effect/turf_decal/tile/blue/half/contrasted,
 /obj/machinery/light,
+/obj/structure/chair{
+	dir = 1
+	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "fWv" = (
@@ -37647,24 +37700,11 @@
 /turf/open/floor/iron/dark,
 /area/service/library/lounge)
 "fWL" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -26
-	},
-/obj/machinery/requests_console{
-	department = "Virology";
-	name = "Virology Requests Console";
-	pixel_x = -32;
-	receive_ore_updates = 1
-	},
-/obj/machinery/vending/medical,
-/obj/effect/turf_decal/tile/green/half/contrasted{
-	dir = 8
+/obj/structure/disposalpipe/segment{
+	dir = 5
 	},
 /turf/open/floor/iron/white,
-/area/medical/virology)
+/area/science/genetics)
 "fYY" = (
 /obj/structure/sign/poster/official/random{
 	pixel_y = 32
@@ -37704,8 +37744,12 @@
 /turf/open/floor/iron/dark,
 /area/engineering/atmos/hfr_room)
 "gcn" = (
-/obj/effect/spawner/random/maintenance,
-/obj/structure/closet,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/spawner/random/trash/mess,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "gcq" = (
@@ -37716,12 +37760,11 @@
 /turf/open/floor/iron,
 /area/cargo/storage)
 "gdJ" = (
-/obj/machinery/holopad,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/science/robotics/lab)
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/obj/effect/spawner/random/trash/grille_or_waste,
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
 "gfi" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -37777,19 +37820,12 @@
 	name = "Virology APC";
 	pixel_y = 25
 	},
-/obj/machinery/light_switch{
-	pixel_x = 22
-	},
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
-/obj/machinery/camera/directional/east{
-	c_tag = "Virology Lab";
-	network = list("ss13","medbay")
-	},
-/obj/effect/turf_decal/tile/green/anticorner/contrasted{
-	dir = 4
+/obj/effect/turf_decal/tile/green/half/contrasted{
+	dir = 1
 	},
 /turf/open/floor/iron/white,
 /area/medical/virology)
@@ -37818,11 +37854,9 @@
 /turf/open/floor/iron,
 /area/commons/storage/primary)
 "gkS" = (
-/obj/structure/flora/grass/jungle/b,
-/obj/structure/flora/ausbushes/ppflowers,
-/mob/living/simple_animal/pet/dog/corgi/puppy,
-/turf/open/floor/grass,
-/area/medical/psychology)
+/obj/machinery/rnd/experimentor,
+/turf/open/floor/engine,
+/area/science/explab)
 "gkX" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Storage";
@@ -37905,13 +37939,6 @@
 	heat_capacity = 1e+006
 	},
 /area/hallway/secondary/exit/departure_lounge)
-"gqe" = (
-/obj/effect/turf_decal/tile/neutral/half/contrasted,
-/obj/structure/sink{
-	pixel_y = 20
-	},
-/turf/open/floor/iron/dark,
-/area/science/genetics)
 "grq" = (
 /obj/effect/spawner/random/structure/closet_maintenance,
 /turf/open/floor/plating,
@@ -37958,12 +37985,10 @@
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
 "gum" = (
-/obj/structure/bookcase/random/reference,
-/obj/effect/turf_decal/tile/blue/anticorner/contrasted{
-	dir = 8
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
 	},
-/turf/open/floor/iron/white,
-/area/medical/psychology)
+/area/maintenance/department/medical)
 "gup" = (
 /obj/machinery/navbeacon/wayfinding{
 	location = "AI Satellite"
@@ -38230,6 +38255,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
+"gKZ" = (
+/obj/structure/mopbucket,
+/obj/item/mop,
+/turf/open/floor/plating,
+/area/maintenance/department/medical)
 "gLF" = (
 /obj/effect/spawner/random/vending/snackvend,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -38385,8 +38415,7 @@
 /turf/open/floor/engine/co2,
 /area/engineering/atmos)
 "gZg" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "hae" = (
@@ -38412,8 +38441,8 @@
 /turf/open/floor/engine,
 /area/engineering/supermatter)
 "hdk" = (
-/obj/structure/flora/junglebush,
-/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/flora/ausbushes/brflowers,
+/obj/structure/flora/ausbushes/lavendergrass,
 /turf/open/floor/grass,
 /area/medical/psychology)
 "heC" = (
@@ -38434,8 +38463,9 @@
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/dorms)
 "hfZ" = (
-/turf/closed/wall/r_wall,
-/area/science/genetics)
+/obj/structure/closet/secure_closet/cytology,
+/turf/open/floor/iron/dark,
+/area/science/xenobiology)
 "hgV" = (
 /obj/structure/table/wood,
 /obj/item/storage/box/seccarts{
@@ -38509,9 +38539,10 @@
 /turf/open/floor/iron,
 /area/security/checkpoint/medical)
 "hko" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/item/wrench,
+/obj/machinery/atmospherics/components/binary/pump/off/general/visible/layer4{
+	dir = 1;
+	name = "Supply to Virology"
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
@@ -38693,9 +38724,14 @@
 /turf/open/floor/iron/white,
 /area/command/heads_quarters/cmo)
 "hBY" = (
-/obj/structure/table,
-/obj/item/flashlight/lamp,
-/turf/open/floor/iron/dark,
+/obj/machinery/disposal/bin,
+/obj/structure/sign/warning/deathsposal{
+	pixel_x = -32
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/turf/open/floor/plating,
 /area/maintenance/department/engine)
 "hCE" = (
 /obj/effect/turf_decal/stripes/line,
@@ -38898,16 +38934,9 @@
 /turf/open/floor/wood,
 /area/command/heads_quarters/hop)
 "hRH" = (
-/obj/structure/table,
-/obj/machinery/reagentgrinder,
-/obj/machinery/newscaster{
-	pixel_x = -30
-	},
-/obj/effect/turf_decal/tile/green/half/contrasted{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/medical/virology)
+/obj/effect/spawner/random/trash/graffiti,
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
 "hSM" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
@@ -39002,8 +39031,11 @@
 /turf/open/floor/iron/white,
 /area/medical/exam_room)
 "hZZ" = (
-/obj/effect/spawner/random/trash/janitor_supplies,
-/turf/open/floor/plating,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
 /area/maintenance/department/engine)
 "iab" = (
 /obj/machinery/disposal/bin,
@@ -39373,10 +39405,9 @@
 /turf/open/floor/iron,
 /area/cargo/storage)
 "iEQ" = (
-/obj/structure/table,
-/obj/item/storage/box/lights/mixed,
+/obj/effect/spawner/random/trash/garbage,
 /turf/open/floor/plating,
-/area/maintenance/department/engine)
+/area/maintenance/department/medical)
 "iEU" = (
 /obj/item/clothing/suit/apron/chef,
 /turf/open/floor/plating,
@@ -39389,10 +39420,12 @@
 /turf/open/floor/iron,
 /area/engineering/main)
 "iGp" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/transit_tube/crossing/horizontal,
-/turf/open/space/basic,
-/area/space/nearstation)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/meter/monitored/layer2,
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/maintenance/department/engine)
 "iGx" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/structure/plasticflaps/opaque,
@@ -39407,6 +39440,16 @@
 /obj/structure/grille,
 /turf/open/floor/plating,
 /area/maintenance/department/science/xenobiology)
+"iHi" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/obj/machinery/camera/directional/east{
+	c_tag = "Virology Isolation A";
+	network = list("ss13","medbay")
+	},
+/turf/open/floor/iron/freezer,
+/area/medical/virology)
 "iIB" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -39420,18 +39463,14 @@
 /turf/open/floor/iron/dark,
 /area/service/library/artgallery)
 "iJI" = (
-/obj/structure/sink{
-	dir = 8;
-	pixel_x = 11
+/obj/structure/cable,
+/obj/machinery/door/airlock/maintenance{
+	req_access_txt = "12"
 	},
-/obj/item/radio/intercom{
-	pixel_x = 28
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
 	},
-/obj/effect/turf_decal/tile/green/half/contrasted{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/medical/virology)
+/area/maintenance/department/medical)
 "iKb" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -39511,10 +39550,9 @@
 /turf/open/floor/iron,
 /area/maintenance/disposal)
 "iQW" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
+/obj/machinery/light/small,
 /mob/living/carbon/human/species/monkey,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/freezer,
 /area/medical/virology)
 "iRs" = (
@@ -40023,8 +40061,6 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment,
-/obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock/medical{
 	name = "Psychology";
 	req_access_txt = "70"
@@ -40187,14 +40223,10 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "jVS" = (
-/obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
-/turf/open/floor/iron/freezer,
-/area/medical/virology)
+/obj/effect/landmark/xeno_spawn,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/plating,
+/area/maintenance/department/medical)
 "jVZ" = (
 /obj/machinery/navbeacon/wayfinding{
 	location = "Service Hall"
@@ -40232,12 +40264,11 @@
 /turf/open/floor/plating,
 /area/maintenance/department/science/xenobiology)
 "jYh" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 4;
-	name = "Supply to Virology"
-	},
+/obj/structure/table,
+/obj/item/stack/sheet/iron/fifty,
+/obj/item/stack/rods/fifty,
 /turf/open/floor/plating{
-	icon_state = "platingdmg3"
+	icon_state = "panelscorched"
 	},
 /area/maintenance/department/engine)
 "jYA" = (
@@ -40246,6 +40277,17 @@
 	},
 /turf/closed/wall,
 /area/maintenance/department/cargo)
+"kaf" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/maintenance/department/engine)
 "kbV" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -40267,9 +40309,11 @@
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "kdF" = (
-/obj/effect/spawner/random/trash/hobo_squat,
-/turf/open/floor/iron/dark,
-/area/maintenance/department/engine)
+/obj/structure/chair{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/central)
 "kee" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -40786,10 +40830,6 @@
 	},
 /turf/open/floor/iron,
 /area/security/checkpoint/supply)
-"kRS" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/science/genetics)
 "kSF" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -40818,15 +40858,13 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "kTU" = (
-/obj/structure/window/reinforced/spawner/east,
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk,
 /obj/effect/turf_decal/tile/green/half/contrasted{
 	dir = 1
 	},
+/obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "kUj" = (
@@ -40893,7 +40931,9 @@
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "kYt" = (
-/obj/structure/flora/ausbushes/sparsegrass,
+/mob/living/simple_animal/butterfly,
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/ywflowers,
 /turf/open/floor/grass,
 /area/medical/psychology)
 "kZU" = (
@@ -40912,9 +40952,9 @@
 /turf/open/floor/iron/dark,
 /area/service/library/artgallery)
 "lba" = (
-/obj/structure/flora/junglebush,
-/obj/structure/flora/ausbushes/brflowers,
-/obj/structure/window/reinforced/spawner/north,
+/obj/structure/flora/ausbushes/lavendergrass,
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/ppflowers,
 /turf/open/floor/grass,
 /area/medical/psychology)
 "lbC" = (
@@ -41047,15 +41087,15 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "lkK" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/bed,
-/obj/item/bedsheet/medical,
+/obj/structure/table/glass,
+/obj/item/reagent_containers/dropper,
+/obj/item/reagent_containers/syringe,
+/obj/item/reagent_containers/glass/beaker,
 /turf/open/floor/iron/freezer,
 /area/medical/virology)
 "lla" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
+/obj/effect/spawner/random/maintenance,
+/obj/structure/closet/emcloset,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "llS" = (
@@ -41071,10 +41111,11 @@
 /turf/open/floor/iron,
 /area/commons/storage/primary)
 "lor" = (
-/obj/structure/flora/ausbushes/sparsegrass,
-/obj/structure/flora/ausbushes/ywflowers,
-/turf/open/floor/grass,
-/area/medical/psychology)
+/obj/effect/spawner/random/structure/crate,
+/turf/open/floor/plating{
+	icon_state = "platingdmg2"
+	},
+/area/maintenance/department/engine)
 "lov" = (
 /obj/effect/landmark/start/paramedic,
 /turf/open/floor/iron/white,
@@ -41095,11 +41136,10 @@
 /turf/open/floor/iron/dark,
 /area/service/library/lounge)
 "lrI" = (
-/obj/structure/rack,
-/obj/effect/spawner/random/maintenance,
-/obj/structure/cable,
+/obj/structure/table,
+/obj/item/storage/box/mousetraps,
 /turf/open/floor/plating,
-/area/maintenance/department/engine)
+/area/maintenance/department/medical)
 "lsq" = (
 /obj/structure/transit_tube/curved{
 	dir = 1
@@ -41152,10 +41192,14 @@
 /turf/open/floor/iron/white,
 /area/medical/paramedic)
 "lya" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/virology/glass{
+	name = "Isolation A";
+	req_access_txt = "39"
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron/white,
+/turf/open/floor/iron/freezer,
 /area/medical/virology)
 "lzJ" = (
 /obj/structure/closet/crate/bin,
@@ -41238,15 +41282,15 @@
 /turf/open/floor/iron/dark,
 /area/security/prison)
 "lGv" = (
-/obj/machinery/door/airlock/atmos{
-	name = "Atmospherics Maintenance";
-	req_access_txt = "12;24"
+/obj/docking_port/stationary{
+	dwidth = 2;
+	height = 6;
+	id = "monastery_shuttle_asteroid";
+	name = "monastery";
+	width = 5
 	},
-/obj/effect/mapping_helpers/airlock/abandoned,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/maintenance/department/engine)
+/turf/open/space,
+/area/space)
 "lGS" = (
 /obj/item/clothing/mask/gas,
 /obj/item/clothing/mask/gas,
@@ -41279,7 +41323,9 @@
 /turf/open/floor/plating,
 /area/commons/storage/emergency/starboard)
 "lLQ" = (
-/obj/effect/spawner/random/trash/food_packaging,
+/obj/structure/disposalpipe/junction{
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "lLS" = (
@@ -41296,11 +41342,15 @@
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
 "lNy" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron/white,
-/area/medical/virology)
+/obj/structure/sign/departments/science{
+	pixel_y = 32
+	},
+/obj/machinery/power/terminal{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
 "lNW" = (
 /obj/effect/spawner/random/trash/graffiti,
 /turf/open/floor/plating,
@@ -41343,10 +41393,10 @@
 /turf/open/floor/iron/dark,
 /area/command/bridge)
 "lQX" = (
-/obj/effect/spawner/random/maintenance,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plating,
-/area/maintenance/department/engine)
+/obj/machinery/smartfridge/petri/preloaded,
+/obj/machinery/firealarm/directional/south,
+/turf/open/floor/iron/dark,
+/area/science/xenobiology)
 "lRS" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron/dark,
@@ -41504,10 +41554,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/science/xenobiology)
-"mfR" = (
-/obj/structure/closet/secure_closet/cytology,
-/turf/open/floor/iron/dark,
-/area/science/xenobiology)
 "mgW" = (
 /obj/structure/table/glass,
 /obj/machinery/reagentgrinder{
@@ -41533,10 +41579,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark,
 /area/engineering/main)
-"mmM" = (
-/obj/item/beacon,
-/turf/open/floor/engine,
-/area/science/explab)
 "mnw" = (
 /obj/machinery/power/terminal{
 	dir = 4
@@ -41571,13 +41613,14 @@
 /turf/open/floor/wood,
 /area/service/lawoffice)
 "mpU" = (
-/obj/structure/table,
-/obj/effect/spawner/random/maintenance,
-/obj/structure/cable,
-/turf/open/floor/plating{
-	icon_state = "platingdmg3"
+/obj/structure/window/reinforced{
+	dir = 8;
+	layer = 2.9
 	},
-/area/maintenance/department/engine)
+/obj/structure/lattice/catwalk,
+/obj/structure/transit_tube/crossing/horizontal,
+/turf/open/space,
+/area/space/nearstation)
 "mqg" = (
 /obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 4
@@ -41662,11 +41705,10 @@
 /turf/open/floor/plating,
 /area/tcommsat/computer)
 "mxV" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 24
-	},
-/obj/effect/turf_decal/tile/green/half/contrasted{
-	dir = 4
 	},
 /turf/open/floor/iron/white,
 /area/medical/virology)
@@ -41733,8 +41775,10 @@
 /turf/open/floor/iron/dark,
 /area/science/genetics)
 "mzU" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
-/turf/closed/wall,
+/obj/structure/grille/broken,
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
 /area/maintenance/department/engine)
 "mAi" = (
 /obj/structure/window/reinforced/spawner,
@@ -41788,15 +41832,10 @@
 	},
 /area/maintenance/department/science/xenobiology)
 "mIa" = (
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/obj/machinery/light/small{
-	dir = 8
-	},
 /obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/department/engine)
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron,
+/area/science/robotics/lab)
 "mIW" = (
 /obj/machinery/atmospherics/components/binary/thermomachine/heater{
 	dir = 4
@@ -41817,9 +41856,12 @@
 /turf/open/floor/iron/dark,
 /area/service/library/lounge)
 "mKz" = (
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/open/floor/grass,
-/area/medical/psychology)
+/obj/machinery/holopad,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/science/robotics/lab)
 "mKE" = (
 /turf/closed/wall,
 /area/medical/medbay/lobby)
@@ -41837,8 +41879,10 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "mMd" = (
-/obj/structure/window/reinforced/spawner/north,
-/obj/structure/flora/junglebush/b,
+/obj/structure/flora/junglebush/large,
+/obj/machinery/light/small{
+	dir = 4
+	},
 /turf/open/floor/grass,
 /area/medical/psychology)
 "mNv" = (
@@ -41985,24 +42029,15 @@
 /area/science/xenobiology)
 "nbt" = (
 /obj/structure/cable,
-/obj/structure/chair/comfy/brown{
-	dir = 4
-	},
-/turf/open/floor/carpet,
+/obj/machinery/holopad,
+/turf/open/floor/carpet/purple,
 /area/medical/psychology)
 "nbP" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron/freezer,
-/area/medical/virology)
-"ncE" = (
+/obj/effect/spawner/random/maintenance,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron,
-/area/science/robotics/lab)
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
 "ndc" = (
 /obj/structure/table/reinforced,
 /obj/machinery/button/door{
@@ -42294,14 +42329,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/command/heads_quarters/cmo)
-"ntk" = (
-/obj/structure/table/glass,
-/obj/effect/turf_decal/tile/neutral/half/contrasted{
-	dir = 8
-	},
-/obj/item/clothing/gloves/color/latex,
-/turf/open/floor/iron/dark,
-/area/science/genetics)
 "ntO" = (
 /obj/machinery/light{
 	dir = 8
@@ -42368,6 +42395,10 @@
 	},
 /turf/open/floor/engine,
 /area/engineering/main)
+"nAp" = (
+/obj/effect/landmark/xeno_spawn,
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
 "nAs" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -42546,11 +42577,9 @@
 /turf/open/floor/engine,
 /area/engineering/main)
 "nMV" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable,
-/obj/effect/spawner/random/trash/grille_or_waste,
+/obj/effect/spawner/random/trash/hobo_squat,
 /turf/open/floor/plating,
-/area/maintenance/department/engine)
+/area/maintenance/department/medical)
 "nNk" = (
 /obj/machinery/recharge_station,
 /obj/effect/turf_decal/stripes/line{
@@ -42583,10 +42612,11 @@
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
 "nPg" = (
-/obj/structure/window/reinforced/spawner/north,
-/obj/structure/flora/grass/jungle/b,
-/obj/structure/flora/ausbushes/lavendergrass,
-/obj/structure/flora/ausbushes/ppflowers,
+/mob/living/simple_animal/pet/dog/corgi,
+/obj/structure/water_source/puddle,
+/obj/structure/flora/ausbushes/reedbush{
+	pixel_y = 6
+	},
 /turf/open/floor/grass,
 /area/medical/psychology)
 "nPh" = (
@@ -42605,7 +42635,9 @@
 "nPn" = (
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	icon_state = "platingdmg2"
+	},
 /area/maintenance/port/lesser)
 "nPo" = (
 /obj/structure/cable,
@@ -42807,10 +42839,10 @@
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "oez" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "ofN" = (
@@ -43058,12 +43090,11 @@
 /turf/open/floor/iron,
 /area/engineering/main)
 "ouv" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/on/layer2{
-	dir = 4;
-	name = "Outlet injector"
+/obj/structure/grille/broken,
+/turf/open/floor/plating{
+	luminosity = 2
 	},
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
+/area/maintenance/department/medical)
 "ovM" = (
 /obj/machinery/camera/directional/north{
 	c_tag = "Arrivals Port Fore"
@@ -43102,18 +43133,13 @@
 /turf/open/floor/iron,
 /area/commons/storage/primary)
 "ozc" = (
-/obj/structure/table/glass,
-/obj/item/paper_bin{
-	layer = 2.9
+/obj/structure/window/reinforced{
+	dir = 1;
+	pixel_y = 1
 	},
-/obj/item/pen/red,
-/obj/item/stack/medical/gauze,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/item/hand_labeler,
-/obj/item/book/manual/wiki/infections,
-/turf/open/floor/iron/white,
+/mob/living/carbon/human/species/monkey,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron/freezer,
 /area/medical/virology)
 "oAk" = (
 /obj/effect/decal/cleanable/dirt,
@@ -43272,12 +43298,9 @@
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "oKD" = (
-/obj/structure/disposalpipe/junction,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
-/turf/open/floor/plating{
-	icon_state = "platingdmg3"
-	},
-/area/maintenance/department/engine)
+/turf/open/floor/plating,
+/area/maintenance/department/medical)
 "oKI" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -43511,10 +43534,9 @@
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
 "pds" = (
-/obj/structure/flora/ausbushes/sparsegrass,
-/mob/living/simple_animal/pet/dog/corgi/puppy,
-/turf/open/floor/grass,
-/area/medical/psychology)
+/obj/structure/sign/poster/official/corporate_perks_vacation,
+/turf/closed/wall,
+/area/maintenance/department/engine)
 "pdW" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -43577,13 +43599,11 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "piR" = (
-/obj/structure/table/wood,
-/obj/machinery/computer/med_data/laptop{
-	dir = 1;
-	pixel_y = 4
-	},
-/obj/effect/turf_decal/tile/blue/half/contrasted,
-/turf/open/floor/iron/white,
+/obj/structure/flora/junglebush,
+/obj/structure/flora/ausbushes/brflowers,
+/obj/structure/window/reinforced/spawner/north,
+/mob/living/simple_animal/pet/dog/corgi/puppy,
+/turf/open/floor/grass,
 /area/medical/psychology)
 "pku" = (
 /obj/structure/closet{
@@ -43655,11 +43675,12 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "pnF" = (
-/obj/structure/flora/junglebush,
-/obj/structure/flora/grass/jungle/b,
-/mob/living/simple_animal/butterfly,
-/turf/open/floor/grass,
-/area/medical/psychology)
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
 "pnU" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
 	dir = 4;
@@ -43816,22 +43837,16 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "pDZ" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
+/obj/structure/bookcase/random/reference,
+/turf/open/floor/carpet/purple,
+/area/medical/psychology)
+"pEv" = (
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/blue/half/contrasted{
-	dir = 8
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
 	},
-/turf/open/floor/iron/white,
-/area/medical/psychology)
-"pEv" = (
-/obj/structure/disposalpipe/junction{
-	dir = 1
-	},
-/turf/open/floor/plating,
 /area/maintenance/department/engine)
 "pEL" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -43993,9 +44008,12 @@
 /turf/open/floor/iron/dark,
 /area/hallway/secondary/service)
 "pOc" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/table/glass,
+/obj/item/folder/white{
+	pixel_y = 4
+	},
+/obj/item/pen/red,
+/obj/machinery/light/small,
 /turf/open/floor/iron/freezer,
 /area/medical/virology)
 "pOr" = (
@@ -44023,16 +44041,27 @@
 /turf/open/floor/carpet,
 /area/service/library/artgallery)
 "pQQ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plating{
-	icon_state = "platingdmg3"
+/obj/structure/table/glass,
+/obj/item/paper_bin{
+	layer = 2.9
 	},
-/area/maintenance/department/engine)
+/obj/item/pen/red,
+/obj/item/stack/medical/gauze,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/item/hand_labeler,
+/obj/item/book/manual/wiki/infections,
+/obj/effect/turf_decal/tile/green/half/contrasted{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron/white,
+/area/medical/virology)
 "pTy" = (
-/obj/machinery/door/window/left/directional/east{
-	dir = 1;
-	name = "Petting Garden"
-	},
+/obj/structure/flora/grass/jungle,
+/obj/structure/flora/ausbushes/brflowers,
+/obj/structure/flora/ausbushes/ppflowers,
 /turf/open/floor/grass,
 /area/medical/psychology)
 "pTD" = (
@@ -44181,10 +44210,11 @@
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
 "qdj" = (
-/obj/structure/disposalpipe/segment,
-/obj/item/stack/sheet/mineral/wood,
-/turf/open/floor/plating,
-/area/maintenance/department/engine)
+/obj/structure/cable,
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/maintenance/department/medical)
 "qgq" = (
 /obj/effect/spawner/random/trash/grime,
 /turf/open/floor/plating,
@@ -44218,11 +44248,15 @@
 	frequency = 1485;
 	pixel_x = -30
 	},
+/obj/machinery/camera/directional/west{
+	c_tag = "Medbay Psychology Office";
+	network = list("ss13","medbay")
+	},
 /obj/structure/filingcabinet/filingcabinet,
-/obj/effect/turf_decal/tile/blue/half/contrasted{
+/obj/machinery/light/small{
 	dir = 8
 	},
-/turf/open/floor/iron/white,
+/turf/open/floor/carpet/purple,
 /area/medical/psychology)
 "qib" = (
 /obj/machinery/disposal/delivery_chute{
@@ -44333,11 +44367,10 @@
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "qpT" = (
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/engine)
+/obj/structure/lattice/catwalk,
+/obj/structure/transit_tube/horizontal,
+/turf/open/space/basic,
+/area/space/nearstation)
 "qqa" = (
 /obj/structure/window/reinforced/plasma/spawner/west,
 /obj/structure/cable,
@@ -44421,14 +44454,14 @@
 /turf/open/floor/engine/vacuum,
 /area/maintenance/disposal/incinerator)
 "qvx" = (
-/obj/item/kirbyplants{
-	icon_state = "plant-21"
-	},
-/obj/machinery/light/small{
+/obj/effect/turf_decal/tile/purple/half/contrasted{
 	dir = 1
 	},
-/turf/open/floor/plating,
-/area/maintenance/department/medical)
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/science/genetics)
 "qvH" = (
 /obj/effect/landmark/start/atmospheric_technician,
 /turf/open/floor/iron,
@@ -44465,11 +44498,11 @@
 /turf/open/floor/plating,
 /area/tcommsat/computer)
 "qxU" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
-/obj/structure/cable,
-/turf/open/floor/iron/white,
+/turf/open/floor/carpet/purple,
 /area/medical/psychology)
 "qzm" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -44484,10 +44517,11 @@
 /turf/open/floor/iron,
 /area/commons/storage/primary)
 "qCG" = (
-/obj/structure/grille/broken,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/light/small{
+	dir = 1
+	},
 /turf/open/floor/plating{
-	icon_state = "platingdmg1"
+	icon_state = "platingdmg3"
 	},
 /area/maintenance/department/engine)
 "qEf" = (
@@ -44507,11 +44541,7 @@
 /turf/open/floor/iron,
 /area/cargo/sorting)
 "qEx" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
+/obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "qEN" = (
@@ -44560,12 +44590,8 @@
 /turf/closed/wall/r_wall,
 /area/maintenance/disposal/incinerator)
 "qIl" = (
-/obj/machinery/computer/pandemic,
-/obj/machinery/airalarm/directional/north{
-	pixel_y = 22
-	},
-/obj/effect/turf_decal/tile/green/half/contrasted{
-	dir = 1
+/obj/effect/turf_decal/tile/green{
+	dir = 4
 	},
 /turf/open/floor/iron/white,
 /area/medical/virology)
@@ -44877,10 +44903,15 @@
 	},
 /area/maintenance/department/engine)
 "rhT" = (
-/obj/structure/flora/ausbushes/fullgrass,
-/mob/living/simple_animal/butterfly,
-/turf/open/floor/grass,
-/area/medical/psychology)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/spawner/random/trash/grime,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
 "rie" = (
 /obj/structure/chair/wood{
 	dir = 8
@@ -44953,12 +44984,9 @@
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
 "rnE" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/space/nearstation)
+/obj/structure/flora/junglebush/b,
+/turf/open/floor/grass,
+/area/medical/psychology)
 "roa" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -45057,6 +45085,12 @@
 	},
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/hos)
+"rtA" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
 "rtD" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -45177,13 +45211,13 @@
 /turf/open/floor/engine,
 /area/medical/chemistry)
 "rzp" = (
-/obj/structure/table,
-/obj/item/stack/sheet/iron/fifty,
-/obj/item/stack/rods/fifty,
-/obj/machinery/atmospherics/pipe/layer_manifold/supply/hidden,
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/structure/disposalpipe/junction/yjunction{
+	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/turf/open/floor/plating,
 /area/maintenance/department/engine)
 "rAE" = (
 /obj/machinery/light/small{
@@ -45321,17 +45355,9 @@
 /turf/open/floor/iron/white,
 /area/medical/exam_room)
 "rJg" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/binary/pump/on{
-	dir = 1;
-	name = "Air Out"
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating{
-	icon_state = "platingdmg1"
-	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
 /area/maintenance/department/engine)
 "rJZ" = (
 /obj/docking_port/stationary{
@@ -45392,10 +45418,10 @@
 /turf/open/floor/plating,
 /area/cargo/sorting)
 "rMV" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating/airless,
-/area/maintenance/department/engine)
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
+/area/maintenance/department/medical)
 "rMZ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
@@ -45487,24 +45513,15 @@
 /turf/open/floor/iron/dark,
 /area/service/bar)
 "rXJ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/spawner/atmos_canister/air,
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
+/turf/open/floor/plating,
 /area/maintenance/department/engine)
 "rXT" = (
-/obj/structure/flora/grass/jungle/b,
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/machinery/camera/directional/west{
-	c_tag = "Genetics Monkey Pen Fore";
-	network = list("ss13","medbay")
-	},
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/grass,
+/obj/structure/sign/poster/official/ian,
+/turf/closed/wall,
 /area/medical/psychology)
 "rYC" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -45596,13 +45613,6 @@
 /turf/open/floor/iron,
 /area/security/prison)
 "sea" = (
-/obj/structure/flora/ausbushes/lavendergrass,
-/obj/structure/flora/ausbushes/sparsegrass,
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/flora/ausbushes/grassybush,
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/flora/ausbushes/pointybush,
-/obj/structure/flora/junglebush,
 /obj/structure/flora/junglebush/large,
 /turf/open/floor/grass,
 /area/medical/psychology)
@@ -45612,14 +45622,6 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/sorting)
-"sfk" = (
-/obj/effect/turf_decal/tile/purple/half/contrasted,
-/obj/effect/turf_decal/stripes/line,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/science/genetics)
 "sgc" = (
 /obj/machinery/vending/cigarette,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -45786,13 +45788,8 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "stQ" = (
-/obj/structure/sign/departments/science{
-	pixel_y = 32
-	},
-/obj/machinery/power/terminal{
-	dir = 8
-	},
-/turf/open/floor/plating,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/turf/closed/wall,
 /area/maintenance/department/engine)
 "sut" = (
 /obj/structure/window/reinforced{
@@ -45972,13 +45969,12 @@
 /turf/open/floor/iron,
 /area/engineering/main)
 "sKe" = (
-/obj/structure/chair/comfy{
-	dir = 8
+/obj/effect/turf_decal/tile/neutral/half/contrasted,
+/obj/structure/sink{
+	pixel_y = 20
 	},
-/obj/effect/landmark/start/assistant,
-/obj/machinery/light/small,
-/turf/open/floor/iron,
-/area/hallway/secondary/entry)
+/turf/open/floor/iron/dark,
+/area/science/genetics)
 "sLv" = (
 /obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 8
@@ -46053,12 +46049,10 @@
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "sUP" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/meter/monitored/layer2,
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
-	},
+/turf/open/floor/plating,
 /area/maintenance/department/engine)
 "sWj" = (
 /obj/effect/turf_decal/stripes/line,
@@ -46075,15 +46069,12 @@
 /turf/open/floor/engine,
 /area/engineering/main)
 "sXi" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
-/obj/structure/sign/warning/deathsposal{
-	pixel_x = -32
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/engine)
+/obj/structure/table,
+/obj/item/folder,
+/obj/item/pen,
+/obj/machinery/light/small,
+/turf/open/floor/iron,
+/area/hallway/secondary/entry)
 "sXR" = (
 /obj/structure/disposalpipe/junction,
 /turf/closed/wall/r_wall,
@@ -46118,7 +46109,11 @@
 /turf/open/floor/plating,
 /area/maintenance/department/science/xenobiology)
 "sZP" = (
-/obj/structure/closet,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "sZU" = (
@@ -46195,10 +46190,13 @@
 /turf/open/floor/plating,
 /area/engineering/supermatter)
 "tbS" = (
-/obj/structure/chair/sofa/left,
 /obj/machinery/firealarm/directional/north,
 /obj/machinery/light_switch/directional/east,
-/turf/open/floor/carpet,
+/obj/structure/table/wood,
+/obj/item/flashlight/lamp/green{
+	pixel_y = 4
+	},
+/turf/open/floor/carpet/purple,
 /area/medical/psychology)
 "tcm" = (
 /turf/open/floor/iron/white,
@@ -46367,10 +46365,21 @@
 /turf/open/floor/plating,
 /area/maintenance/port/lesser)
 "tml" = (
-/obj/structure/cable,
-/obj/effect/spawner/random/trash/food_packaging,
-/turf/open/floor/plating,
-/area/maintenance/department/medical)
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/requests_console{
+	department = "Virology";
+	name = "Virology Requests Console";
+	pixel_x = -32;
+	receive_ore_updates = 1
+	},
+/obj/effect/turf_decal/tile/green/half/contrasted{
+	dir = 8
+	},
+/obj/machinery/vending/wardrobe/viro_wardrobe,
+/turf/open/floor/iron/white,
+/area/medical/virology)
 "tnY" = (
 /obj/machinery/button/door{
 	id = "aux_base_shutters";
@@ -46873,12 +46882,10 @@
 /turf/open/floor/plating,
 /area/engineering/main)
 "tZa" = (
-/obj/machinery/vending/wardrobe/viro_wardrobe,
-/obj/effect/turf_decal/tile/green/half/contrasted{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/medical/virology)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
 "uaC" = (
 /obj/structure/chair/comfy/black{
 	dir = 8
@@ -46980,31 +46987,6 @@
 	},
 /turf/open/floor/wood,
 /area/maintenance/department/engine)
-"uiV" = (
-/obj/structure/table,
-/obj/item/book/manual/wiki/robotics_cyborgs{
-	pixel_x = 6;
-	pixel_y = 5
-	},
-/obj/item/storage/belt/utility,
-/obj/item/reagent_containers/glass/beaker/large,
-/obj/item/radio/headset/headset_sci{
-	pixel_x = -3
-	},
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/machinery/button/door{
-	id = "robotics";
-	name = "Shutters Control Button";
-	pixel_x = -26;
-	pixel_y = 8;
-	req_access_txt = "29"
-	},
-/obj/machinery/light_switch{
-	pixel_x = -25;
-	pixel_y = -8
-	},
-/turf/open/floor/iron/dark,
-/area/science/robotics/lab)
 "ujf" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 4
@@ -47128,19 +47110,17 @@
 /turf/open/floor/iron/dark,
 /area/service/library/artgallery)
 "umV" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/department/engine)
-"und" = (
-/obj/machinery/door/window/left/directional/east{
-	name = "Monkey Pen";
-	req_one_access_txt = "39"
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
-/turf/open/floor/iron/white,
+/obj/structure/bed,
+/obj/item/bedsheet/medical,
+/turf/open/floor/iron/freezer,
 /area/medical/virology)
+"und" = (
+/obj/effect/spawner/atmos_canister/air,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/medical)
 "uok" = (
 /obj/structure/cable,
 /obj/effect/spawner/random/trash/garbage,
@@ -47162,7 +47142,7 @@
 /turf/open/floor/iron,
 /area/security)
 "uqs" = (
-/obj/structure/flora/junglebush/c,
+/obj/structure/flora/junglebush,
 /turf/open/floor/grass,
 /area/medical/psychology)
 "uqJ" = (
@@ -47194,18 +47174,18 @@
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "urP" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
+/obj/structure/flora/grass/jungle/b,
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/machinery/camera/directional/west{
+	c_tag = "Genetics Monkey Pen Fore";
+	network = list("ss13","medbay")
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
+/obj/machinery/light/small{
+	dir = 8
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/science/genetics)
+/mob/living/simple_animal/butterfly,
+/turf/open/floor/grass,
+/area/medical/psychology)
 "usl" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
 /turf/open/floor/iron/dark,
@@ -47335,9 +47315,9 @@
 /turf/closed/wall,
 /area/maintenance/department/cargo)
 "uAs" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
+/obj/effect/landmark/blobstart,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/freezer,
 /area/medical/virology)
 "uAx" = (
@@ -47459,9 +47439,10 @@
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
 "uLp" = (
-/obj/structure/flora/ausbushes/lavendergrass,
-/turf/open/floor/grass,
-/area/medical/psychology)
+/obj/structure/cable,
+/obj/structure/reagent_dispensers/watertank,
+/turf/open/floor/plating,
+/area/maintenance/department/medical)
 "uLF" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/red{
@@ -47500,12 +47481,9 @@
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "uOA" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/structure/reagent_dispensers/water_cooler,
-/obj/effect/turf_decal/tile/blue/half/contrasted,
-/turf/open/floor/iron/white,
+/obj/structure/window/reinforced/spawner/north,
+/obj/structure/flora/ausbushes/fernybush,
+/turf/open/floor/grass,
 /area/medical/psychology)
 "uPu" = (
 /obj/machinery/plate_press,
@@ -47671,12 +47649,11 @@
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "vbv" = (
-/obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+/obj/effect/landmark/xeno_spawn,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/mob/living/carbon/human/species/monkey,
 /turf/open/floor/iron/freezer,
 /area/medical/virology)
 "vbR" = (
@@ -47731,14 +47708,11 @@
 /turf/open/floor/plating,
 /area/maintenance/port/lesser)
 "vgg" = (
-/obj/structure/table/wood,
-/obj/item/flashlight/lamp/green{
-	pixel_y = 4
-	},
 /obj/structure/noticeboard{
 	pixel_y = 32
 	},
-/turf/open/floor/carpet,
+/obj/structure/chair/sofa/right,
+/turf/open/floor/carpet/purple,
 /area/medical/psychology)
 "vgp" = (
 /obj/machinery/door/firedoor,
@@ -47775,12 +47749,11 @@
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "viB" = (
-/obj/structure/reagent_dispensers/watertank,
-/obj/structure/sign/warning/deathsposal{
-	pixel_x = -32
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
-/turf/open/floor/plating,
-/area/maintenance/department/engine)
+/turf/open/floor/iron,
+/area/science/robotics/lab)
 "vjH" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/reagent_dispensers/fueltank/large,
@@ -47806,6 +47779,7 @@
 	name = "Pharmacy"
 	},
 /obj/structure/cable,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "vlV" = (
@@ -47824,15 +47798,18 @@
 /turf/open/floor/iron/white,
 /area/medical/storage)
 "vmo" = (
-/obj/machinery/camera/directional/west{
-	c_tag = "Medbay Psychology Office";
-	network = list("ss13","medbay")
-	},
 /obj/machinery/airalarm/directional/west,
-/obj/effect/turf_decal/tile/blue/half/contrasted{
-	dir = 8
+/obj/structure/table/wood,
+/obj/item/paper_bin/carbon{
+	pixel_x = -3;
+	pixel_y = 2
 	},
-/turf/open/floor/iron/white,
+/obj/item/pen,
+/obj/item/folder/white{
+	pixel_x = 14;
+	pixel_y = 3
+	},
+/turf/open/floor/carpet/purple,
 /area/medical/psychology)
 "vmA" = (
 /obj/effect/turf_decal/stripes/line{
@@ -47855,14 +47832,11 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "vmY" = (
-/obj/structure/table/glass,
-/obj/item/reagent_containers/dropper,
-/obj/item/reagent_containers/syringe,
-/obj/item/reagent_containers/glass/beaker,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
-/turf/open/floor/iron/freezer,
-/area/medical/virology)
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/maintenance/department/medical)
 "voI" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -47909,10 +47883,12 @@
 /turf/open/floor/iron,
 /area/cargo/storage)
 "vsn" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
+/obj/structure/table/wood,
+/obj/machinery/computer/med_data/laptop{
+	dir = 1;
+	pixel_y = 4
 	},
-/turf/open/floor/iron/white,
+/turf/open/floor/carpet/purple,
 /area/medical/psychology)
 "vsw" = (
 /obj/effect/turf_decal/trimline/brown/filled/line{
@@ -48050,10 +48026,20 @@
 /turf/open/floor/iron/dark,
 /area/service/chapel/monastery)
 "vGg" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/maintenance/department/engine)
+/obj/effect/turf_decal/tile/green/anticorner/contrasted{
+	dir = 4
+	},
+/obj/machinery/camera/directional/east{
+	c_tag = "Virology Lab";
+	network = list("ss13","medbay")
+	},
+/obj/machinery/disposal/bin,
+/obj/structure/sign/warning/deathsposal{
+	pixel_y = 32
+	},
+/obj/structure/disposalpipe/trunk,
+/turf/open/floor/iron/white,
+/area/medical/virology)
 "vHj" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -48270,10 +48256,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/science/mixing)
-"vUh" = (
-/obj/machinery/rnd/experimentor,
-/turf/open/floor/engine,
-/area/science/explab)
 "vVQ" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -48353,14 +48335,14 @@
 /turf/open/floor/engine,
 /area/engineering/main)
 "wdx" = (
-/obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "wem" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/spawner/random/trash/food_packaging,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "wen" = (
@@ -48411,15 +48393,9 @@
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "wha" = (
-/obj/structure/table/glass,
-/obj/item/folder/white{
-	pixel_y = 4
-	},
-/obj/item/pen/red,
-/obj/machinery/light/small,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron/freezer,
-/area/medical/virology)
+/obj/effect/spawner/random/trash/food_packaging,
+/turf/open/floor/plating,
+/area/maintenance/department/medical)
 "whH" = (
 /obj/structure/chair/wood,
 /obj/item/radio/intercom/chapel{
@@ -48493,11 +48469,10 @@
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
 "wlc" = (
-/obj/structure/table,
-/obj/item/storage/box/mousetraps,
-/obj/effect/spawner/random/maintenance,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
+/obj/structure/mineral_door/wood{
+	name = "The Roosterdome"
+	},
+/turf/open/floor/iron/dark,
 /area/maintenance/department/engine)
 "wns" = (
 /obj/machinery/smartfridge/chemistry/preloaded,
@@ -48573,11 +48548,9 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "wwp" = (
-/obj/structure/disposalpipe/segment{
-	dir = 10
+/obj/item/kirbyplants{
+	icon_state = "plant-21"
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
-/obj/effect/spawner/random/trash/graffiti,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "wwr" = (
@@ -48676,6 +48649,7 @@
 	network = list("ss13","medbay");
 	c_tag = "Medbay Port Hall"
 	},
+/obj/structure/chair,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "wCj" = (
@@ -48755,8 +48729,10 @@
 /turf/closed/wall,
 /area/maintenance/disposal)
 "wGM" = (
-/obj/effect/turf_decal/tile/blue/half/contrasted,
-/turf/open/floor/iron/white,
+/obj/structure/flora/ausbushes/sparsegrass,
+/mob/living/simple_animal/pet/dog/corgi/puppy,
+/obj/structure/window/reinforced/spawner/north,
+/turf/open/floor/grass,
 /area/medical/psychology)
 "wIv" = (
 /obj/machinery/power/apc/highcap/five_k{
@@ -48820,10 +48796,12 @@
 /turf/open/floor/iron/dark,
 /area/maintenance/disposal/incinerator)
 "wMn" = (
-/obj/structure/window/reinforced/spawner/east,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron/white,
-/area/medical/virology)
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/science/robotics/lab)
 "wMF" = (
 /obj/effect/spawner/random/food_or_drink/three_course_meal,
 /obj/effect/spawner/random/food_or_drink/three_course_meal,
@@ -48838,11 +48816,11 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "wNq" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "wNQ" = (
@@ -49014,10 +48992,10 @@
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "wVV" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/spawner/structure/window/reinforced,
+/obj/item/chair,
+/obj/effect/spawner/random/trash/cigbutt,
 /turf/open/floor/plating,
-/area/medical/virology)
+/area/maintenance/department/medical)
 "wWC" = (
 /obj/structure/chair,
 /obj/effect/turf_decal/bot,
@@ -49026,12 +49004,9 @@
 /turf/open/floor/iron/dark,
 /area/hallway/primary/aft)
 "wWO" = (
-/obj/structure/lattice,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/maintenance/department/medical)
 "wXu" = (
 /obj/machinery/door/window/left/directional/south{
 	dir = 8;
@@ -49056,11 +49031,12 @@
 	},
 /area/maintenance/department/cargo)
 "xan" = (
-/obj/structure/disposalpipe/segment{
-	dir = 5
+/obj/effect/turf_decal/tile/blue/half/contrasted,
+/obj/structure/chair{
+	dir = 1
 	},
 /turf/open/floor/iron/white,
-/area/science/genetics)
+/area/medical/medbay/central)
 "xau" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -49162,11 +49138,9 @@
 /turf/open/floor/wood,
 /area/service/lawoffice)
 "xeI" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
-/obj/structure/chair/stool/directional/west,
-/turf/open/floor/plating,
-/area/maintenance/department/engine)
+/obj/item/beacon,
+/turf/open/floor/engine,
+/area/science/explab)
 "xgt" = (
 /obj/machinery/dna_scannernew,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -49649,19 +49623,20 @@
 /turf/open/floor/iron/dark,
 /area/service/library/artgallery)
 "xNx" = (
-/obj/structure/lattice,
-/obj/structure/disposalpipe/junction/flip,
-/turf/open/space/basic,
-/area/space/nearstation)
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/sorting/mail/flip{
+	dir = 1;
+	sortType = 27
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
 "xNS" = (
-/obj/effect/turf_decal/tile/purple/half/contrasted{
-	dir = 1
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating{
+	icon_state = "platingdmg2"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/science/genetics)
+/area/maintenance/department/engine)
 "xOC" = (
 /obj/machinery/door/airlock/external{
 	name = "Construction Zone"
@@ -49766,12 +49741,14 @@
 /turf/open/floor/iron/dark,
 /area/science/server)
 "xXe" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/segment{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/obj/machinery/atmospherics/components/binary/pump/off/general/visible/layer2{
+	name = "Virology Waste to Atmos";
 	dir = 4
 	},
-/obj/effect/spawner/random/trash/grime,
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
 /area/maintenance/department/engine)
 "xXA" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -49881,10 +49858,10 @@
 /turf/open/floor/iron,
 /area/construction/mining/aux_base)
 "ygZ" = (
-/obj/effect/spawner/random/structure/crate,
-/turf/open/floor/plating{
-	icon_state = "platingdmg3"
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/spawner/random/trash/mess,
+/obj/structure/cable,
+/turf/open/floor/plating,
 /area/maintenance/department/engine)
 "yhB" = (
 /obj/structure/disposaloutlet,
@@ -58346,7 +58323,7 @@ aaa
 aaa
 aaa
 aaa
-cjB
+aaa
 aaa
 aaa
 aaa
@@ -58586,11 +58563,6 @@ aaa
 aaa
 aaa
 aaa
-bZY
-bZY
-cBM
-bZY
-bZY
 aaa
 aaa
 aaa
@@ -58600,12 +58572,17 @@ aaa
 aaa
 aaa
 aaa
-cfN
-cfN
-fIT
-cfH
-fIT
-cfN
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -58842,28 +58819,28 @@ aaa
 aaa
 aaa
 aaa
-bZY
-bZY
-csn
-ceF
-csY
-bZY
-bZY
 aaa
 aaa
 aaa
 aaa
-cfN
-cfN
-cfN
-cfN
-cfN
-cfN
-fIT
-cfI
-fIT
-cfN
-cfN
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -59099,28 +59076,28 @@ aaa
 aaa
 aaa
 aaa
-cBM
-csd
-csd
-csB
-csd
-csd
-cBM
 aaa
 aaa
-cfN
-cfN
-cfN
-cfN
-cfN
-cfN
-cfN
-cfN
-fIT
-cjC
-fIT
-cfN
-cfN
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -59352,33 +59329,33 @@ aaa
 aaa
 aaa
 aaa
-cfN
-cfN
-cfN
-bZY
-bZY
-cse
-cso
-csC
-cdp
-kDf
-bZY
-bZY
-cfN
-cfN
-cfN
-cfN
-cfN
-cfN
-cfN
-bWV
-bWV
-fIT
-cfJ
-fIT
-bWV
-cfN
-cfN
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -59608,34 +59585,34 @@ aaa
 aaa
 aaa
 aaa
-cfN
-bZY
-bZY
-bZY
-bZY
-jsD
-csd
-csp
-csp
-csp
-csd
-dpb
-bZY
-bZY
-cfN
-cfN
-cfN
-cfN
-cfN
-cfN
-bWV
-ciJ
-cjf
-cdw
-cjZ
-bWV
-cfN
-cfN
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -59865,34 +59842,34 @@ aaa
 aaa
 aaa
 aaa
-bZY
-bZY
-crt
-crD
-bZY
-xSX
-csi
-owS
-csE
-rrU
-ctr
-cdo
-ctX
-bWV
-bWV
-bWV
-bWV
-bWV
-bWV
-bWV
-bWV
-ciK
-bXJ
-cjk
-cka
-bWV
-cfN
-cfN
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -60122,36 +60099,36 @@ aaa
 aaa
 aaa
 aaa
-crb
-crg
-cru
-nvG
-bZY
-crT
-csi
-owS
-csE
-rrU
-ctr
-cdo
-kfM
-bWV
-cuk
-cus
-cuG
-bWV
-chC
-chV
-bWV
-bWV
-cvq
-aTf
-bWV
-bWV
-bWV
-bWV
-cwM
-bIT
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -60378,38 +60355,38 @@ aaa
 aaa
 aaa
 aaa
-cfN
-bZY
-ceC
-aRJ
-ceE
-nku
-ceE
-csg
-csq
-aTd
-rrU
-ctr
-cdo
-lzJ
-bWV
-cgb
-cut
-cuH
-chb
-chD
-chW
-bWV
-bWV
-bWV
-cvA
-bWV
-cwj
-cww
-bWV
-fIT
-fIT
-cxg
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -60634,39 +60611,39 @@ aaa
 aaa
 aaa
 aaa
-cfN
-cfN
-bZY
-crh
-crv
-crG
-bZY
-crU
-csh
-csr
-aTe
-ctb
-ctt
-ctJ
-bZY
-bWV
-cul
-chB
-cuI
-chc
-cuZ
-chX
-bWV
-ciz
-cvr
-aTf
-cvR
-bXJ
-bXJ
-crj
-cwO
-fIT
-cxh
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+cjB
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -60890,41 +60867,41 @@ aaa
 aaa
 aaa
 aaa
-bVp
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+bZY
+bZY
+cBM
+bZY
+bZY
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 cfN
 cfN
-bZY
-bZY
-bZY
-bZY
-bZY
-bZY
-lAf
-owS
-aTe
-rrU
-ctu
-bZY
-bZY
-bWV
-cum
-cgd
-cuJ
-chd
-chE
-chY
-bWV
-ciz
-cvs
-cvB
-cvS
-bXJ
-bXJ
-bXJ
-bXJ
 fIT
+cfH
 fIT
-cxg
+cfN
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -61146,41 +61123,41 @@ aaa
 aaa
 aaa
 aaa
-bGI
-bNs
-cfN
-cqW
-cqW
-cfN
-cfN
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 bZY
-giI
-pkM
-crv
-owS
-aTe
-rrU
-gKz
 bZY
+csn
+ceF
+csY
+bZY
+bZY
+aaa
+aaa
+aaa
+aaa
 cfN
-bWV
-cfC
-cuu
-chU
-cuR
-ciy
-chZ
-bWV
-ciz
-ckb
-cku
-cvT
-bZo
-cwx
-cwE
-ckv
-ckM
-clb
+cfN
+cfN
+cfN
+cfN
+cfN
+fIT
+cfI
+fIT
+cfN
+cfN
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -61403,41 +61380,41 @@ aaa
 aaa
 aaa
 aaa
-bGI
-bNs
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+cBM
+csd
+csd
+csB
+csd
+csd
+cBM
+aaa
+aaa
 cfN
 cfN
 cfN
 cfN
-bOw
-bZY
-pkM
-bZY
-bZY
-bZY
-tan
-bZY
-bZY
-bZY
 cfN
-bWV
-bWV
-bWV
-bWV
-cuS
-bWV
-bWV
-bWV
-ciz
-ckb
-cku
-cvT
-cwk
-cwy
-cwE
-ckw
-ckN
-clb
+cfN
+cfN
+cfN
+fIT
+cjC
+fIT
+cfN
+cfN
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -61660,42 +61637,42 @@ aaa
 aaa
 aaa
 aaa
-bGI
-bNs
-cqW
-bOw
+aaa
+aaa
+aaa
+aaa
+aaa
 cfN
-bOw
-bOw
-bOw
-bOw
-bOw
-ccu
-ceB
-cef
-ceB
+cfN
+cfN
+bZY
+bZY
+cse
+cso
+csC
+cdp
+kDf
+bZY
+bZY
+cfN
+cfN
+cfN
+cfN
 cfN
 cfN
 cfN
 bWV
-cdr
-cuv
-cdw
-aTf
-crj
-ciN
 bWV
-ciz
-cvs
-cvB
-cvV
-cdx
-ciA
-bXJ
-bXJ
 fIT
+cfJ
 fIT
-cxg
+bWV
+cfN
+cfN
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -61913,45 +61890,45 @@ aaa
 aaa
 aaa
 aaa
-aby
-aby
-aby
-aby
-cqU
-bNs
-bUC
-bOw
-bOw
-bOw
-bOw
-bOw
-bOw
-bUC
-bOw
-ceB
-csM
-ceB
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+cfN
+bZY
+bZY
+bZY
+bZY
+jsD
+csd
+csp
+csp
+csp
+csd
+dpb
+bZY
+bZY
+cfN
+cfN
+cfN
 cfN
 cfN
 cfN
 bWV
-cdC
-cuw
-cbK
-aTf
-ciA
-cvd
+ciJ
+cjf
+cdw
+cjZ
 bWV
-ciz
-cvt
-aTf
-crk
-bXJ
-bXJ
-cwG
-cwO
-fIT
-cxk
+cfN
+cfN
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -62170,56 +62147,40 @@ aaa
 aaa
 aaa
 aaa
-aby
 aaa
 aaa
-tpI
-bNs
-bNs
-bOw
-bOw
-bOw
-bOw
-bOw
-bOw
-bOw
-bOw
-bOw
-ceB
-cee
-ceB
-cfN
-cfN
-cfN
-bWV
-cdC
-cux
-cbK
-aTf
-cdC
-ciO
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+bZY
+bZY
+crt
+crD
+bZY
+xSX
+csi
+owS
+csE
+rrU
+ctr
+cdo
+ctX
 bWV
 bWV
 bWV
-cjl
 bWV
-cwl
-cwz
 bWV
-fIT
-fIT
-cxg
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-cfN
+bWV
+bWV
+bWV
+ciK
+bXJ
+cjk
+cka
+bWV
 cfN
 cfN
 aaa
@@ -62228,8 +62189,24 @@ aaa
 aaa
 aaa
 aaa
-cfN
-cfN
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -62427,44 +62404,44 @@ aaa
 aaa
 aaa
 aaa
-abI
-bGD
-bQQ
-bNs
-bNs
-bQe
-bOw
-bOw
-bOw
-bOw
-bOw
-bOw
-bSm
-bOw
-bUC
-ceB
-cef
-ceB
-cfN
-cfN
-cfN
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+crb
+crg
+cru
+nvG
+bZY
+crT
+csi
+owS
+csE
+rrU
+ctr
+cdo
+kfM
 bWV
-bXJ
-cve
-cuK
-aTf
-bXJ
-cve
+cuk
+cus
+cuG
 bWV
+chC
+chV
+bWV
+bWV
+cvq
 aTf
-ckd
-aTf
-cjm
-cjm
-cjm
-cjm
-cwR
-cwR
+bWV
+bWV
+bWV
+bWV
+cwM
+bIT
 aaa
 aaa
 aaa
@@ -62473,22 +62450,22 @@ aaa
 aaa
 aaa
 aaa
-cfN
-cfN
-cfN
-cfN
-cfN
-cyM
 aaa
 aaa
 aaa
-cfN
-cfN
-cfN
-cfN
-cfN
-cfN
-cfN
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -62677,77 +62654,77 @@ aaa
 aaa
 aaa
 aaa
-aby
-abI
-aby
-aby
-aby
-aby
 aaa
-bNr
-bNs
-bNs
-bNs
-bOw
-bOw
-bOw
-bOw
-bOw
-bOw
-bOw
-bQe
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+cfN
+bZY
+ceC
+aRJ
+ceE
+nku
+ceE
+csg
+csq
+aTd
+rrU
+ctr
+cdo
+lzJ
+bWV
+cgb
+cut
+cuH
+chb
+chD
+chW
 bWV
 bWV
 bWV
+cvA
 bWV
-ceg
+cwj
+cww
 bWV
-cfm
-cfm
-cfm
-cfm
-cfm
-cfm
-cfm
-cuU
-cfm
-cfm
-cfm
-cjH
-cfm
-cfm
-cwa
-cky
-gOS
-cjm
-cld
-tYF
+fIT
+fIT
+cxg
 aaa
 aaa
 aaa
 aaa
 aaa
 aaa
-cfN
-cfN
-cfN
-cfN
-cfN
-cfN
-cfN
-aht
 aaa
 aaa
 aaa
-cfN
-cyM
-cfN
-cfN
-cfN
-cfN
-cfN
-cfN
-cfN
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -62934,77 +62911,77 @@ aaa
 aaa
 aaa
 aaa
-aby
 aaa
 aaa
-bOv
-bGD
-bOv
-bQQ
-bNs
-bNs
-bOw
-bOw
-bOw
-bOw
-bOw
-bOw
-bOw
-bOw
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+cfN
+cfN
+bZY
+crh
+crv
+crG
+bZY
+crU
+csh
+csr
+aTe
+ctb
+ctt
+ctJ
+bZY
 bWV
+cul
+chB
+cuI
+chc
+cuZ
+chX
 bWV
-bWV
+ciz
+cvr
+aTf
+cvR
 bXJ
-bYz
-cdr
-cfD
 bXJ
-cfm
-ctK
-cvu
-cfD
-chf
-cuz
-cvu
-cfD
-cvu
-cfD
-chf
-cfD
-cvu
-cvE
-cwa
-cky
-gOS
-idA
-cld
-cjm
+crj
+cwO
+fIT
+cxh
 aaa
 aaa
 aaa
 aaa
 aaa
 aaa
-cfN
-cfN
-cfN
-cyM
-cfN
-cyM
-aaa
-aht
 aaa
 aaa
 aaa
 aaa
-aht
 aaa
-cfN
-cfN
-cfN
-cfN
-cfN
-cfN
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -63191,77 +63168,77 @@ aaa
 aaa
 aaa
 aaa
-aed
-abI
-bNr
-bNs
-bNs
-bNs
-bNs
-bNs
-bSm
-bOw
-bOw
-bOw
-bOw
-bOw
-bOw
-bOw
-bUC
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+bVp
+cfN
+cfN
+bZY
+bZY
+bZY
+bZY
+bZY
+bZY
+lAf
+owS
+aTe
+rrU
+ctu
+bZY
+bZY
 bWV
-whH
-caT
-vFZ
+cum
+cgd
+cuJ
+chd
+chE
+chY
 bWV
-cds
-cfD
-ceH
-cfl
-cvu
-cvy
-cvy
-cvy
-cvy
-cvy
-bXI
-cvy
-cvy
-cvy
-cvy
-cvy
-cvu
-cwa
-cwm
-ckj
-ckj
-ckO
-cjm
-cfN
+ciz
+cvs
+cvB
+cvS
+bXJ
+bXJ
+bXJ
+bXJ
+fIT
+fIT
+cxg
 aaa
 aaa
 aaa
 aaa
 aaa
-cfN
-cfN
-cfN
-aht
 aaa
-aht
 aaa
-aht
-aht
-aht
-aht
-aht
-aht
 aaa
-cfN
-cfN
-cyM
-cfN
-cfN
-cfN
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -63445,79 +63422,79 @@ aaa
 aaa
 aaa
 aaa
-bHI
-aby
-aby
-aby
-bGH
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+bGI
 bNs
-bNs
-bOw
-bQc
-bOw
-bOw
-bOw
-bOw
-bOw
-bOw
-bOw
-bOw
-bOw
-bWV
-bWV
-bWV
-bYz
-bWV
-bWV
-bWV
-bWV
-cei
-bWV
-cfm
-cfD
-cvy
-bWV
-cgG
-cgG
-bWV
-cuX
-bWV
-cgG
-cgG
-bWV
-cvy
-cfD
-cwa
-cwn
-ckg
-ckz
-ckP
-cjm
+cfN
+cqW
+cqW
 cfN
 cfN
+bZY
+giI
+pkM
+crv
+owS
+aTe
+rrU
+gKz
+bZY
 cfN
+bWV
+cfC
+cuu
+chU
+cuR
+ciy
+chZ
+bWV
+ciz
+ckb
+cku
+cvT
+bZo
+cwx
+cwE
+ckv
+ckM
+clb
 aaa
 aaa
 aaa
 aaa
 aaa
 aaa
-aht
-aaa
-aht
-aaa
-aht
 aaa
 aaa
 aaa
 aaa
-aht
 aaa
 aaa
 aaa
-aht
-cfN
-cfN
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -63701,78 +63678,78 @@ aaa
 aaa
 aaa
 aaa
-bGD
-bGD
-bIT
-bJZ
-bIT
-bMr
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+bGI
 bNs
+cfN
+cfN
+cfN
+cfN
 bOw
-bOw
-bOw
-bOw
-bOw
-bOw
-bOw
-bOw
-bOw
-bOw
-bOw
-bOw
+bZY
+pkM
+bZY
+bZY
+bZY
+tan
+bZY
+bZY
+bZY
+cfN
 bWV
-crj
-bXJ
-bXJ
-crK
-cdr
-cdw
-csv
-cfD
 bWV
-cfm
-cfF
-cvy
-cgG
-chi
-cid
-cuM
-chj
-cvb
-ciT
-cvh
-cgG
-cvy
-cvu
-cwa
-cwo
-ckh
-ckA
-ckP
-cjm
-cfN
-cfN
-cfN
-cfN
+bWV
+bWV
+cuS
+bWV
+bWV
+bWV
+ciz
+ckb
+cku
+cvT
+cwk
+cwy
+cwE
+ckw
+ckN
+clb
 aaa
 aaa
 aaa
 aaa
 aaa
-cjp
-cyU
-cjp
-cyU
-cjp
-cjp
-cyU
-cjp
-cyU
-cjp
-cyU
-aht
-aht
-aht
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -63958,78 +63935,78 @@ aaa
 aaa
 aaa
 aaa
-bGE
-bGE
-bIU
-bHM
-bHM
-bHM
-bHM
-bNw
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+bGI
+bNs
+cqW
 bOw
-bQd
+cfN
 bOw
-bQd
 bOw
-bQd
 bOw
-bQd
 bOw
-bQd
+bOw
+ccu
+ceB
+cef
+ceB
+cfN
+cfN
+cfN
 bWV
+cdr
+cuv
+cdw
+aTf
+crj
+ciN
 bWV
+ciz
+cvs
+cvB
+cvV
+cdx
+ciA
 bXJ
-bZl
-bYA
-bZl
-bYA
-cbP
-cdu
-cfD
-ceK
-cfm
-xXB
-cvy
-cgG
-cid
-cuA
-cib
-cgH
-cgH
-ciS
-cid
-cgG
-cvy
-cvu
-cwc
-cwp
-cwA
-ckz
-ckP
-cjm
-caS
-caS
-caS
-caS
-aht
-aht
-aht
-aht
-cjp
-cjp
-ckH
-cyY
-ckH
-ckH
-ckH
-ckH
-czH
-ckH
-cyR
-cyU
+bXJ
+fIT
+fIT
+cxg
 aaa
 aaa
-aht
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -64214,79 +64191,79 @@ aaa
 aaa
 aaa
 aaa
-bFE
-bGF
-bHJ
-pbm
-bKa
-cqH
-aIP
-bNt
-bNw
-bNw
-bQe
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aby
+aby
+aby
+aby
+cqU
+bNs
+bUC
 bOw
 bOw
 bOw
-bQe
 bOw
 bOw
 bOw
-bQe
+bUC
+bOw
+ceB
+csM
+ceB
+cfN
+cfN
+cfN
 bWV
+cdC
+cuw
+cbK
+aTf
+ciA
+cvd
+bWV
+ciz
+cvt
+aTf
+crk
 bXJ
 bXJ
-bZm
-bYB
-bZm
-caV
-cbM
-ccH
-cfD
-ceL
-cfm
-ctM
-cvy
-bWV
-cun
-cuB
-cic
-cgH
-chG
-ciT
-cjo
-bWV
-cvy
-cvI
-cwa
-clf
-cwA
-bgc
-cwS
-cjm
-cfN
-caS
-cfN
+cwG
+cwO
+fIT
+cxk
 aaa
 aaa
 aaa
 aaa
 aaa
-cjp
-cCW
-ckH
-cyZ
-ckH
-czl
-czr
-czr
-czI
-ckH
-ckH
-cjp
-cjp
-cyU
-aht
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -64472,78 +64449,78 @@ aaa
 aaa
 aaa
 aaa
-bGE
-bGE
-bIV
-bNu
-bLo
-bOx
-bNu
-bOx
-bPn
-bQf
-bQf
-bQf
-bQf
-bQf
-bQf
-bQf
-bQf
-bQf
-bWW
-bXI
-bZn
-bZn
-bZn
-bZn
-bZn
-bZn
-cbN
-ccE
-bXJ
-bWX
-aTf
-cvy
-cgG
-cgk
-cuA
-ciS
-chk
-cgH
-cgH
-cvi
-cgG
-cvy
-cfD
-cwa
-cjO
-ckk
-ckC
-ckR
-cjm
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aby
+aaa
+aaa
+tpI
+bNs
+bNs
+bOw
+bOw
+bOw
+bOw
+bOw
+bOw
+bOw
+bOw
+bOw
+ceB
+cee
+ceB
 cfN
-caS
-caS
-aht
-aht
-aht
-aht
-aht
-cjp
-ckW
-ckH
-ckH
-ckH
-czl
-czr
-czB
-czI
-czV
-ckH
-cAr
-cAB
-cyU
-cjp
+cfN
+cfN
+bWV
+cdC
+cux
+cbK
+aTf
+cdC
+ciO
+bWV
+bWV
+bWV
+cjl
+bWV
+cwl
+cwz
+bWV
+fIT
+fIT
+cxg
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+cfN
+cfN
+cfN
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+cfN
+cfN
+aaa
 aaa
 aaa
 aaa
@@ -64729,84 +64706,84 @@ aaa
 aaa
 aaa
 aaa
-bGG
-bHL
-bIW
-bKc
-aHE
-cgU
-bLn
-cqI
-bPo
-bQg
-bQg
-bQg
-bQg
-bQg
-bQg
-bQg
-bQg
-bQg
-bWX
-uDA
-bZo
-bZo
-bZo
-bZo
-bZo
-bZo
-cbO
-ccF
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+abI
+bGD
+bQQ
+bNs
+bNs
+bQe
+bOw
+bOw
+bOw
+bOw
+bOw
+bOw
+bSm
+bOw
+bUC
+ceB
+cef
+ceB
+cfN
+cfN
+cfN
+bWV
+bXJ
+cve
+cuK
 aTf
-cek
+bXJ
+cve
+bWV
 aTf
-cvy
-cgG
-cuo
-ciV
-cgI
-chl
-cib
-cvg
-cid
-cgG
-cvy
-cfD
-cwa
-cwa
-cwa
-cwa
-cwa
-cwa
-cwe
-cwe
+ckd
+aTf
+cjm
+cjm
+cjm
+cjm
+cwR
+cwR
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+cfN
+cfN
+cfN
+cfN
+cfN
+cyM
+aaa
+aaa
+aaa
+cfN
+cfN
+cfN
+cfN
+cfN
+cfN
 cfN
 aaa
 aaa
 aaa
 aaa
 aaa
-cjp
-cyP
-ckH
-cyZ
-ckH
-czl
-czt
-czC
-czI
-czM
-cAg
-cAs
-ckH
-cAH
-cjp
-cyU
-aaa
-aaa
-aaa
-aaa
-cfN
 aaa
 aaa
 aaa
@@ -64986,85 +64963,85 @@ aaa
 aaa
 aaa
 aaa
-bGH
-bGE
-bIX
-bKd
-bLp
-bMu
-bNv
-bNw
-bNw
-bQe
+aaa
+aaa
+aaa
+aaa
+aby
+abI
+aby
+aby
+aby
+aby
+aaa
+bNr
+bNs
+bNs
+bNs
 bOw
 bOw
 bOw
-bQe
+bOw
 bOw
 bOw
 bOw
 bQe
 bWV
-bXJ
-bXJ
-bZl
-bYA
-bZl
-caW
-cbP
-cdu
-cdx
-cth
+bWV
+bWV
+bWV
+ceg
+bWV
 cfm
-ctN
-cvy
-bWV
-cup
-cuE
-cgK
-cgJ
-cgH
-cgj
-cvj
-bWV
-cvy
-cvJ
-cwe
-cjP
-ckl
-ckD
-ckS
-clg
-clk
-cwe
-cwe
-cyB
-cxM
-cxM
-cxM
-cyB
-cjp
-cyQ
-ckH
-ckH
-ckH
-ckH
-ckH
-ckH
-ckH
-czM
-cAg
-cAt
-ckH
-czM
-cAS
-cyU
+cfm
+cfm
+cfm
+cfm
+cfm
+cfm
+cuU
+cfm
+cfm
+cfm
+cjH
+cfm
+cfm
+cwa
+cky
+gOS
+cjm
+cld
+tYF
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+cfN
+cfN
+cfN
+cfN
+cfN
+cfN
+cfN
 aht
-aht
-aht
+aaa
+aaa
+aaa
+cfN
 cyM
 cfN
 cfN
+cfN
+cfN
+cfN
+cfN
+cfN
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -65243,85 +65220,85 @@ aaa
 aaa
 aaa
 aaa
-bGI
-bHM
-bHM
-bHM
-bLq
-bNw
-bNw
-bNw
+aaa
+aaa
+aaa
+aaa
+aby
+aaa
+aaa
+bOv
+bGD
+bOv
+bQQ
+bNs
+bNs
 bOw
-bQd
 bOw
-bQd
 bOw
-bQd
 bOw
-bQd
 bOw
-bWi
+bOw
+bOw
+bOw
+bWV
 bWV
 bWV
 bXJ
-bZm
-bYB
-bZm
-bYB
-cbM
-ccH
-cdx
-ceK
+bYz
+cdr
+cfD
+bXJ
 cfm
-xXB
-cvy
-cgG
-ciV
-cgH
-cgH
-cgH
-cic
-ciV
-cjq
-cgG
-cvy
+ctK
 cvu
-ckT
-xhj
-xhj
-xhj
-xhj
-xhj
-cxn
-xhj
-lqy
-cxC
-cxK
-cxX
-cyl
-cyz
-jgr
-cjQ
-cjQ
-cjQ
-cjQ
-cjQ
-cjQ
-jMS
-czL
-czY
-cAi
-cAu
-cAC
-czY
-ckH
-cyU
+cfD
+chf
+cuz
+cvu
+cfD
+cvu
+cfD
+chf
+cfD
+cvu
+cvE
+cwa
+cky
+gOS
+idA
+cld
+cjm
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
 cfN
 cfN
 cfN
+cyM
+cfN
+cyM
+aaa
+aht
+aaa
+aaa
+aaa
+aaa
+aht
+aaa
+cfN
+cfN
+cfN
+cfN
+cfN
+cfN
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -65501,13 +65478,18 @@ aaa
 aaa
 aaa
 aaa
-bHN
-bGE
-bKe
-bLp
-bMw
-bNx
-bNw
+aaa
+aaa
+aaa
+aed
+abI
+bNr
+bNs
+bNs
+bNs
+bNs
+bNs
+bSm
 bOw
 bOw
 bOw
@@ -65515,70 +65497,65 @@ bOw
 bOw
 bOw
 bOw
-bOw
-bOw
-bOw
-bOw
+bUC
 bWV
-crk
-bXJ
-bXJ
-crN
-crX
-cdx
-cgn
-cdx
+whH
+caT
+vFZ
 bWV
-cfm
-ctO
+cds
+cfD
+ceH
+cfl
+cvu
 cvy
-cgG
-cgm
-cuE
-cuO
-cgH
-ciE
-ciW
-cjr
-cgG
+cvy
+cvy
+cvy
+cvy
+bXI
+cvy
+cvy
+cvy
+cvy
 cvy
 cvu
-cwg
-cjR
-cjR
-ckF
-cjR
-cxe
-cjR
-cjR
-cxz
-cxD
-cxL
-cxY
-cym
-cyA
-vOw
-ijF
-ijF
-ckm
-ckm
-ckm
-ckm
-ckm
-czM
-czY
-cAj
-cAv
-cAD
-czY
-cAU
-cyU
+cwa
+cwm
+ckj
+ckj
+ckO
+cjm
+cfN
+aaa
+aaa
 aaa
 aaa
 aaa
 cfN
 cfN
 cfN
+aht
+aaa
+aht
+aaa
+aht
+aht
+aht
+aht
+aht
+aht
+aaa
+cfN
+cfN
+cyM
+cfN
+cfN
+cfN
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -65758,19 +65735,19 @@ aaa
 aaa
 aaa
 aaa
-bGI
-bGE
-bKf
-aIP
-bMw
-bNy
-bNw
+bHI
+aby
+aby
+aby
+bGH
+bNs
+bNs
 bOw
-bQh
+bQc
 bOw
 bOw
 bOw
-bSm
+bOw
 bOw
 bOw
 bOw
@@ -65778,64 +65755,64 @@ bOw
 bOw
 bWV
 bWV
-crx
-crH
 bWV
-crY
-csk
+bYz
 bWV
-cbR
+bWV
+bWV
+bWV
+cei
 bWV
 cfm
-aTf
+cfD
 cvy
 bWV
 cgG
 cgG
 bWV
-cuY
+cuX
 bWV
 cgG
 cgG
-sYe
+bWV
 cvy
 cfD
-cwe
-cwr
-clm
-ckG
-cwU
-jXh
-ckU
-cwe
-cwe
-cyB
-cxM
-cxM
-cxM
-cyB
-cjp
-cyR
-ick
-ckH
-ckH
-ckH
-ckH
-ckH
-ckH
-czL
-cAg
-cAt
-ckH
-czL
-cAV
-cyU
+cwa
+cwn
+ckg
+ckz
+ckP
+cjm
+cfN
+cfN
+cfN
 aaa
 aaa
+aaa
+aaa
+aaa
+aaa
+aht
+aaa
+aht
+aaa
+aht
+aaa
+aaa
+aaa
+aaa
+aht
+aaa
+aaa
+aaa
+aht
 cfN
 cfN
-cfN
-cfN
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -66014,17 +65991,12 @@ aaa
 aaa
 aaa
 aaa
-aaa
-bGI
-bGE
-bKg
-aIP
-bMx
-bNz
-bHM
-bNs
-bNs
-bNs
+bGD
+bGD
+bIT
+bJZ
+bIT
+bMr
 bNs
 bOw
 bOw
@@ -66034,65 +66006,70 @@ bOw
 bOw
 bOw
 bOw
+bOw
+bOw
+bOw
+bOw
 bWV
-bWV
-bWV
-bWV
-bWV
-bWV
-bWV
-ccJ
-aTf
-cel
-xXB
-cvy
-cvy
-cvy
-cvy
-cvy
+crj
 bXJ
+bXJ
+crK
+cdr
+cdw
+csv
+cfD
+bWV
+cfm
+cfF
 cvy
-cvy
-cvy
-cvy
+cgG
+chi
+cid
+cuM
+chj
+cvb
+ciT
+cvh
+cgG
 cvy
 cvu
-cwe
-cwe
-fWv
-qOE
-ckV
-qOE
-cln
-cwe
+cwa
+cwo
+ckh
+ckA
+ckP
+cjm
+cfN
+cfN
+cfN
 cfN
 aaa
 aaa
 aaa
 aaa
 aaa
-cjp
-cyS
-ick
-cyZ
-ckH
-czo
-czu
-czD
-czN
-czL
-cAg
-cAs
-ckH
-cAM
 cjp
 cyU
+cjp
+cyU
+cjp
+cjp
+cyU
+cjp
+cyU
+cjp
+cyU
+aht
+aht
+aht
 aaa
 aaa
-cfN
-cfN
-cfN
-cfN
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -66271,85 +66248,85 @@ aaa
 aaa
 aaa
 aaa
-aaa
-bGI
-bHM
 bGE
 bGE
+bIU
 bHM
-bNA
 bHM
-cqS
-bQi
-bQR
-bNs
-bNs
+bHM
+bHM
+bNw
 bOw
+bQd
 bOw
+bQd
 bOw
+bQd
 bOw
+bQd
 bOw
-bOw
-bOw
-bOw
-bOw
-bOw
-bUC
-bOw
-bQg
-cbR
+bQd
+bWV
+bWV
 bXJ
-cdx
-cfm
-ctP
-xXB
-aTf
-aVY
-aTf
-xXB
-aTf
-xXB
-aTf
-cvk
-aTf
-xXB
+bZl
+bYA
+bZl
+bYA
+cbP
+cdu
 cfD
+ceK
 cfm
-cwe
-bHH
-qOE
-mKc
-qOE
-txB
-cwe
+xXB
+cvy
+cgG
+cid
+cuA
+cib
+cgH
+cgH
+ciS
+cid
+cgG
+cvy
+cvu
+cwc
+cwp
+cwA
+ckz
+ckP
+cjm
+caS
+caS
+caS
 caS
 aht
 aht
 aht
 aht
-aht
 cjp
-cko
-ick
+cjp
+ckH
+cyY
 ckH
 ckH
-clp
-czv
-czv
-czO
-cli
 ckH
-cAy
-cAB
+ckH
+czH
+ckH
+cyR
 cyU
-cjp
+aaa
+aaa
 aht
-aht
-aht
-cyM
-cfN
-cfN
-cfN
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -66527,73 +66504,73 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-bIY
-bIY
-bLs
-bMy
-bNB
-bMy
-abI
-aby
-abI
-bRC
-bNs
-bNs
-bNs
+lGv
+bGF
+bHJ
+pbm
+bKa
+cqH
+aIP
+bNt
+bNw
+bNw
+bQe
 bOw
 bOw
 bOw
+bQe
 bOw
 bOw
 bOw
-bOw
-bOw
-bOw
-bOw
-bQg
-cbR
+bQe
+bWV
 bXJ
-cdB
+bXJ
+bZm
+bYB
+bZm
+caV
+cbM
+ccH
+cfD
+ceL
 cfm
-cfm
-cfH
-cfm
-cfm
-chp
-cfm
-cfm
-cfm
-ciF
-cfm
-cfm
-whJ
-tXV
-whJ
-cwe
-ckp
-qOE
-ckX
-qOE
-cln
-cwe
+ctM
+cvy
+bWV
+cun
+cuB
+cic
+cgH
+chG
+ciT
+cjo
+bWV
+cvy
+cvI
+cwa
+clf
+cwA
+bgc
+cwS
+cjm
 cfN
+caS
 cfN
+aaa
 aaa
 aaa
 aaa
 aaa
 cjp
-cyT
-ick
+cCW
+ckH
 cyZ
 ckH
-czp
-ckH
-ckH
-czP
+czl
+czr
+czr
+czI
 ckH
 ckH
 cjp
@@ -66603,10 +66580,10 @@ aht
 aaa
 aaa
 aaa
-cfN
-cfN
-cfN
-cfN
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -66785,85 +66762,85 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aby
-aby
-aaa
-aaa
-amC
-aaa
-aht
-aby
-aby
-abI
-bSn
-cFX
-bNs
-bNs
-bQe
-bOw
-bOw
-bOw
-bQg
-bQg
-bQg
-bOw
-bOw
-ccL
-bWV
-csT
-cen
-bWV
-ctQ
-cfI
-cfm
-cgL
-chq
-chK
-cfm
-cio
-chq
-ciX
-cfm
-yii
-iJb
-fdN
-cwe
-cwe
-cwe
-cwe
-cwe
-cwe
-cwe
+bGE
+bGE
+bIV
+bNu
+bLo
+bOx
+bNu
+bOx
+bPn
+bQf
+bQf
+bQf
+bQf
+bQf
+bQf
+bQf
+bQf
+bQf
+bWW
+bXI
+bZn
+bZn
+bZn
+bZn
+bZn
+bZn
+cbN
+ccE
+bXJ
+bWX
+aTf
+cvy
+cgG
+cgk
+cuA
+ciS
+chk
+cgH
+cgH
+cvi
+cgG
+cvy
+cfD
+cwa
+cjO
+ckk
+ckC
+ckR
+cjm
+cfN
 caS
 caS
 aht
 aht
 aht
 aht
+aht
 cjp
-cjp
-ick
-xja
+ckW
 ckH
-czq
-czw
 ckH
-czQ
 ckH
-cyR
+czl
+czr
+czB
+czI
+czV
+ckH
+cAr
+cAB
 cyU
+cjp
 aaa
 aaa
-aht
 aaa
 aaa
-cfN
-cfN
-cfN
-cfN
-cfN
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -67042,83 +67019,83 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-amB
-aht
-aht
-aaa
-aaa
-abI
-abI
-abI
-cFX
-bNs
-bNs
-bNs
-bUC
-bOw
-crl
-bXL
-bNs
-bOw
-bOw
-bOw
-bWV
-csU
-bWV
-bWV
-bWV
-cfJ
-cfm
-cgM
-chr
-chL
-cfm
-cgM
-chr
-chL
-cfm
-niN
-njB
-kFP
-whJ
-elH
-dbI
-nBO
-dbI
-elH
-whJ
-whJ
-whJ
+bGG
+bHL
+bIW
+bKc
+aHE
+cgU
+bLn
+cqI
+bPo
+bQg
+bQg
+bQg
+bQg
+bQg
+bQg
+bQg
+bQg
+bQg
+bWX
+uDA
+bZo
+bZo
+bZo
+bZo
+bZo
+bZo
+cbO
+ccF
+aTf
+cek
+aTf
+cvy
+cgG
+cuo
+ciV
+cgI
+chl
+cib
+cvg
+cid
+cgG
+cvy
+cfD
+cwa
+cwa
+cwa
+cwa
+cwa
+cwa
+cwe
+cwe
 cfN
 aaa
 aaa
 aaa
-aht
+aaa
+aaa
+cjp
+cyP
+ckH
+cyZ
+ckH
+czl
+czt
+czC
+czI
+czM
+cAg
+cAs
+ckH
+cAH
 cjp
 cyU
-cjp
-cyU
-cjp
-cjp
-cyU
-cjp
-cyU
-cjp
-cyU
-aht
-aht
-aht
-aht
-cyM
-cfN
-cfN
-cfN
+aaa
+aaa
+aaa
+aaa
 cfN
 aaa
 aaa
@@ -67299,85 +67276,85 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-amC
-aaa
-aht
-aaa
-aaa
-aaa
-aaa
-abI
-aht
-wWO
-bQR
-bNs
-bNs
-bNs
-bNs
-bXM
-bNs
+bGH
+bGE
+bIX
+bKd
+bLp
+bMu
+bNv
+bNw
+bNw
+bQe
 bOw
 bOw
 bOw
+bQe
 bOw
-ccM
-cdD
-ceo
 bOw
-bQg
+bOw
+bQe
+bWV
+bXJ
+bXJ
+bZl
+bYA
+bZl
+caW
+cbP
+cdu
+cdx
+cth
 cfm
-cgN
-chs
-chM
-cfm
-cip
-chs
-ciY
-cfm
-pIy
-iJb
-rie
-whJ
-tNT
-mTp
-tNT
-tNT
-tNT
-fAe
-kZU
-whJ
-cfN
-aaa
-aaa
-aaa
+ctN
+cvy
+bWV
+cup
+cuE
+cgK
+cgJ
+cgH
+cgj
+cvj
+bWV
+cvy
+cvJ
+cwe
+cjP
+ckl
+ckD
+ckS
+clg
+clk
+cwe
+cwe
+cyB
+cxM
+cxM
+cxM
+cyB
+cjp
+cyQ
+ckH
+ckH
+ckH
+ckH
+ckH
+ckH
+ckH
+czM
+cAg
+cAt
+ckH
+czM
+cAS
+cyU
 aht
-aaa
-aaa
 aht
-aaa
-aaa
 aht
-aaa
-aht
-aaa
-aht
-aaa
-aaa
-aaa
-aaa
-aaa
+cyM
 cfN
 cfN
-aaa
-cfN
-cfN
-aaa
 aaa
 aaa
 aaa
@@ -67556,85 +67533,85 @@ aaa
 aaa
 aaa
 aaa
+bGI
+bHM
+bHM
+bHM
+bLq
+bNw
+bNw
+bNw
+bOw
+bQd
+bOw
+bQd
+bOw
+bQd
+bOw
+bQd
+bOw
+bWi
+bWV
+bWV
+bXJ
+bZm
+bYB
+bZm
+bYB
+cbM
+ccH
+cdx
+ceK
+cfm
+xXB
+cvy
+cgG
+ciV
+cgH
+cgH
+cgH
+cic
+ciV
+cjq
+cgG
+cvy
+cvu
+ckT
+xhj
+xhj
+xhj
+xhj
+xhj
+cxn
+xhj
+lqy
+cxC
+cxK
+cxX
+cyl
+cyz
+jgr
+cjQ
+cjQ
+cjQ
+cjQ
+cjQ
+cjQ
+jMS
+czL
+czY
+cAi
+cAu
+cAC
+czY
+ckH
+cyU
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-amB
-aht
-aht
-aht
-aht
-aht
-aht
-abI
-abI
-aht
-abI
-bSZ
-bSZ
-cre
-bNs
-bXN
-bNs
-bOw
-bOw
-bOw
-bOw
-bOw
-bQe
-bOw
-bOw
-cfL
-cfm
-cfm
-cht
-cfm
-cfm
-cfm
-cht
-cfm
-cfm
-nPm
-njB
-fGm
-fnq
-fnq
-pQA
-ewV
-ewV
-ewV
-iiJ
-fwx
-whJ
 cfN
 cfN
-aaa
-aaa
-aht
-aht
-aht
-aht
-aaa
-aaa
-aht
-aht
-aht
-aaa
-aht
-aaa
 cfN
-cfN
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -67814,84 +67791,84 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-iGp
-aaa
-aht
-aaa
-aaa
-aht
-aaa
-aaa
-aaa
-aht
-aaa
-aaa
-abI
-aaa
-bSZ
-ahi
-bNs
-bOw
-bOw
-bUC
+bHN
+bGE
+bKe
+bLp
+bMw
+bNx
+bNw
 bOw
 bOw
 bOw
 bOw
-bUC
-cfM
+bOw
+bOw
+bOw
+bOw
+bOw
+bOw
+bOw
+bWV
+crk
+bXJ
+bXJ
+crN
+crX
+cdx
+cgn
+cdx
+bWV
 cfm
-cgO
-chu
-chN
-cfm
-ciq
-chu
-ciZ
-cfm
-pIy
-iJb
-iYT
-oya
-fnq
-ewV
-ewV
-ewV
-ewV
-tqW
-woX
-whJ
+ctO
+cvy
+cgG
+cgm
+cuE
+cuO
+cgH
+ciE
+ciW
+cjr
+cgG
+cvy
+cvu
+cwg
+cjR
+cjR
+ckF
+cjR
+cxe
+cjR
+cjR
+cxz
+cxD
+cxL
+cxY
+cym
+cyA
+vOw
+ijF
+ijF
+ckm
+ckm
+ckm
+ckm
+ckm
+czM
+czY
+cAj
+cAv
+cAD
+czY
+cAU
+cyU
+aaa
+aaa
+aaa
 cfN
 cfN
-aaa
-aaa
-aht
-aaa
-aaa
-aht
 cfN
-cfN
-cyM
-cfN
-aht
-aaa
-aht
-cfN
-cfN
-cfN
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -68071,84 +68048,84 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-amB
-aht
-aht
-aht
-aht
-aht
-aht
-aht
-aht
-aht
-abI
-abI
-abI
-aaa
-aht
-ahi
-bNs
-bNs
-bNs
-bNs
-bNs
-bNs
-bNs
-bNs
-bNs
-bNs
+bGI
+bGE
+bKf
+aIP
+bMw
+bNy
+bNw
+bOw
+bQh
+bOw
+bOw
+bOw
+bSm
+bOw
+bOw
+bOw
+bOw
+bOw
+bWV
+bWV
+crx
+crH
+bWV
+crY
+csk
+bWV
+cbR
+bWV
 cfm
-cfm
-cfm
-cfm
-cfm
-cfm
-cfm
-cfm
-cfm
-niN
-njB
-qtD
-whJ
-fGm
-nQb
-nQb
-vek
-tNT
-fAe
-jOw
-whJ
-cfN
-cfN
+aTf
+cvy
+bWV
+cgG
+cgG
+bWV
+cuY
+bWV
+cgG
+cgG
+sYe
+cvy
+cfD
+cwe
+cwr
+clm
+ckG
+cwU
+jXh
+ckU
+cwe
+cwe
+cyB
+cxM
+cxM
+cxM
+cyB
+cjp
+cyR
+ick
+ckH
+ckH
+ckH
+ckH
+ckH
+ckH
+czL
+cAg
+cAt
+ckH
+czL
+cAV
+cyU
 aaa
 aaa
-aht
-aaa
-cfN
-cyM
 cfN
 cfN
 cfN
 cfN
-cyM
-cfN
-cyM
-cfN
-cfN
-cfN
-cfN
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -68328,84 +68305,84 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-amB
-aaa
-aht
-aaa
-aaa
-aaa
-aht
-aht
-aaa
-aaa
-aaa
-aaa
-aht
-abI
-abI
-ahi
-bSZ
-crO
-crO
-crO
-crO
-crO
-crO
-crO
-crO
-crO
-cfN
-cfN
-whJ
-gtl
-tBb
-lto
-hwY
-njB
-icy
-vvY
-kzj
-gMG
-whJ
-ebp
-wJL
-mFu
-wJL
-iYT
-whJ
-whJ
-whJ
-cfN
-aaa
-aaa
-aaa
-cyM
-cfN
-cfN
-cfN
-cfN
-cfN
-cfN
-cfN
-cfN
-cfN
-cfN
-cfN
-cfN
-cfN
+bGI
+bGE
+bKg
+aIP
+bMx
+bNz
+bHM
+bNs
+bNs
+bNs
+bNs
+bOw
+bOw
+bOw
+bOw
+bOw
+bOw
+bOw
+bOw
+bWV
+bWV
+bWV
+bWV
+bWV
+bWV
+bWV
+ccJ
+aTf
+cel
+xXB
+cvy
+cvy
+cvy
+cvy
+cvy
+bXJ
+cvy
+cvy
+cvy
+cvy
+cvy
+cvu
+cwe
+cwe
+fWv
+qOE
+ckV
+qOE
+cln
+cwe
 cfN
 aaa
 aaa
 aaa
 aaa
 aaa
+cjp
+cyS
+ick
+cyZ
+ckH
+czo
+czu
+czD
+czN
+czL
+cAg
+cAs
+ckH
+cAM
+cjp
+cyU
 aaa
 aaa
+cfN
+cfN
+cfN
+cfN
 aaa
 aaa
 aaa
@@ -68585,84 +68562,84 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-amB
+bGI
+bHM
+bGE
+bGE
+bHM
+bNA
+bHM
+cqS
+bQi
+bQR
+bNs
+bNs
+bOw
+bOw
+bOw
+bOw
+bOw
+bOw
+bOw
+bOw
+bOw
+bOw
+bUC
+bOw
+bQg
+cbR
+bXJ
+cdx
+cfm
+ctP
+xXB
+aTf
+aVY
+aTf
+xXB
+aTf
+xXB
+aTf
+cvk
+aTf
+xXB
+cfD
+cfm
+cwe
+bHH
+qOE
+mKc
+qOE
+txB
+cwe
+caS
 aht
 aht
-bva
-bIZ
-bIZ
-bva
-bva
-bIZ
-bIZ
-bva
-fon
-aaa
-aaa
 aht
-cdm
 aht
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-cfN
-whJ
-wCj
-tKm
-tNT
-tNT
-roy
-whJ
-whJ
-whJ
-whJ
-whJ
-umO
-whJ
-whJ
-whJ
-whJ
-whJ
+aht
+cjp
+cko
+ick
+ckH
+ckH
+clp
+czv
+czv
+czO
+cli
+ckH
+cAy
+cAB
+cyU
+cjp
+aht
+aht
+aht
+cyM
 cfN
 cfN
 cfN
-aaa
-aaa
-cfN
-cfN
-cfN
-cfN
-cfN
-cfN
-cfN
-cfN
-cfN
-cfN
-cfN
-cfN
-cfN
-cfN
-cfN
-cfN
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -68843,57 +68820,76 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-amB
-aaa
-bva
-bva
-bJa
-bHQ
-bLt
-hBY
-bNF
-bHQ
-bva
-fMm
-aht
-aht
-aht
-cdm
-aht
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-cfN
+cwR
+bIY
+bLs
+bMy
+mpU
+bMy
+abI
+aby
+abI
+bRC
+bNs
+bNs
+bNs
+bOw
+bOw
+bOw
+bOw
+bOw
+bOw
+bOw
+bOw
+bOw
+bOw
+bQg
+cbR
+bXJ
+cdB
+cfm
+cfm
+cfH
+cfm
+cfm
+chp
+cfm
+cfm
+cfm
+ciF
+cfm
+cfm
 whJ
-wBO
-fdN
-qtD
-qtD
-kEk
+tXV
 whJ
-reR
-tFt
-dCh
-dCh
-tJH
-sBW
-whJ
+cwe
+ckp
+qOE
+ckX
+qOE
+cln
+cwe
 cfN
 cfN
-cfN
-cfN
-cfN
+aaa
+aaa
+aaa
+aaa
+cjp
+cyT
+ick
+cyZ
+ckH
+czp
+ckH
+ckH
+czP
+ckH
+ckH
+cjp
+cjp
+cyU
+aht
 aaa
 aaa
 aaa
@@ -68901,25 +68897,6 @@ cfN
 cfN
 cfN
 cfN
-cfN
-cfN
-cfN
-aaa
-aaa
-cfN
-cfN
-cfN
-cfN
-cfN
-cfN
-cfN
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -69100,83 +69077,83 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-amB
-aht
-bva
-bHP
-bJb
-bJb
-bJb
-bJb
-bJb
-bJb
-bPp
-bva
-aaa
-aaa
-aht
-cdm
+bBW
+bzy
 aht
 aaa
+amC
+aaa
+aht
+aby
+aby
+abI
+bSn
+cFX
+bNs
+bNs
+bQe
+bOw
+bOw
+bOw
+bOw
+bOw
+bOw
+bOw
+bOw
+ccL
+bWV
+csT
+cen
+bWV
+ctQ
+cfI
+cfm
+cgL
+chq
+chK
+cfm
+cio
+chq
+ciX
+cfm
+yii
+iJb
+fdN
+cwe
+cwe
+cwe
+cwe
+cwe
+cwe
+cwe
+caS
+caS
+aht
+aht
+aht
+aht
+cjp
+cjp
+ick
+xja
+ckH
+czq
+czw
+ckH
+czQ
+ckH
+cyR
+cyU
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aht
 aaa
 aaa
 cfN
-whJ
-nVN
-gkQ
-gkQ
-gkQ
-xkB
-whJ
-uIv
-kVM
-nWF
-xMQ
-nKQ
-gXh
-whJ
-cfN
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-cfN
-cfN
-cfN
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
 cfN
 cfN
 cfN
 cfN
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -69356,83 +69333,83 @@ aaa
 aaa
 aaa
 aaa
+bBW
 aaa
-aaa
-aaa
-aaa
-aaa
+gYo
+aht
+aht
 amB
-bva
-bva
-bHQ
-bJc
-bKh
-bLu
-bLu
-bNG
-bOz
-kdF
-bIZ
+aht
+aht
+aaa
+aaa
+abI
+abI
+abI
+bRC
+bNs
+bNs
+bNs
+bUC
+bOw
+bOw
+bOw
+bOw
+bOw
+bOw
+bOw
+bWV
+csU
+bWV
+bWV
+bWV
+cfJ
+cfm
+cgM
+chr
+chL
+cfm
+cgM
+chr
+chL
+cfm
+niN
+njB
+kFP
+whJ
+elH
+dbI
+nBO
+dbI
+elH
+whJ
+whJ
+whJ
+cfN
+aaa
+aaa
+aaa
+aht
+cjp
+cyU
+cjp
+cyU
+cjp
+cjp
+cyU
+cjp
+cyU
+cjp
+cyU
 aht
 aht
 aht
-cdm
 aht
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-whJ
-whJ
-wIX
-wIX
-wIX
-wIX
-whJ
-whJ
-whJ
-whJ
-whJ
-whJ
-whJ
-whJ
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cyM
+cfN
+cfN
+cfN
+cfN
 aaa
 aaa
 aaa
@@ -69615,81 +69592,81 @@ aaa
 aaa
 aaa
 aaa
+aht
 aaa
 aaa
+sDQ
 aaa
-amB
-bva
-bGK
-bHQ
-bJd
-bKi
-bLv
-bMA
-bNH
-bOz
-bHQ
-bIZ
-aht
-aht
-aht
-cdm
 aht
 aaa
 aaa
 aaa
 aaa
+abI
+aaa
+crO
+bQR
+bNs
+bNs
+bNs
+bOw
+bOw
+bQg
+bQg
+bQg
+bOw
+bOw
+ccM
+cdD
+ceo
+bOw
+bQg
+cfm
+cgN
+chs
+chM
+cfm
+cip
+chs
+ciY
+cfm
+pIy
+iJb
+rie
+whJ
+tNT
+mTp
+tNT
+tNT
+tNT
+fAe
+kZU
+whJ
+cfN
+aaa
+aaa
+aaa
+aht
+aaa
+aaa
+aht
+aaa
+aaa
+aht
+aaa
+aht
+aaa
+aht
 aaa
 aaa
 aaa
 aaa
 aaa
+cfN
+cfN
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cfN
+cfN
 aaa
 aaa
 aaa
@@ -69859,87 +69836,87 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-amB
-bva
-bGL
-bHQ
-bJe
-bKj
-bLv
-bMB
-bNI
-bOz
-bHQ
-bIZ
+bBV
+bWl
+bWl
+bWl
+bWl
+bwv
+bwv
+bwv
+bwv
+bwv
+bwv
+bwv
+bwv
+bwv
+bwv
+lsq
+aht
+aht
+aht
+aht
+aht
+aht
+aht
+aht
+aht
+aht
+aht
+bSZ
+cFX
+bNs
+bNs
+bNs
+crl
+bXL
+bNs
+bOw
+bOw
+bOw
+bQe
+bOw
+bOw
+cfL
+cfm
+cfm
+cht
+cfm
+cfm
+cfm
+cht
+cfm
+cfm
+nPm
+njB
+fGm
+fnq
+fnq
+pQA
+ewV
+ewV
+ewV
+iiJ
+fwx
+whJ
+cfN
+cfN
 aaa
 aaa
 aht
-cdm
+aht
+aht
 aht
 aaa
 aaa
+aht
+aht
+aht
 aaa
+aht
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cfN
+cfN
 aaa
 aaa
 aaa
@@ -70115,88 +70092,88 @@ aaa
 aaa
 aaa
 aaa
+bAI
 aaa
+aht
 aaa
+aht
 aaa
+eZM
+vmY
+vmY
+eZM
+eZM
+eZM
+eON
+eON
+eZM
+eZM
+eZM
+eZM
+eZM
+aht
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-sDQ
 bva
-bGM
-bHR
-bJf
-bKk
-bLx
-bLx
-bNJ
-bOz
-bHQ
 bIZ
+bIZ
+bva
+bva
+bIZ
+bIZ
+bva
+aht
+evR
+evR
+aeI
+bNs
+bXM
+bNs
+bUC
+bOw
+bOw
+bOw
+bOw
+bUC
+cfM
+cfm
+cgO
+chu
+chN
+cfm
+ciq
+chu
+ciZ
+cfm
+pIy
+iJb
+iYT
+oya
+fnq
+ewV
+ewV
+ewV
+ewV
+tqW
+woX
+whJ
+cfN
+cfN
 aaa
 aaa
 aht
-cdm
+aaa
+aaa
+aht
+cfN
+cfN
+cyM
+cfN
 aht
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aht
+cfN
+cfN
+cfN
 aaa
 aaa
 aaa
@@ -70372,89 +70349,89 @@ btK
 aaa
 aaa
 aaa
-aaa
-bBV
+qpT
+bSl
+bSl
+bSl
+bSl
+eZM
+eZM
+lrI
+blE
+bTc
+bNQ
+rMV
 bDf
-bDf
-bDf
-bDf
-bDf
-bDf
-bDf
-bDf
-bDf
-bDf
-bDf
-bDf
-bDf
-bDf
-lsq
+bCa
+nMV
+eZM
+gKZ
+gXg
+wWO
 aht
 bva
-bHQ
-bHQ
-bJg
-bKl
-bJb
-bMC
-bJb
-bJb
-bPq
 bva
+bJa
+bHQ
+bLt
+bHQ
+bNF
+bHQ
+bva
+oTJ
+aaa
 aht
+bGI
+bNs
+bXN
+bNs
+bNs
+bNs
+bNs
+bNs
+bNs
+bNs
+bNs
+cfm
+cfm
+cfm
+cfm
+cfm
+cfm
+cfm
+cfm
+cfm
+niN
+njB
+qtD
+whJ
+fGm
+nQb
+nQb
+vek
+tNT
+fAe
+jOw
+whJ
+cfN
+cfN
+aaa
+aaa
 aht
-aht
-cdm
-aht
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cfN
+cyM
+cfN
+cfN
+cfN
+cfN
+cyM
+cfN
+cyM
+cfN
+cfN
+cfN
+cfN
 aaa
 aaa
 aaa
@@ -70626,92 +70603,92 @@ aZx
 aZx
 bsl
 btL
-aYG
+aZx
 aaa
 aaa
-bAI
-bBW
-abI
-aaa
-abI
+qpT
+bSl
+bSi
+bEj
+bFF
+eZM
+fNX
+bFI
+fwg
+bCa
+wha
 eZM
 eZM
+bNQ
 eZM
 eZM
+ouv
 eZM
 eZM
-eZM
-eON
-eON
-eZM
-eZM
-eZM
-eZM
-oTJ
-bHQ
-bHQ
-bJh
-bHQ
-bKm
-bMD
-bHQ
-bOA
-bPr
 bva
+bva
+bHP
+bJb
+bJb
+bJb
+bJb
+bJb
+bJb
+bPp
+bva
+aaa
 aht
-aht
-aht
-cdm
-aht
+aaa
+bSZ
+ahi
+bSZ
+crO
+crO
+crO
+crO
+crO
+crO
+crO
+cfN
+cfN
+whJ
+gtl
+tBb
+lto
+hwY
+njB
+icy
+vvY
+kzj
+gMG
+whJ
+ebp
+wJL
+mFu
+wJL
+iYT
+whJ
+whJ
+whJ
+cfN
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cyM
+cfN
+cfN
+cfN
+cfN
+cfN
+cfN
+cfN
+cfN
+cfN
+cfN
+cfN
+cfN
+cfN
+cfN
 aaa
 aaa
 aaa
@@ -70883,43 +70860,45 @@ bbR
 bbR
 aZx
 bcX
-aYG
+aZx
 aZx
 aYG
 bAJ
 bSl
-bSl
-bSl
-bSl
+bSi
+bEk
 eZM
-uyy
-tml
-uPG
-uPG
-uyy
-uPG
-pZT
-xKD
-pZT
-uPG
-uyy
-kJU
+eZM
+bNB
+bCa
+eZM
+dAG
+eZM
+eZM
+und
+bCa
+gum
+rMV
+iEQ
+bNQ
+bVs
 bva
-bLy
-bLy
-bva
-bva
-bva
-bva
+bGK
+bHQ
+bJc
+bKh
+bLu
+bLu
+bNG
+bOz
+bHQ
 bIZ
-bIZ
-bva
-bva
+aaa
 aht
 aaa
 aht
 cdm
-abI
+aht
 aaa
 bva
 bva
@@ -70928,47 +70907,45 @@ bIZ
 bIZ
 aaa
 aaa
+cfN
+whJ
+wCj
+tKm
+tNT
+tNT
+roy
+whJ
+whJ
+whJ
+whJ
+whJ
+umO
+whJ
+whJ
+whJ
+whJ
+whJ
+cfN
+cfN
+cfN
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cfN
+cfN
+cfN
+cfN
+cfN
+cfN
+cfN
+cfN
+cfN
+cfN
+cfN
+cfN
+cfN
+cfN
+cfN
+cfN
 aaa
 aaa
 aaa
@@ -71140,43 +71117,45 @@ baK
 baK
 bsl
 btM
-aYG
+aZx
 bxY
 bzz
 bAK
 bSl
-bSi
-bEj
-bFF
+bDh
+bEl
 eZM
+bVv
+qdj
 uPG
-eZM
+uMY
+uyy
+uPG
+pZT
+xKD
+pZT
+pZT
 bHT
-bJi
-eZM
-bRu
-aeq
-eZM
-qvx
-bHT
-bNQ
-bwv
-umV
-umV
-bmf
-bmf
-mpU
+pZT
+uPG
+uPG
+bva
+bGL
+bHQ
+bJd
+bKi
+bLv
+bMA
+bNH
+bOz
+bHQ
 bIZ
-aaa
-aaa
-aht
-aaa
 aaa
 aht
 aaa
 aht
 cdm
-abI
+aht
 aaa
 bIZ
 caZ
@@ -71185,47 +71164,45 @@ ccN
 bIZ
 aaa
 aaa
+cfN
+whJ
+wBO
+fdN
+qtD
+qtD
+kEk
+whJ
+reR
+tFt
+dCh
+dCh
+tJH
+sBW
+whJ
+cfN
+cfN
+cfN
+cfN
+cfN
 aaa
 aaa
 aaa
+cfN
+cfN
+cfN
+cfN
+cfN
+cfN
+cfN
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cfN
+cfN
+cfN
+cfN
+cfN
+cfN
+cfN
 aaa
 aaa
 aaa
@@ -71402,9 +71379,8 @@ bxZ
 bzA
 bAK
 bSl
-bSi
-bEk
 eZM
+bEm
 eZM
 uyy
 bSl
@@ -71418,21 +71394,24 @@ bSl
 bSl
 bSl
 bSl
+eZM
+iJI
 bva
-bva
-bWZ
-ary
-lrI
+bGM
+bHQ
+bJe
+bKj
+bLv
+bMB
+bNI
+bOz
+bHQ
 bIZ
 aaa
-aaa
-bUD
-bVr
-cqX
-cqX
-cqX
-crm
-cry
+aht
+aht
+abI
+ahi
 abI
 aaa
 bIZ
@@ -71442,6 +71421,22 @@ bDi
 bIZ
 aaa
 aaa
+cfN
+whJ
+nVN
+gkQ
+gkQ
+gkQ
+xkB
+whJ
+uIv
+kVM
+nWF
+xMQ
+nKQ
+gXh
+whJ
+cfN
 aaa
 aaa
 aaa
@@ -71451,37 +71446,19 @@ aaa
 aaa
 aaa
 aaa
+cfN
+cfN
+cfN
 aaa
 aaa
 aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cfN
+cfN
+cfN
+cfN
 aaa
 aaa
 aaa
@@ -71659,17 +71636,15 @@ bya
 bzB
 bAL
 bSl
-bDh
-bEl
-eZM
-gXg
+eUe
+oKD
+bCa
 uyy
 bSl
+bOG
 doo
-hRH
 nCe
-fWL
-tZa
+tml
 bKn
 bLz
 bMF
@@ -71677,19 +71652,23 @@ bNL
 bOD
 aht
 bIZ
-bDi
-bmf
-ccN
+ary
 bva
-bTa
-bTW
-bUE
-aaa
-abI
-aaa
-aaa
 bva
+bHR
+bJf
+bKk
+bLx
+bLx
+bNJ
+bOz
+bHQ
+bIZ
+aht
+aht
 crz
+bva
+bQS
 bva
 aaa
 bIZ
@@ -71700,22 +71679,20 @@ bIZ
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+whJ
+whJ
+wIX
+wIX
+wIX
+wIX
+whJ
+whJ
+whJ
+whJ
+whJ
+whJ
+whJ
+whJ
 aaa
 aaa
 aaa
@@ -71905,8 +71882,8 @@ eZM
 eZM
 bmc
 bnt
-sKe
-aYG
+bnt
+sXi
 bSl
 bSl
 btO
@@ -71916,16 +71893,14 @@ bSl
 bSl
 bSl
 bSl
-eZM
-bEm
-eZM
-bCa
+jVS
+oKD
+wVV
 uPG
 bSl
 erQ
 oat
 iMd
-sEN
 sEN
 bKo
 bLA
@@ -71934,19 +71909,23 @@ bNM
 bOD
 aht
 bIZ
-bDi
 bmf
-ftp
+bNX
 bva
-bTb
-ouv
-bIZ
-bIZ
-bva
+bHQ
+bJg
+bKl
+bJb
+bMC
+bJb
+bJb
+bPq
 bva
 aht
 bIZ
 crA
+bIZ
+bVr
 bIZ
 aaa
 bva
@@ -71956,8 +71935,6 @@ bva
 bva
 aaa
 cFB
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -72164,10 +72141,10 @@ bSl
 bSl
 bSl
 bSl
-eUe
-eZM
-bvb
+bSl
 bRu
+bvb
+eZM
 bws
 byb
 bzC
@@ -72175,15 +72152,13 @@ bzC
 bBY
 tNl
 btQ
-uPG
 ajJ
-uPG
+uLp
 bSl
+bTW
 qIl
-bGW
 iMd
 bJm
-bGW
 bKn
 bKn
 bKn
@@ -72191,27 +72166,29 @@ bKn
 bEr
 aht
 bva
-ftp
+aSr
+bsu
+bva
 bmd
-bTl
+bJh
+bKm
+bHQ
+bMD
+bKm
+bOA
+bPr
 bva
-bTc
-rMV
+aht
 bIZ
-bVs
-viB
-cqy
-aaa
-bva
 crB
+bva
+bTa
 bva
 aaa
 aaa
 bIZ
 csy
 bQl
-cqX
-xNx
 ctS
 aaa
 aaa
@@ -72416,7 +72393,7 @@ bhH
 biL
 eZM
 bRu
-bCa
+rMV
 uPG
 jMD
 uPG
@@ -72435,41 +72412,41 @@ bSl
 bSl
 bSl
 bSl
-bSl
+bEr
 kTU
-wMn
+sEN
+sEN
 lya
-lya
-lNy
-aSr
+bLA
+bMG
 pOc
-nbP
-wha
-wVV
-bPy
-bTX
-pEv
-jTw
-qpT
-bSo
-bSq
+bOD
+aht
+bIZ
+bmf
+ccN
+bva
+bva
+bva
+bva
 wlc
-bUF
-bNK
+wlc
+bva
+bva
 bva
 bva
 bva
 bva
 crC
 bva
+pEv
+bva
 bva
 bva
 bva
 bSq
 bva
 bva
-rnE
-aaa
 aaa
 aaa
 aaa
@@ -72665,8 +72642,8 @@ baS
 bbV
 bdZ
 bdZ
-bfc
-atx
+bTb
+bjK
 bgW
 bhK
 bic
@@ -72694,45 +72671,45 @@ sSl
 bHS
 bEr
 wLl
-bGW
 iMd
 bGW
-iMd
 bKn
+umV
+iHi
 lkK
-bQS
-vmY
-bSp
-bTd
-mSr
+bOD
+aht
+bIZ
+bJi
+bTl
 qEx
 dXa
 wwp
-oKD
-fwg
-xeI
-bDi
-bDi
+bva
+bsn
+bME
+bva
+bJj
 hZZ
-bWZ
-bDi
-bDi
+wdx
+bXU
+bVC
 bZr
 caa
 caa
 bXa
+xNS
+bXa
 bRD
-bWl
+lLQ
 cdE
 bIZ
-rnE
+aaa
+bBW
+bBW
 aaa
 aaa
 aaa
-nge
-adR
-adR
-adR
 aaa
 aaa
 aaa
@@ -72951,28 +72928,27 @@ ybu
 tuM
 jpa
 gGs
-iMd
 aNO
 cBK
-und
-bKq
+bKn
 bKn
 bEr
 bEr
 bEr
 aht
 bva
-bSq
-bCB
+bmf
+hRH
 bva
-bva
-bva
-lGv
-bva
-bva
-bva
+aej
 bDi
-fov
+bDi
+bWZ
+bDi
+bWZ
+rXJ
+cre
+bDi
 bva
 bva
 bva
@@ -72983,13 +72959,14 @@ bva
 bva
 bva
 ukn
-bIZ
 bva
 bva
+bHI
 aht
 aht
 aht
-aht
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -73208,30 +73185,27 @@ dok
 rus
 bEr
 gjt
-iJI
+sEN
 mxV
 fWl
-jVS
+bLA
 uAs
 bQj
-bFI
-bEr
-aaa
-aaa
-bva
-eNy
-bCB
-bFZ
+bSp
+bTd
+mSr
+kaf
+rJg
+bXa
+bRD
+tZa
 sUP
 bTf
-vGg
+wdx
 wdx
 bVu
 mzU
-rzp
-qCG
-bva
-bNX
+bOB
 bva
 cab
 jPf
@@ -73239,9 +73213,9 @@ oFI
 bva
 rse
 uIn
-mIa
-qdj
-sXi
+pnF
+oAW
+hBY
 bva
 bBX
 bBX
@@ -73249,6 +73223,9 @@ bBX
 bBX
 aht
 adR
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -73464,37 +73441,34 @@ bEr
 jnG
 bEr
 bEr
-bEr
-bEr
-bEr
+vGg
+cqy
+pQQ
 ozc
 vbv
 bFJ
 iQW
 bFL
-bEr
-aaa
-aaa
+bPy
+bQl
+rzp
 bva
-bSq
-bmf
 bva
-rXJ
-bTg
-bUa
+bva
+cSf
+bva
+bva
+bva
 jYh
-bVv
-bva
-nQc
-pQQ
-bva
-bOB
+bDi
+bDi
+lor
 bva
 kRq
 kRq
 kRq
 bva
-stQ
+lNy
 bDi
 bmf
 bmf
@@ -73506,6 +73480,9 @@ bDi
 bBX
 aht
 nge
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -73721,7 +73698,7 @@ fEZ
 eOe
 aCD
 buk
-sOB
+bEr
 dlS
 bEr
 bEr
@@ -73729,23 +73706,20 @@ bEr
 bEr
 bEr
 bEr
-bEr
-bJj
 aht
 oTJ
-crC
-bmf
-bva
-bSt
+bLy
+bFZ
+iGp
+atx
+gZg
+bDi
 bTh
-rJg
-dAG
-bVw
 bva
-iEQ
-pQQ
-ccN
-bSw
+nQc
+bVw
+bDi
+bWZ
 bva
 bva
 gkX
@@ -73763,6 +73737,9 @@ bDi
 bBX
 aht
 nge
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -73982,26 +73959,23 @@ sOB
 pDZ
 qhW
 vmo
-gum
 sHH
+urP
 hdk
 rXT
-pnF
-sOB
 aht
 bva
+rhT
+stQ
 xXe
-bCB
-bFZ
-bFZ
-bFZ
-bFZ
-bva
-bva
-bva
-bva
+bTX
+hko
 tTl
-bDi
+bTg
+fov
+bUE
+bXV
+rtA
 bZt
 bva
 oAW
@@ -74020,6 +73994,9 @@ dWk
 bBX
 aht
 adR
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -74239,26 +74216,23 @@ jKE
 feS
 agl
 vsn
-fNX
 pOt
-dES
-bOG
-mKz
+nPg
+rHh
 bSs
 aht
 bIZ
-bSq
+aLw
+bFZ
+bry
 bWH
+bKq
 bva
-bSu
-bTi
-bUb
 bva
-bVy
-ohR
-hVx
-bXU
-bDi
+bva
+bva
+tvP
+nAp
 bZt
 bZs
 kRq
@@ -74277,6 +74251,9 @@ weL
 bBX
 aht
 adR
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -74499,22 +74476,19 @@ bss
 piR
 lba
 sea
-uLp
-gkS
 bSs
 aht
 bIZ
-bSq
-bCB
-bRF
-bDi
-bPC
-bDi
+sZP
 bva
-bDg
-bSw
-bSw
-bXV
+bva
+bva
+bva
+bva
+bVy
+ohR
+hVx
+oWw
 bDi
 wuR
 bva
@@ -74534,6 +74508,9 @@ bDi
 bBX
 aht
 eNF
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -74752,26 +74729,23 @@ clK
 sOB
 vgg
 nbt
-cSf
-wGM
-nPg
+bss
+fMm
 gsP
+rnE
 bOI
-rHh
-sOB
 aht
 bva
-bSq
-lla
-bNK
-bSv
-bTj
-bDi
+sZP
 bva
-tRc
-bVz
-ftp
-tvP
+bSu
+bTi
+bUb
+bva
+bDg
+bSw
+bSw
+tTl
 bDi
 wRk
 bva
@@ -74791,6 +74765,9 @@ wfO
 bBX
 aht
 eNF
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -75009,26 +74986,23 @@ auB
 sOB
 bpz
 bOE
-bsu
+bss
 wGM
 pTy
 kYt
-pds
-rhT
 bSs
 aht
 bIZ
-bSq
-bCB
+sZP
+bRF
+bDi
+bPC
+bDi
 bva
-nGx
-eBb
-bUc
-bva
-bva
-bva
-bva
-oWw
+tRc
+bVz
+ftp
+tTl
 bDi
 bNS
 bva
@@ -75048,6 +75022,9 @@ fLG
 bBX
 aht
 nge
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -75270,21 +75247,18 @@ bNO
 uOA
 mMd
 uqs
-lor
-rHh
 sOB
 aht
 bva
-bSq
-bCB
-bva
-bSx
-bTk
-bUd
-bva
-bTl
+sZP
+bNK
+bSv
+bTj
 bDi
-wIv
+bva
+bva
+bva
+bva
 tTl
 bDi
 nWP
@@ -75305,6 +75279,9 @@ bBX
 bBX
 aht
 eNF
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -75525,25 +75502,22 @@ tqC
 tqC
 tqC
 bva
-bva
+pds
 snZ
 bva
 bva
 bva
+bUa
 bva
+nGx
+eBb
+bUc
 bva
-hko
-bCB
-bva
-bva
-bva
-bva
-bva
+ccN
 bDi
+wIv
+nbP
 bDi
-ary
-lQX
-bva
 bva
 bva
 bva
@@ -75560,6 +75534,9 @@ aht
 aht
 aht
 aht
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -75787,18 +75764,18 @@ bvZ
 bTJ
 bwB
 bva
-bsn
-bVC
-bSq
-bWH
-ccN
-bDi
-bDi
-bDi
-bOB
+sZP
+bva
+bSx
+bTk
+bUd
+bva
+qCG
+bva
+bva
 ygZ
-tTl
-gZg
+bDi
+bDi
 cad
 eYM
 bQl
@@ -75808,11 +75785,11 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
 eNF
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -76045,31 +76022,31 @@ nSe
 bcv
 bva
 gcn
-umd
-bSq
-bCB
-bDi
-bDi
+bva
+bva
+bva
+bva
+bva
 qOH
 fpT
-nMV
 fpT
+gdJ
 wNq
-bmf
+bva
 gMO
 kCc
 bBX
-jlb
-bXk
-bXk
-aaa
-aaa
+bUF
 aaa
 aaa
 aaa
 aaa
 aaa
 eNF
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -76303,10 +76280,10 @@ jdr
 bva
 sZP
 bDi
-bSq
+bDg
 lla
+dES
 bDi
-lLQ
 oez
 bBX
 bBX
@@ -76316,13 +76293,13 @@ bBX
 fdS
 xTi
 bXk
-mci
-vKD
+jlb
 bXk
 bXk
 bXk
 bXk
-aaa
+bXk
+bXk
 aaa
 aaa
 aaa
@@ -76558,9 +76535,9 @@ bva
 bva
 amZ
 bzO
-aAO
-aAO
-bKH
+xNx
+fpT
+jTw
 wem
 iyg
 jTw
@@ -76574,12 +76551,12 @@ oYj
 uMo
 bXk
 mci
+cry
 vKD
 pAb
 ceq
 ceq
 bXk
-aaa
 aaa
 aaa
 aaa
@@ -76832,11 +76809,11 @@ cdI
 cri
 eVW
 cbX
+cbX
 ceq
 ceq
 ceq
 bXk
-aaa
 aaa
 aaa
 aaa
@@ -77089,11 +77066,11 @@ cdI
 cri
 eVW
 cbX
+cbX
 ccQ
 ccQ
 ccQ
 bXk
-aaa
 aaa
 aaa
 aaa
@@ -77346,11 +77323,11 @@ ous
 bXk
 tuL
 ccR
+vKD
 lhu
 cbV
 ccQ
 bXk
-aaa
 aaa
 aaa
 aaa
@@ -77607,7 +77584,7 @@ bXk
 bXk
 bXk
 bXk
-aht
+bXk
 aht
 aht
 aht
@@ -78334,7 +78311,7 @@ boF
 bwC
 xte
 bGT
-cqm
+xan
 boB
 tWt
 pPN
@@ -78848,7 +78825,7 @@ bTL
 diT
 qqQ
 bGT
-cqm
+xan
 bsA
 xQr
 bpH
@@ -86041,7 +86018,7 @@ bEa
 bmL
 boX
 bvQ
-uiV
+bKH
 bqg
 brw
 bku
@@ -86298,7 +86275,7 @@ blF
 bmM
 bmM
 bqh
-ncE
+mIa
 brx
 bsX
 buv
@@ -86549,13 +86526,13 @@ bgC
 bgC
 bhQ
 bip
-aeI
+kdF
 bku
 blG
 bmN
 bnP
 bSh
-evR
+wMn
 bmM
 bsY
 bku
@@ -86812,7 +86789,7 @@ blH
 bmO
 bvU
 bqi
-bry
+viB
 bSQ
 bsZ
 bkt
@@ -87069,7 +87046,7 @@ blI
 bmO
 bvU
 boY
-gdJ
+mKz
 bmM
 bta
 bkt
@@ -87328,7 +87305,7 @@ bnR
 ldQ
 bqj
 bmM
-aej
+crm
 bkt
 bvJ
 bxw
@@ -89635,7 +89612,7 @@ aEj
 asG
 iSi
 bkz
-vUh
+gkS
 bmW
 bnW
 bpe
@@ -90149,7 +90126,7 @@ aEj
 asG
 iSi
 bky
-mmM
+xeI
 bky
 bnY
 bpg
@@ -93498,7 +93475,7 @@ iSi
 brT
 bxF
 wkZ
-kRS
+aeq
 spz
 any
 ahp
@@ -94012,10 +93989,10 @@ iSi
 bkF
 ume
 bkF
-hfZ
+cPT
 iLl
 wTZ
-sfk
+bFE
 xgt
 iUX
 bPl
@@ -94269,11 +94246,11 @@ bqC
 tMs
 vMx
 xzp
-hfZ
-aUj
-xNS
-urk
 cPT
+aUj
+qvx
+urk
+eNy
 iUX
 bLf
 bLf
@@ -94526,10 +94503,10 @@ bzg
 brX
 csu
 ofN
-hfZ
+cPT
 pXg
 uAx
-urP
+bUD
 aiL
 skj
 skj
@@ -94783,13 +94760,13 @@ bqE
 brW
 btu
 xpr
-hfZ
-hfZ
+cPT
+cPT
 mzp
 kPi
 azn
 azn
-xan
+fWL
 bFx
 gOV
 pgk
@@ -95040,9 +95017,9 @@ bqF
 brW
 qtf
 axj
-mfR
 hfZ
-gqe
+cPT
+sKe
 pNf
 kkQ
 rKL
@@ -95297,10 +95274,10 @@ ost
 nOY
 dgz
 jxl
-blE
-hfZ
+lQX
+cPT
 aeV
-ntk
+bSt
 izP
 aUj
 dfm

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -1103,12 +1103,12 @@
 /turf/open/floor/plating,
 /area/ai_monitored/aisat/exterior)
 "aej" = (
-/obj/item/stack/sheet/cardboard{
-	amount = 14
-	},
-/obj/item/vending_refill/cola,
-/turf/open/floor/plating,
-/area/maintenance/department/engine)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/structure/sign/poster/official/random/directional/east,
+/turf/open/floor/iron/dark,
+/area/service/chapel/monastery)
 "aek" = (
 /obj/structure/closet/secure_closet/medical3,
 /obj/item/screwdriver,
@@ -1150,9 +1150,11 @@
 /turf/open/floor/iron/dark,
 /area/security/brig)
 "aeq" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/science/genetics)
+/obj/structure/table/wood/fancy,
+/obj/item/spiritboard,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/service/chapel)
 "aer" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "Prison Gate";
@@ -1244,12 +1246,12 @@
 /turf/open/floor/iron/dark,
 /area/engineering/atmos)
 "aeI" = (
-/obj/structure/window/reinforced{
-	dir = 8
+/obj/machinery/door/airlock/grunge{
+	name = "Chapel Office"
 	},
-/obj/structure/window/reinforced,
-/turf/open/space/basic,
-/area/space/nearstation)
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/service/chapel)
 "aeJ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -3809,10 +3811,13 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "amC" = (
-/obj/structure/transit_tube/horizontal,
-/obj/structure/lattice/catwalk,
-/turf/open/space/basic,
-/area/space/nearstation)
+/obj/structure/flora/ausbushes/stalkybush,
+/obj/machinery/camera/directional/east{
+	c_tag = "Monastery Fore Exterior Starboard";
+	network = list("ss13","monastery")
+	},
+/turf/open/misc/asteroid,
+/area/service/chapel/asteroid/monastery)
 "amD" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -4673,10 +4678,10 @@
 /turf/open/floor/plating,
 /area/maintenance/disposal/incinerator)
 "apS" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
-/turf/open/space,
-/area/science/mixing)
+/obj/structure/rack,
+/obj/effect/spawner/random/maintenance,
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
 "apT" = (
 /turf/closed/wall/r_wall,
 /area/ai_monitored/command/nuke_storage)
@@ -5751,13 +5756,9 @@
 /turf/open/floor/iron,
 /area/security/brig)
 "atx" = (
-/obj/machinery/atmospherics/components/binary/pump/on/layer2{
-	name = "Virology Waste to Space"
-	},
-/turf/open/floor/plating{
-	icon_state = "platingdmg1"
-	},
-/area/maintenance/department/engine)
+/obj/item/flashlight/lantern,
+/turf/open/floor/iron/dark,
+/area/service/chapel)
 "atA" = (
 /obj/machinery/door/window/brigdoor/security/cell{
 	id = "Cell 3";
@@ -13289,9 +13290,20 @@
 /turf/open/floor/iron/dark,
 /area/hallway/primary/central)
 "aRJ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/dark,
-/area/service/chapel/office)
+/obj/structure/table,
+/obj/structure/table,
+/obj/item/storage/box/beakers{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/obj/item/storage/box/syringes,
+/obj/item/reagent_containers/spray/cleaner,
+/obj/effect/turf_decal/tile/green/anticorner/contrasted{
+	dir = 1
+	},
+/obj/machinery/newscaster/directional/north,
+/turf/open/floor/iron/white,
+/area/medical/virology)
 "aRL" = (
 /turf/closed/wall,
 /area/service/hydroponics)
@@ -13446,11 +13458,9 @@
 /turf/open/floor/iron,
 /area/cargo/storage)
 "aSr" = (
-/obj/structure/cable,
-/turf/open/floor/plating{
-	icon_state = "platingdmg1"
-	},
-/area/maintenance/department/engine)
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/service/library/lounge)
 "aSu" = (
 /obj/item/wirecutters,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -13641,23 +13651,21 @@
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen)
 "aTd" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/red/fourcorners,
+/obj/item/radio/intercom/chapel/directional/south,
+/obj/structure/chair/wood{
+	dir = 8
+	},
+/obj/machinery/light/small/directional/east,
 /turf/open/floor/iron/dark,
-/area/service/chapel/office)
+/area/service/chapel)
 "aTe" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/red/fourcorners,
-/turf/open/floor/iron/dark,
-/area/service/chapel/office)
-"aTf" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
+/obj/machinery/newscaster/directional/east,
+/turf/open/floor/iron/checker,
 /area/service/chapel/monastery)
+"aTf" = (
+/obj/structure/window/reinforced/fulltile,
+/turf/open/floor/plating,
+/area/service/hydroponics/garden/monastery)
 "aTg" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -14442,11 +14450,10 @@
 /turf/open/floor/iron/cafeteria,
 /area/security/prison)
 "aVY" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/service/chapel/monastery)
 "aVZ" = (
@@ -17463,12 +17470,12 @@
 /turf/open/floor/iron,
 /area/commons/vacant_room/commissary)
 "bgc" = (
-/obj/machinery/atmospherics/components/binary/pump/on{
-	dir = 4;
-	name = "Air Out"
+/obj/machinery/camera/directional/west{
+	c_tag = "Monastery Starboard Exterior";
+	network = list("ss13","monastery")
 	},
-/turf/open/floor/plating,
-/area/maintenance/department/chapel/monastery)
+/turf/open/misc/asteroid,
+/area/service/chapel/asteroid/monastery)
 "bge" = (
 /obj/structure/sign/directions/engineering{
 	dir = 4;
@@ -17539,9 +17546,9 @@
 /turf/open/floor/plating,
 /area/service/kitchen)
 "bgl" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/on/layer2{
-	dir = 4;
-	name = "Outlet Injector"
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/passive_vent/layer2{
+	dir = 4
 	},
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
@@ -18993,11 +19000,14 @@
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
 "blE" = (
-/obj/structure/table,
-/obj/item/stack/cable_coil,
-/obj/item/extinguisher,
-/turf/open/floor/plating,
-/area/maintenance/department/medical)
+/obj/effect/turf_decal/tile/purple/half/contrasted{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/science/genetics)
 "blF" = (
 /obj/structure/chair/office/light{
 	dir = 1
@@ -20588,11 +20598,9 @@
 /turf/open/floor/iron,
 /area/science/robotics/lab)
 "bry" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
-/obj/machinery/meter/monitored/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/maintenance/department/engine)
+/obj/structure/extinguisher_cabinet/directional/east,
+/turf/open/floor/iron/dark,
+/area/service/library/lounge)
 "brz" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -20767,6 +20775,11 @@
 	},
 /turf/open/floor/iron,
 /area/science/xenobiology)
+"bsj" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/light_switch/directional/east,
+/turf/open/floor/iron/dark,
+/area/service/library/artgallery)
 "bsl" = (
 /obj/structure/sign/warning/vacuum/external,
 /obj/effect/spawner/structure/window/reinforced,
@@ -20824,13 +20837,16 @@
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "bss" = (
-/turf/open/floor/carpet/purple,
-/area/medical/psychology)
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/science/robotics/lab)
 "bsu" = (
-/obj/structure/rack,
-/obj/effect/spawner/random/maintenance,
+/obj/item/stack/cable_coil,
 /turf/open/floor/plating,
-/area/maintenance/department/engine)
+/area/tcommsat/computer)
 "bsv" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -21814,10 +21830,9 @@
 /turf/open/floor/iron/white,
 /area/medical/surgery)
 "bwv" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/transit_tube,
-/turf/open/space/basic,
-/area/space/nearstation)
+/obj/structure/bookcase/random/adult,
+/turf/open/floor/iron/dark,
+/area/service/library)
 "bwx" = (
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 4;
@@ -22275,12 +22290,8 @@
 /turf/open/floor/iron/white,
 /area/medical/storage)
 "byg" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
+/obj/effect/turf_decal/tile/purple/half/contrasted,
+/obj/effect/turf_decal/stripes/line,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -22983,9 +22994,8 @@
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "bAI" = (
-/obj/structure/transit_tube/curved/flipped{
-	dir = 4
-	},
+/obj/structure/lattice/catwalk,
+/obj/structure/transit_tube/horizontal,
 /turf/open/space/basic,
 /area/space/nearstation)
 "bAJ" = (
@@ -22998,7 +23008,7 @@
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
 "bAL" = (
-/obj/structure/transit_tube/station/dispenser/reverse,
+/obj/structure/transit_tube/station/dispenser/reverse/flipped,
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
 "bAM" = (
@@ -23301,9 +23311,14 @@
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "bBV" = (
-/obj/structure/transit_tube/curved,
-/turf/open/space,
-/area/space/nearstation)
+/obj/machinery/door/airlock/grunge{
+	name = "Chapel Auxiliary""
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/service/chapel)
 "bBW" = (
 /turf/open/space,
 /area/space)
@@ -24219,11 +24234,11 @@
 /turf/open/floor/engine,
 /area/science/storage)
 "bFc" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/on{
+/obj/machinery/atmospherics/components/unary/passive_vent{
 	dir = 1
 	},
 /turf/open/floor/plating/airless,
-/area/science/mixing)
+/area/space/nearstation)
 "bFd" = (
 /obj/structure/cable,
 /turf/open/floor/engine,
@@ -24388,13 +24403,12 @@
 /turf/open/floor/plating,
 /area/maintenance/department/science/xenobiology)
 "bFE" = (
-/obj/effect/turf_decal/tile/purple/half/contrasted,
-/obj/effect/turf_decal/stripes/line,
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/item/kirbyplants{
+	icon_state = "plant-10"
 	},
-/turf/open/floor/iron/white,
-/area/science/genetics)
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/iron/dark,
+/area/service/chapel/monastery)
 "bFF" = (
 /obj/machinery/atmospherics/components/tank/air{
 	dir = 1
@@ -24402,10 +24416,11 @@
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
 "bFI" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/stool/directional/west,
-/turf/open/floor/plating,
-/area/maintenance/department/medical)
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/service/library)
 "bFJ" = (
 /mob/living/carbon/human/species/monkey,
 /obj/structure/disposalpipe/segment,
@@ -24707,11 +24722,15 @@
 /turf/open/floor/grass,
 /area/science/genetics)
 "bGD" = (
-/obj/structure/window/reinforced{
-	dir = 4
+/obj/structure/chair/wood{
+	dir = 8
 	},
-/turf/open/space,
-/area/space/nearstation)
+/obj/machinery/camera/directional/north{
+	c_tag = "Monastery Obsequy";
+	network = list("ss13","monastery")
+	},
+/turf/open/floor/iron/dark,
+/area/service/chapel/funeral)
 "bGE" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -24724,16 +24743,13 @@
 /turf/open/floor/plating,
 /area/service/chapel/dock)
 "bGG" = (
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 8;
-	layer = 2.9
+/obj/structure/chair/wood{
+	dir = 8
 	},
-/obj/machinery/atmospherics/components/unary/outlet_injector/on/layer2{
-	name = "Outlet Injector"
+/turf/open/floor/iron/chapel{
+	dir = 8
 	},
-/turf/open/floor/plating/airless,
-/area/service/chapel/dock)
+/area/service/chapel)
 "bGH" = (
 /obj/structure/window/reinforced,
 /turf/open/space,
@@ -24992,12 +25008,14 @@
 /turf/open/floor/iron/dark,
 /area/science/explab)
 "bHH" = (
-/obj/structure/bookcase/random/religion,
-/obj/machinery/light/small{
-	dir = 1
+/obj/machinery/door/airlock/grunge{
+	name = "Monastery Transit"
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
-/area/service/library/lounge)
+/area/service/chapel/dock)
 "bHI" = (
 /obj/structure/grille/broken,
 /turf/open/space/basic,
@@ -25006,13 +25024,17 @@
 /turf/open/floor/plating,
 /area/service/chapel/dock)
 "bHL" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/service/chapel/dock)
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/service/library/artgallery)
 "bHM" = (
-/turf/closed/wall/r_wall,
-/area/service/chapel/dock)
+/obj/machinery/computer/pod/old/mass_driver_controller/chapelgun{
+	pixel_y = 28
+	},
+/turf/open/floor/iron/dark,
+/area/service/chapel/funeral)
 "bHN" = (
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -25229,25 +25251,29 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "bIU" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/closed/wall,
-/area/service/chapel/dock)
+/obj/structure/extinguisher_cabinet/directional/north,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/maintenance/department/chapel/monastery)
 "bIV" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/sign/warning/vacuum/external,
 /turf/open/floor/plating,
 /area/service/chapel/dock)
 "bIW" = (
-/obj/machinery/computer/shuttle/monastery_shuttle,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/service/chapel/dock)
+/obj/effect/turf_decal/sand,
+/obj/structure/flora/ausbushes,
+/turf/open/floor/iron,
+/area/service/chapel/asteroid/monastery)
 "bIX" = (
-/obj/effect/spawner/atmos_canister/air,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/service/chapel/dock)
+/obj/item/stack/sheet/cardboard{
+	amount = 14
+	},
+/obj/item/vending_refill/cola,
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
 "bIY" = (
 /obj/structure/lattice,
 /obj/structure/window/reinforced{
@@ -25303,22 +25329,14 @@
 /turf/open/floor/iron/dark,
 /area/maintenance/department/engine)
 "bJi" = (
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/maintenance/department/engine)
+/obj/structure/chair/wood,
+/turf/open/floor/carpet,
+/area/service/library/lounge)
 "bJj" = (
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/item/kirbyplants{
-	icon_state = "plant-21"
-	},
 /turf/open/floor/plating{
-	icon_state = "platingdmg3"
+	icon_state = "panelscorched"
 	},
-/area/maintenance/department/engine)
+/area/maintenance/department/medical)
 "bJk" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -25495,28 +25513,31 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "bKa" = (
-/obj/machinery/airalarm/directional/west{
-	pixel_x = -22
+/obj/machinery/camera/directional/west{
+	c_tag = "Monastery Fore Exterior Port";
+	network = list("ss13","monastery")
 	},
-/turf/open/floor/iron/dark,
-/area/service/chapel/dock)
+/turf/open/misc/asteroid,
+/area/service/chapel/asteroid/monastery)
 "bKc" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/computer/shuttle/monastery_shuttle,
 /turf/open/floor/iron/dark,
 /area/service/chapel/dock)
 "bKd" = (
-/obj/machinery/power/apc/auto_name/directional/east{
-	name = "Monastery Docking Bay APC"
+/obj/machinery/camera/directional/north{
+	c_tag = "Monastery Chapel";
+	network = list("ss13","monastery")
 	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /turf/open/floor/iron/dark,
-/area/service/chapel/dock)
+/area/service/chapel)
 "bKe" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
-/turf/open/floor/iron/dark,
-/area/service/chapel/dock)
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/north{
+	name = "Monastery Maintenance APC"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/maintenance/department/chapel/monastery)
 "bKf" = (
 /obj/structure/chair,
 /turf/open/floor/iron/dark,
@@ -25593,14 +25614,12 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "bKq" = (
-/obj/machinery/atmospherics/components/tank/air{
-	dir = 1;
-	piping_layer = 4
-	},
-/turf/open/floor/plating{
-	icon_state = "platingdmg1"
-	},
-/area/maintenance/department/engine)
+/obj/structure/table/wood,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/camera,
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/turf/open/floor/iron/dark,
+/area/service/library/artgallery)
 "bKr" = (
 /obj/machinery/vending/medical,
 /obj/effect/turf_decal/tile/blue/anticorner/contrasted{
@@ -25643,30 +25662,13 @@
 /turf/open/floor/iron/white,
 /area/medical/surgery)
 "bKH" = (
-/obj/structure/table,
-/obj/item/book/manual/wiki/robotics_cyborgs{
-	pixel_x = 6;
-	pixel_y = 5
-	},
-/obj/item/storage/belt/utility,
-/obj/item/reagent_containers/glass/beaker/large,
-/obj/item/radio/headset/headset_sci{
-	pixel_x = -3
-	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/machinery/button/door{
-	id = "robotics";
-	name = "Shutters Control Button";
-	pixel_x = -26;
-	pixel_y = 8;
-	req_access_txt = "29"
-	},
-/obj/machinery/light_switch{
-	pixel_x = -25;
-	pixel_y = -8
-	},
+/obj/effect/landmark/start/assistant,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
-/area/science/robotics/lab)
+/area/service/library/artgallery)
 "bKI" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/tile/yellow{
@@ -25811,25 +25813,22 @@
 /turf/open/floor/iron/dark,
 /area/service/chapel/dock)
 "bLo" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/service/chapel/dock)
-"bLp" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
-/turf/open/floor/iron/dark,
-/area/service/chapel/dock)
-"bLq" = (
-/obj/machinery/door/airlock/grunge{
-	name = "Monastery Transit"
+/obj/structure/chair/wood,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/service/chapel/dock)
+/turf/open/floor/carpet/black,
+/area/service/chapel/office)
+"bLp" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
+"bLq" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/science/genetics)
 "bLs" = (
 /obj/structure/lattice,
 /obj/structure/window/reinforced{
@@ -25861,17 +25860,13 @@
 /turf/open/floor/engine,
 /area/maintenance/department/engine)
 "bLy" = (
-/obj/machinery/light/small{
-	dir = 1
+/obj/machinery/door/airlock/grunge{
+	name = "Chapel"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
-/turf/open/floor/plating,
-/area/maintenance/department/engine)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark,
+/area/service/chapel)
 "bLz" = (
 /obj/item/bedsheet/medical,
 /obj/structure/bed,
@@ -26128,9 +26123,10 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "bMu" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
-/turf/open/floor/iron/dark,
-/area/service/chapel/dock)
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/maintenance/department/chapel/monastery)
 "bMw" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron/dark,
@@ -26146,12 +26142,11 @@
 /turf/open/floor/iron/dark,
 /area/service/chapel/dock)
 "bMy" = (
-/obj/structure/window/reinforced{
-	dir = 8;
-	layer = 2.9
+/obj/structure/transit_tube/curved/flipped{
+	dir = 4
 	},
 /obj/structure/lattice,
-/turf/open/space,
+/turf/open/space/basic,
 /area/space/nearstation)
 "bMA" = (
 /obj/effect/landmark/event_spawn,
@@ -26350,56 +26345,42 @@
 /turf/open/floor/iron/dark,
 /area/command/bridge)
 "bNr" = (
+/obj/structure/closet/crate/coffin,
 /obj/structure/window/reinforced{
-	dir = 4
+	dir = 1
 	},
-/obj/structure/window/reinforced,
-/obj/structure/lattice,
-/turf/open/space,
-/area/space/nearstation)
+/turf/open/floor/iron/dark,
+/area/service/chapel/funeral)
 "bNs" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/service/chapel/asteroid/monastery)
 "bNt" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -24
-	},
-/obj/machinery/light/small,
-/obj/machinery/camera/directional/south{
-	c_tag = "Monastery Dock";
-	network = list("ss13","monastery")
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/service/chapel/dock)
+/obj/effect/spawner/random/trash/janitor_supplies,
+/turf/open/floor/plating,
+/area/maintenance/department/medical)
 "bNu" = (
-/obj/structure/cable,
+/obj/structure/displaycase/trophy,
+/obj/machinery/light/directional/east,
 /turf/open/floor/iron/dark,
-/area/service/chapel/dock)
+/area/service/library/artgallery)
 "bNv" = (
-/obj/item/radio/intercom{
-	pixel_x = 27
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/airlock/maintenance{
+	name = "Monastery Maintenance";
+	req_one_access_txt = "22;24;10;11;37;12"
 	},
-/obj/machinery/light/small,
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/service/chapel/dock)
+/turf/open/floor/plating,
+/area/maintenance/department/chapel/monastery)
 "bNw" = (
 /turf/closed/wall,
 /area/service/chapel/dock)
 "bNx" = (
-/obj/structure/transit_tube/station/dispenser/reverse/flipped{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/service/chapel/dock)
+/obj/effect/turf_decal/sand,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/service/chapel/asteroid/monastery)
 "bNy" = (
 /obj/structure/transit_tube/horizontal,
 /obj/machinery/camera/directional/south{
@@ -26418,10 +26399,12 @@
 /turf/open/floor/plating,
 /area/service/chapel/dock)
 "bNB" = (
-/obj/structure/rack,
-/obj/effect/spawner/random/entertainment/drugs,
-/turf/open/floor/plating,
-/area/maintenance/department/medical)
+/obj/machinery/door/morgue{
+	name = "Private Exhibit";
+	req_access_txt = "37"
+	},
+/turf/open/floor/iron/dark,
+/area/service/library/artgallery)
 "bNF" = (
 /obj/item/stack/medical/suture,
 /turf/open/floor/iron/dark,
@@ -26530,11 +26513,8 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "bNX" = (
-/obj/structure/table,
 /obj/effect/spawner/random/maintenance,
-/turf/open/floor/plating{
-	icon_state = "platingdmg3"
-	},
+/turf/open/floor/plating,
 /area/maintenance/department/engine)
 "bNZ" = (
 /obj/machinery/door/airlock/maintenance{
@@ -26640,7 +26620,7 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "bOo" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/monitored{
+/obj/machinery/atmospherics/components/unary/passive_vent{
 	dir = 4
 	},
 /turf/open/floor/plating/airless,
@@ -26675,20 +26655,17 @@
 /turf/open/floor/iron,
 /area/security)
 "bOv" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/lattice,
-/turf/open/space,
-/area/space/nearstation)
+/turf/closed/wall,
+/area/service/chapel/funeral)
 "bOw" = (
 /turf/open/misc/asteroid,
 /area/service/chapel/asteroid/monastery)
 "bOx" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
-/area/service/chapel/dock)
+/area/service/chapel/funeral)
 "bOz" = (
 /obj/structure/chair/comfy/black{
 	dir = 1
@@ -26724,20 +26701,14 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "bOG" = (
-/obj/structure/table,
-/obj/structure/table,
-/obj/item/storage/box/beakers{
-	pixel_x = 4;
-	pixel_y = 4
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/structure/sign/poster/official/pda_ad{
+	pixel_x = 32
 	},
-/obj/item/storage/box/syringes,
-/obj/item/reagent_containers/spray/cleaner,
-/obj/effect/turf_decal/tile/green/anticorner/contrasted{
-	dir = 1
-	},
-/obj/machinery/newscaster/directional/north,
-/turf/open/floor/iron/white,
-/area/medical/virology)
+/turf/open/floor/iron/dark,
+/area/service/chapel/monastery)
 "bOH" = (
 /obj/effect/landmark/blobstart,
 /obj/structure/cable,
@@ -26882,20 +26853,14 @@
 /turf/open/space/basic,
 /area/science/mixing/chamber)
 "bPn" = (
-/obj/machinery/door/airlock/grunge{
-	name = "Chapel"
-	},
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/bookbinder,
 /turf/open/floor/iron/dark,
-/area/service/chapel/dock)
+/area/service/library)
 "bPo" = (
-/obj/machinery/door/airlock/grunge{
-	name = "Chapel"
-	},
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/service/chapel/dock)
+/obj/structure/chair/wood,
+/obj/effect/landmark/start/assistant,
+/turf/open/floor/carpet,
+/area/service/library/lounge)
 "bPp" = (
 /obj/structure/sign/poster/contraband/random{
 	pixel_y = -32
@@ -27111,12 +27076,10 @@
 /turf/open/floor/engine/n2o,
 /area/engineering/atmos)
 "bQc" = (
-/obj/machinery/camera/directional/west{
-	c_tag = "Monastery Asteroid Dock Port";
-	network = list("ss13","monastery")
-	},
-/turf/open/misc/asteroid,
-/area/service/chapel/asteroid/monastery)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark,
+/area/service/chapel/funeral)
 "bQd" = (
 /obj/structure/flora/ausbushes/leafybush,
 /obj/structure/flora/ausbushes/reedbush,
@@ -27129,28 +27092,30 @@
 /turf/open/misc/asteroid,
 /area/service/chapel/asteroid/monastery)
 "bQf" = (
-/obj/effect/turf_decal/sand,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/service/chapel/asteroid/monastery)
+/obj/machinery/camera/directional/west{
+	c_tag = "Monastery Lounge";
+	network = list("ss13","monastery")
+	},
+/obj/structure/sign/poster/official/random/directional/west,
+/turf/open/floor/iron/dark,
+/area/service/library/lounge)
 "bQg" = (
 /obj/effect/turf_decal/sand,
 /turf/open/floor/iron,
 /area/service/chapel/asteroid/monastery)
 "bQh" = (
-/obj/machinery/camera/directional/east{
-	c_tag = "Monastery Asteroid Dock Staboard";
-	network = list("ss13","monastery")
-	},
-/turf/open/misc/asteroid,
-/area/service/chapel/asteroid/monastery)
-"bQi" = (
-/obj/structure/window/reinforced{
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
-/obj/structure/lattice,
-/turf/open/space,
-/area/space/nearstation)
+/turf/open/floor/iron/dark,
+/area/service/library/artgallery)
+"bQi" = (
+/obj/machinery/door/airlock/grunge{
+	name = "Library"
+	},
+/turf/open/floor/iron,
+/area/service/library)
 "bQj" = (
 /mob/living/carbon/human/species/monkey,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
@@ -27388,14 +27353,13 @@
 /turf/open/space,
 /area/space/nearstation)
 "bQS" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
+/obj/structure/table/glass,
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 8
 	},
-/obj/machinery/door/airlock/external{
-	req_access_txt = "13"
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/engine)
+/obj/item/clothing/gloves/color/latex,
+/turf/open/floor/iron/dark,
+/area/science/genetics)
 "bQY" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -27829,11 +27793,9 @@
 /turf/open/misc/asteroid,
 /area/service/chapel/asteroid/monastery)
 "bSn" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/open/space,
-/area/space/nearstation)
+/obj/structure/closet/secure_closet/cytology,
+/turf/open/floor/iron/dark,
+/area/science/xenobiology)
 "bSo" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -27848,9 +27810,9 @@
 /turf/open/floor/plating,
 /area/medical/virology)
 "bSq" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/obj/machinery/meter/monitored/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "bSs" = (
@@ -27858,13 +27820,16 @@
 /turf/open/floor/plating,
 /area/medical/psychology)
 "bSt" = (
-/obj/structure/table/glass,
-/obj/effect/turf_decal/tile/neutral/half/contrasted{
-	dir = 8
+/obj/structure/closet/crate/coffin,
+/obj/structure/window/reinforced{
+	dir = 4
 	},
-/obj/item/clothing/gloves/color/latex,
+/obj/machinery/door/window/left/directional/north{
+	name = "Coffin Storage";
+	req_access_txt = "22"
+	},
 /turf/open/floor/iron/dark,
-/area/science/genetics)
+/area/service/chapel/funeral)
 "bSu" = (
 /obj/item/broken_bottle,
 /obj/effect/spawner/random/maintenance,
@@ -28062,31 +28027,36 @@
 /turf/open/floor/engine/plasma,
 /area/engineering/atmos)
 "bSZ" = (
-/obj/structure/lattice,
-/obj/structure/window/reinforced{
-	dir = 8
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
 	},
-/turf/open/space,
-/area/space/nearstation)
+/turf/open/floor/iron/dark,
+/area/service/library)
 "bTa" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/obj/machinery/door/airlock/external{
-	req_access_txt = "13"
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/engine)
+/obj/machinery/smartfridge/petri/preloaded,
+/obj/machinery/firealarm/directional/south,
+/turf/open/floor/iron/dark,
+/area/science/xenobiology)
 "bTb" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/hallway/secondary/entry)
-"bTc" = (
-/turf/open/floor/plating{
-	luminosity = 2
+/obj/machinery/atmospherics/components/tank/air{
+	dir = 1
 	},
-/area/maintenance/department/medical)
+/obj/structure/sign/poster/contraband/random/directional/south,
+/turf/open/floor/plating,
+/area/maintenance/department/chapel/monastery)
+"bTc" = (
+/obj/machinery/light/small,
+/obj/machinery/camera/directional/south{
+	c_tag = "Monastery Fore Dock";
+	network = list("ss13","monastery")
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/extinguisher_cabinet/directional/west,
+/turf/open/floor/iron/dark,
+/area/service/chapel/dock)
 "bTd" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -28100,12 +28070,12 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "bTg" = (
-/obj/machinery/meter/monitored/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plating{
-	icon_state = "platingdmg3"
+/obj/structure/chair/wood{
+	dir = 1
 	},
-/area/maintenance/department/engine)
+/obj/item/radio/intercom/directional/west,
+/turf/open/floor/iron/dark,
+/area/service/library/lounge)
 "bTh" = (
 /obj/effect/spawner/atmos_canister/nitrous_oxide,
 /obj/machinery/atmospherics/components/unary/portables_connector/visible/layer4{
@@ -28430,26 +28400,45 @@
 /turf/open/floor/engine/plasma,
 /area/engineering/atmos)
 "bTW" = (
-/obj/machinery/computer/pandemic,
-/obj/machinery/airalarm/directional/north,
-/obj/effect/turf_decal/tile/green/anticorner/contrasted{
-	dir = 4
+/obj/structure/window/reinforced{
+	dir = 1
 	},
-/turf/open/floor/iron/white,
-/area/medical/virology)
+/obj/structure/table/wood,
+/obj/item/flashlight/lantern,
+/turf/open/floor/iron/dark,
+/area/service/chapel/funeral)
 "bTX" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
-/turf/open/floor/plating,
-/area/maintenance/department/engine)
-"bUa" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/segment{
+/obj/effect/decal/cleanable/blood/old,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/department/engine)
+/turf/open/floor/iron/dark,
+/area/service/chapel/funeral)
+"bUa" = (
+/obj/structure/table,
+/obj/item/book/manual/wiki/robotics_cyborgs{
+	pixel_x = 6;
+	pixel_y = 5
+	},
+/obj/item/storage/belt/utility,
+/obj/item/reagent_containers/glass/beaker/large,
+/obj/item/radio/headset/headset_sci{
+	pixel_x = -3
+	},
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/button/door{
+	id = "robotics";
+	name = "Shutters Control Button";
+	pixel_x = -26;
+	pixel_y = 8;
+	req_access_txt = "29"
+	},
+/obj/machinery/light_switch{
+	pixel_x = -25;
+	pixel_y = -8
+	},
+/turf/open/floor/iron/dark,
+/area/science/robotics/lab)
 "bUb" = (
 /obj/structure/grille/broken,
 /obj/structure/musician/piano,
@@ -28646,30 +28635,25 @@
 /turf/open/misc/asteroid,
 /area/service/chapel/asteroid/monastery)
 "bUD" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/science/genetics)
+/turf/open/floor/iron/checker,
+/area/service/chapel/monastery)
 "bUE" = (
-/obj/structure/table,
-/obj/item/storage/box/lights/mixed,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plating,
-/area/maintenance/department/engine)
+/obj/item/kirbyplants{
+	icon_state = "plant-22"
+	},
+/obj/machinery/camera/directional/west{
+	c_tag = "Library Port";
+	network = list("ss13","monastery")
+	},
+/turf/open/floor/iron/dark,
+/area/service/library)
 "bUF" = (
-/obj/structure/disposalpipe/segment{
+/obj/structure/window/reinforced{
 	dir = 4
 	},
-/turf/open/space/basic,
-/area/space/nearstation)
+/obj/structure/flora/ausbushes/reedbush,
+/turf/open/misc/asteroid,
+/area/service/chapel/asteroid/monastery)
 "bUG" = (
 /obj/machinery/power/emitter,
 /turf/open/floor/plating,
@@ -28947,21 +28931,22 @@
 /turf/open/floor/engine/co2,
 /area/engineering/atmos)
 "bVp" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
+/obj/machinery/vending/dinnerware,
+/turf/open/floor/iron/checker,
+/area/service/chapel/monastery)
 "bVr" = (
-/obj/structure/sign/warning/vacuum/external{
-	pixel_y = -32
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "bVs" = (
-/obj/effect/spawner/random/trash/janitor_supplies,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden,
+/obj/structure/cable,
 /turf/open/floor/plating,
-/area/maintenance/department/medical)
+/area/maintenance/department/chapel/monastery)
 "bVu" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -28970,12 +28955,10 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "bVv" = (
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
-	},
-/area/maintenance/department/medical)
+/obj/machinery/light/small/directional/south,
+/obj/structure/extinguisher_cabinet/directional/south,
+/turf/open/floor/iron/dark,
+/area/service/chapel/funeral)
 "bVw" = (
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/plating{
@@ -28997,12 +28980,9 @@
 	},
 /area/maintenance/department/engine)
 "bVC" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating{
-	icon_state = "platingdmg2"
-	},
-/area/maintenance/department/engine)
+/obj/structure/flora/ausbushes/stalkybush,
+/turf/open/misc/asteroid,
+/area/service/chapel/asteroid/monastery)
 "bVD" = (
 /obj/machinery/button/door{
 	desc = "A remote control-switch for the engineering security doors.";
@@ -29228,19 +29208,28 @@
 /turf/open/floor/engine/co2,
 /area/engineering/atmos)
 "bWi" = (
-/obj/structure/flora/ausbushes/leafybush,
-/obj/structure/flora/ausbushes/reedbush,
-/obj/machinery/camera/directional/south{
-	c_tag = "Monastery Asteroid Primary Entrance";
-	network = list("ss13","monastery")
-	},
-/turf/open/misc/asteroid,
-/area/service/chapel/asteroid/monastery)
+/obj/structure/table/wood/fancy,
+/obj/item/storage/fancy/candle_box,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/carpet,
+/area/service/library/lounge)
 "bWl" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/transit_tube/crossing,
-/turf/open/space/basic,
-/area/space/nearstation)
+/obj/item/stack/sheet/glass/fifty{
+	layer = 4
+	},
+/obj/item/stack/sheet/iron{
+	amount = 20;
+	layer = 3.1
+	},
+/obj/structure/table,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/cobweb,
+/obj/item/stack/rods/fifty,
+/turf/open/floor/plating,
+/area/maintenance/department/chapel/monastery)
 "bWn" = (
 /obj/structure/closet/secure_closet/engineering_chief,
 /obj/structure/extinguisher_cabinet{
@@ -29516,16 +29505,15 @@
 /turf/closed/wall,
 /area/service/chapel/monastery)
 "bWW" = (
-/obj/machinery/door/airlock/grunge{
-	name = "Chapel"
+/obj/structure/sign/departments/holy{
+	pixel_x = -32
 	},
-/obj/structure/cable,
 /turf/open/floor/iron/dark,
-/area/service/chapel/monastery)
+/area/service/library/lounge)
 "bWX" = (
-/obj/machinery/door/airlock/grunge{
-	name = "Chapel"
-	},
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/service/chapel/monastery)
 "bWZ" = (
@@ -29747,37 +29735,32 @@
 	},
 /area/hallway/secondary/entry)
 "bXI" = (
-/obj/structure/cable,
+/obj/item/kirbyplants{
+	icon_state = "plant-22"
+	},
 /turf/open/floor/iron/dark,
-/area/service/chapel/monastery)
+/area/service/library/lounge)
 "bXJ" = (
 /turf/open/floor/iron/dark,
 /area/service/chapel/monastery)
 "bXL" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
-/obj/machinery/door/airlock/external,
-/turf/open/floor/plating,
-/area/service/chapel/asteroid/monastery)
+/obj/machinery/rnd/experimentor,
+/turf/open/floor/engine,
+/area/science/explab)
 "bXM" = (
-/obj/machinery/light/small{
-	dir = 1
+/obj/item/kirbyplants{
+	icon_state = "plant-21"
 	},
-/turf/open/floor/plating,
-/area/service/chapel/asteroid/monastery)
+/turf/open/floor/iron/dark,
+/area/service/chapel/monastery)
 "bXN" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/obj/machinery/door/airlock/external,
-/turf/open/floor/plating,
-/area/service/chapel/asteroid/monastery)
+/turf/closed/wall/mineral/iron,
+/area/service/library)
 "bXU" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment,
+/obj/structure/table,
+/obj/effect/spawner/random/maintenance,
 /turf/open/floor/plating{
-	icon_state = "platingdmg2"
+	icon_state = "platingdmg3"
 	},
 /area/maintenance/department/engine)
 "bXV" = (
@@ -29909,20 +29892,24 @@
 /turf/closed/wall/r_wall,
 /area/maintenance/disposal/incinerator)
 "bYz" = (
-/obj/machinery/door/morgue{
-	name = "Confession Booth"
+/obj/structure/window/reinforced{
+	dir = 1
 	},
+/obj/structure/flora/ausbushes/stalkybush,
+/turf/open/misc/asteroid,
+/area/service/chapel/asteroid/monastery)
+"bYA" = (
+/obj/machinery/door/airlock/grunge{
+	name = "Chapel Auxiliary""
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/service/chapel/monastery)
-"bYA" = (
-/obj/structure/chair/wood,
-/turf/open/floor/iron/chapel{
-	dir = 8
-	},
-/area/service/chapel/monastery)
 "bYB" = (
-/obj/structure/chair/wood,
-/turf/open/floor/iron/chapel,
+/obj/machinery/vending/cigarette,
+/turf/open/floor/iron/dark,
 /area/service/chapel/monastery)
 "bYC" = (
 /obj/structure/chair/office{
@@ -30165,27 +30152,29 @@
 /turf/closed/wall/r_wall,
 /area/maintenance/disposal/incinerator)
 "bZl" = (
-/obj/structure/chair/wood,
-/turf/open/floor/iron/chapel{
+/obj/structure/chair/wood{
 	dir = 1
 	},
+/turf/open/floor/iron/checker,
 /area/service/chapel/monastery)
 "bZm" = (
-/obj/structure/chair/wood,
-/turf/open/floor/iron/chapel{
-	dir = 4
-	},
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/sign/poster/official/random/directional/west,
+/turf/open/floor/iron/dark,
 /area/service/chapel/monastery)
 "bZn" = (
+/obj/machinery/power/apc/auto_name/directional/north{
+	name = "Monastery APC"
+	},
 /obj/structure/cable,
-/turf/open/floor/carpet,
+/turf/open/floor/iron/dark,
 /area/service/chapel/monastery)
 "bZo" = (
-/turf/open/floor/carpet,
-/area/service/chapel/monastery)
+/obj/effect/landmark/xeno_spawn,
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
 "bZr" = (
 /obj/item/trash/tray,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/junction,
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
@@ -30551,24 +30540,28 @@
 /turf/open/space,
 /area/engineering/atmos)
 "caS" = (
-/turf/closed/wall,
-/area/service/chapel/asteroid/monastery)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/carpet,
+/area/service/chapel)
 "caT" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/tinted/fulltile,
-/turf/open/floor/iron/dark,
-/area/service/chapel/monastery)
-"caV" = (
-/obj/machinery/holopad,
-/obj/item/flashlight/lantern,
-/turf/open/floor/iron/chapel,
-/area/service/chapel/monastery)
-"caW" = (
-/obj/item/flashlight/lantern,
-/turf/open/floor/iron/chapel{
-	dir = 8
+/obj/machinery/door/morgue{
+	name = "Confession Booth";
+	req_access_txt = "22"
 	},
-/area/service/chapel/monastery)
+/turf/open/floor/iron/dark,
+/area/service/chapel)
+"caV" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark,
+/area/service/chapel/dock)
+"caW" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/iron/dark,
+/area/service/library/artgallery)
 "caZ" = (
 /obj/structure/table,
 /obj/item/wirecutters,
@@ -30731,40 +30724,46 @@
 /turf/open/floor/iron,
 /area/cargo/office)
 "cbK" = (
-/obj/structure/chair/wood{
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
-/turf/open/floor/iron/dark,
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/iron/checker,
 /area/service/chapel/monastery)
 "cbM" = (
-/turf/open/floor/iron/chapel{
-	dir = 4
-	},
-/area/service/chapel/monastery)
-"cbN" = (
-/obj/item/storage/book/bible,
-/obj/structure/cable,
-/obj/structure/altar_of_gods,
-/turf/open/floor/carpet,
-/area/service/chapel/monastery)
-"cbO" = (
-/obj/structure/table/wood,
-/obj/item/reagent_containers/food/drinks/trophy{
-	pixel_y = 8
-	},
-/turf/open/floor/carpet,
-/area/service/chapel/monastery)
-"cbP" = (
-/turf/open/floor/iron/chapel{
-	dir = 1
-	},
-/area/service/chapel/monastery)
-"cbR" = (
-/obj/machinery/door/airlock/grunge{
-	name = "Chapel Access"
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/light/small/directional/west,
+/obj/structure/sign/departments/holy{
+	pixel_x = -32
 	},
 /turf/open/floor/iron/dark,
 /area/service/chapel/monastery)
+"cbN" = (
+/obj/machinery/meter/monitored/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/maintenance/department/engine)
+"cbO" = (
+/obj/structure/table/wood,
+/obj/item/storage/box/matches{
+	pixel_x = -3;
+	pixel_y = 8
+	},
+/turf/open/floor/iron/dark,
+/area/service/chapel/funeral)
+"cbP" = (
+/obj/structure/window/reinforced/tinted/fulltile,
+/turf/open/floor/iron/dark,
+/area/service/chapel)
+"cbR" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/flora/ausbushes/leafybush,
+/turf/open/misc/asteroid,
+/area/service/chapel/asteroid/monastery)
 "cbS" = (
 /obj/structure/chair/comfy/black{
 	dir = 1
@@ -30930,45 +30929,49 @@
 /turf/open/floor/iron,
 /area/science/mixing)
 "ccu" = (
-/obj/structure/flora/ausbushes/leafybush,
-/turf/open/misc/asteroid,
-/area/service/chapel/asteroid/monastery)
+/obj/structure/chair{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/service/chapel)
 "ccE" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/carpet,
-/area/service/chapel/monastery)
+/obj/machinery/light_switch/directional/west,
+/turf/open/floor/iron/dark,
+/area/service/library)
 "ccF" = (
-/obj/effect/landmark/start/chaplain,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/carpet,
-/area/service/chapel/monastery)
+/obj/structure/cable,
+/obj/machinery/camera/directional/west{
+	c_tag = "Monastery Art Storage";
+	network = list("ss13","monastery")
+	},
+/turf/open/floor/iron/dark,
+/area/service/library/artgallery)
 "ccH" = (
-/turf/open/floor/iron/chapel,
-/area/service/chapel/monastery)
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/cable,
+/turf/open/floor/grass,
+/area/service/hydroponics/garden/monastery)
 "ccJ" = (
-/obj/machinery/light/small{
-	dir = 1
+/obj/structure/disposalpipe/segment,
+/obj/structure/sign/poster/contraband/random/directional/west,
+/turf/open/floor/plating{
+	icon_state = "platingdmg2"
 	},
-/obj/machinery/airalarm/directional/north{
-	pixel_y = 22
+/area/maintenance/department/engine)
+"ccL" = (
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/drinks/bottle/wine{
+	pixel_y = 8
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/iron/dark,
+/area/service/chapel)
+"ccM" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/machinery/light/small/directional/east,
 /turf/open/floor/iron/dark,
 /area/service/chapel/monastery)
-"ccL" = (
-/obj/item/flashlight/lantern{
-	icon_state = "lantern-on"
-	},
-/obj/effect/turf_decal/sand,
-/turf/open/floor/iron,
-/area/service/chapel/asteroid/monastery)
-"ccM" = (
-/obj/structure/chair,
-/turf/open/misc/asteroid,
-/area/service/chapel/asteroid/monastery)
 "ccN" = (
 /obj/effect/spawner/random/structure/crate,
 /turf/open/floor/plating,
@@ -31059,8 +31062,10 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "cdo" = (
-/turf/open/floor/carpet,
-/area/service/chapel/office)
+/turf/open/floor/plating{
+	luminosity = 2
+	},
+/area/maintenance/department/medical)
 "cdp" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin{
@@ -31072,42 +31077,51 @@
 /turf/open/floor/carpet/black,
 /area/service/chapel/office)
 "cdr" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/iron/dark,
-/area/service/chapel/monastery)
+/obj/effect/turf_decal/sand,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/service/chapel/asteroid/monastery)
 "cds" = (
-/obj/machinery/light/small{
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/obj/machinery/door/airlock/external{
+	name = "Auxiliary Dock"
+	},
+/turf/open/floor/plating,
+/area/service/chapel)
+"cdu" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/airalarm/directional/west{
+	pixel_x = -22
+	},
+/turf/open/floor/iron/dark,
+/area/service/chapel/dock)
+"cdw" = (
+/obj/structure/window/reinforced{
 	dir = 1
 	},
-/obj/machinery/camera/directional/north{
-	c_tag = "Chapel Port Access";
-	network = list("ss13","monastery")
-	},
-/turf/open/floor/iron/dark,
-/area/service/chapel/monastery)
-"cdu" = (
-/turf/open/floor/iron/chapel{
-	dir = 8
-	},
-/area/service/chapel/monastery)
-"cdw" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
-/area/service/chapel/monastery)
+/obj/structure/flora/ausbushes,
+/turf/open/misc/asteroid,
+/area/service/chapel/asteroid/monastery)
 "cdx" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
-/area/service/chapel/monastery)
+/area/service/chapel)
 "cdB" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/service/chapel/monastery)
+/obj/effect/landmark/xeno_spawn,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/plating,
+/area/maintenance/department/medical)
 "cdC" = (
-/obj/structure/chair/wood,
-/turf/open/floor/iron/dark,
-/area/service/chapel/monastery)
+/obj/structure/chair/wood{
+	dir = 1
+	},
+/obj/effect/landmark/start/chaplain,
+/turf/open/floor/carpet/black,
+/area/service/chapel/office)
 "cdD" = (
 /obj/structure/table,
 /obj/item/plate,
@@ -31115,10 +31129,10 @@
 /turf/open/misc/asteroid,
 /area/service/chapel/asteroid/monastery)
 "cdE" = (
-/obj/structure/chair,
-/obj/item/cigbutt,
-/turf/open/floor/plating,
-/area/maintenance/department/engine)
+/obj/structure/altar_of_gods,
+/obj/item/storage/book/bible,
+/turf/open/floor/carpet,
+/area/service/chapel)
 "cdI" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/tile/yellow/half/contrasted,
@@ -31285,71 +31299,59 @@
 /turf/open/floor/iron/white,
 /area/medical/exam_room)
 "cee" = (
-/obj/machinery/light/small{
-	dir = 1
+/obj/machinery/atmospherics/components/binary/pump/on/layer2{
+	name = "Virology Waste to Space"
 	},
-/obj/effect/turf_decal/sand,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/service/chapel/office)
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
+/area/maintenance/department/engine)
 "cef" = (
-/obj/effect/turf_decal/sand,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/obj/machinery/light/small/directional/north,
+/obj/structure/extinguisher_cabinet/directional/north,
+/turf/open/floor/iron/dark,
 /area/service/chapel/office)
 "ceg" = (
-/obj/machinery/door/airlock/grunge{
-	name = "Chapel Office";
-	req_access_txt = "22"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/closet/crate/bin,
+/obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/iron/dark,
-/area/service/chapel/monastery)
+/area/service/chapel/office)
 "cei" = (
-/obj/machinery/door/airlock/grunge{
-	name = "Chapel"
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
+/obj/structure/table,
+/obj/item/reagent_containers/food/condiment/flour,
+/obj/item/kitchen/rollingpin,
+/obj/item/knife/kitchen,
+/turf/open/floor/iron,
 /area/service/chapel/monastery)
 "cek" = (
-/obj/machinery/door/airlock/grunge{
-	name = "Chapel"
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/light/small/directional/south,
 /turf/open/floor/iron/dark,
-/area/service/chapel/monastery)
+/area/service/chapel)
 "cel" = (
-/obj/machinery/door/airlock/grunge{
-	name = "Chapel Access"
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
-/area/service/chapel/monastery)
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/science/genetics)
 "cen" = (
 /obj/structure/table/wood,
-/obj/item/storage/photo_album,
-/turf/open/floor/iron/dark,
-/area/service/chapel/monastery)
-"ceo" = (
-/obj/structure/chair{
-	dir = 1
+/obj/item/reagent_containers/food/drinks/trophy{
+	pixel_y = 8
 	},
-/turf/open/misc/asteroid,
-/area/service/chapel/asteroid/monastery)
+/turf/open/floor/carpet,
+/area/service/chapel)
+"ceo" = (
+/obj/machinery/newscaster/directional/north,
+/turf/open/floor/iron/dark,
+/area/service/chapel)
 "ceq" = (
 /obj/machinery/power/emitter,
 /turf/open/floor/plating,
@@ -31400,40 +31402,41 @@
 /turf/open/floor/plating,
 /area/service/chapel/office)
 "ceC" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/machinery/camera/directional/north{
-	c_tag = "Chapel Crematorium";
-	network = list("ss13","monastery")
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/service/chapel/office)
+/area/service/chapel/funeral)
 "ceE" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
-/area/service/chapel/office)
+/obj/structure/chair{
+	dir = 4
+	},
+/turf/open/misc/asteroid,
+/area/service/chapel/asteroid/monastery)
 "ceF" = (
 /obj/structure/filingcabinet,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/service/chapel/office)
 "ceH" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/iron/dark,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/obj/item/radio/intercom/directional/west,
+/turf/open/floor/iron/grimy,
 /area/service/chapel/monastery)
 "ceK" = (
-/obj/item/kirbyplants{
-	icon_state = "plant-08"
+/obj/machinery/door/airlock{
+	id_tag = "Cell1";
+	name = "Cell 1"
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/service/chapel/monastery)
 "ceL" = (
-/obj/structure/table/wood/fancy,
-/obj/machinery/light/small,
-/obj/item/spiritboard,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/service/chapel/monastery)
 "ceT" = (
@@ -31509,12 +31512,16 @@
 /turf/open/floor/engine,
 /area/engineering/main)
 "cfl" = (
-/obj/machinery/door/airlock/grunge{
-	name = "Chapel Access"
+/obj/structure/bed,
+/obj/item/bedsheet/yellow,
+/obj/machinery/button/door{
+	id = "Cell2";
+	name = "Cell Bolt Control";
+	normaldoorcontrol = 1;
+	pixel_x = 25;
+	specialfunctions = 4
 	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/grimy,
 /area/service/chapel/monastery)
 "cfm" = (
 /turf/closed/wall/mineral/iron,
@@ -31523,7 +31530,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/structure/transit_tube/station/dispenser/reverse/flipped{
+/obj/structure/transit_tube/station/dispenser/reverse{
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -31555,56 +31562,60 @@
 /turf/open/floor/plating,
 /area/engineering/main)
 "cfC" = (
-/obj/machinery/biogenerator,
-/turf/open/floor/iron,
-/area/service/chapel/monastery)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -24
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/service/library/artgallery)
 "cfD" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
-/area/service/chapel/monastery)
+/turf/closed/wall/mineral/iron,
+/area/service/chapel/office)
 "cfF" = (
-/obj/machinery/power/apc/auto_name/directional/north{
-	name = "Monastery APC"
+/obj/structure/sign/painting/large/library{
+	pixel_y = -36
 	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
-/area/service/chapel/monastery)
+/area/service/library/artgallery)
 "cfH" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
-/obj/machinery/door/airlock/external,
-/turf/open/floor/plating,
-/area/service/chapel/monastery)
+/turf/open/floor/iron/dark,
+/area/service/chapel/funeral)
 "cfI" = (
-/turf/open/floor/plating,
-/area/service/chapel/monastery)
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/item/radio/intercom/directional/west,
+/turf/open/floor/iron/dark,
+/area/service/chapel/dock)
 "cfJ" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+/obj/structure/chair/wood{
 	dir = 8
 	},
-/obj/machinery/door/airlock/external,
-/turf/open/floor/plating,
-/area/service/chapel/monastery)
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/iron/dark,
+/area/service/chapel/funeral)
 "cfL" = (
-/obj/structure/flora/ausbushes/fernybush,
-/obj/machinery/camera/directional/south{
-	c_tag = "Monastery Asteroid Starboard Aft";
-	network = list("ss13","monastery")
+/obj/machinery/light/small{
+	dir = 8
 	},
-/obj/effect/turf_decal/sand,
-/turf/open/floor/iron,
-/area/service/chapel/asteroid/monastery)
+/obj/structure/sign/poster/contraband/moffuchis_pizza{
+	pixel_x = -32
+	},
+/turf/open/floor/iron/checker,
+/area/service/chapel/monastery)
 "cfM" = (
-/obj/structure/flora/ausbushes,
-/obj/effect/turf_decal/sand,
-/turf/open/floor/iron,
-/area/service/chapel/asteroid/monastery)
+/obj/structure/sign/painting/library_private{
+	pixel_x = -32
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/service/library/artgallery)
 "cfN" = (
 /turf/closed/mineral,
 /area/service/chapel/asteroid/monastery)
@@ -31683,9 +31694,10 @@
 /turf/open/floor/iron,
 /area/service/chapel/monastery)
 "cgd" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/iron,
-/area/service/chapel/monastery)
+/obj/structure/closet/emcloset,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/maintenance/department/chapel/monastery)
 "cgj" = (
 /obj/structure/flora/ausbushes/ywflowers,
 /obj/structure/flora/ausbushes/ppflowers,
@@ -31693,26 +31705,20 @@
 /turf/open/floor/grass,
 /area/service/hydroponics/garden/monastery)
 "cgk" = (
-/obj/structure/flora/ausbushes/ywflowers,
-/obj/structure/flora/ausbushes/sparsegrass,
-/obj/machinery/camera/directional/north{
-	c_tag = "Monastery Garden";
-	network = list("ss13","monastery")
-	},
-/turf/open/floor/grass,
-/area/service/hydroponics/garden/monastery)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/sand,
+/turf/open/floor/iron,
+/area/service/chapel/asteroid/monastery)
 "cgm" = (
 /obj/machinery/hydroponics/soil,
 /obj/item/seeds/watermelon/holy,
 /turf/open/floor/grass,
 /area/service/hydroponics/garden/monastery)
 "cgn" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/dark,
-/area/service/chapel/monastery)
+/obj/structure/flora/ausbushes/ywflowers,
+/obj/structure/cable,
+/turf/open/floor/grass,
+/area/service/hydroponics/garden/monastery)
 "cgp" = (
 /obj/item/wrench,
 /obj/structure/cable,
@@ -31774,8 +31780,15 @@
 /turf/open/floor/iron,
 /area/commons/fitness/recreation)
 "cgG" = (
-/obj/structure/window/reinforced/fulltile,
-/turf/open/floor/plating,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/obj/machinery/light/small/directional/south,
+/obj/structure/sign/directions/evac{
+	pixel_y = -32
+	},
+/turf/open/floor/iron/dark,
 /area/service/chapel/monastery)
 "cgH" = (
 /turf/open/floor/grass,
@@ -31794,19 +31807,12 @@
 /turf/open/floor/grass,
 /area/service/hydroponics/garden/monastery)
 "cgL" = (
-/obj/structure/closet/cabinet,
-/obj/item/clothing/suit/chaplainsuit/holidaypriest,
-/obj/item/clothing/suit/chaplainsuit/nun,
-/obj/item/clothing/head/nun_hood,
-/obj/machinery/button/door{
-	id = "Cell1";
-	name = "Cell Bolt Control";
-	normaldoorcontrol = 1;
-	pixel_x = -25;
-	specialfunctions = 4
-	},
-/turf/open/floor/iron/grimy,
-/area/service/chapel/monastery)
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/service/library/artgallery)
 "cgM" = (
 /obj/structure/dresser,
 /obj/structure/sign/picture_frame/portrait{
@@ -31824,15 +31830,9 @@
 /turf/open/floor/iron/grimy,
 /area/service/chapel/monastery)
 "cgO" = (
-/obj/structure/toilet{
-	pixel_y = 8
-	},
-/obj/machinery/light/small{
-	brightness = 3;
-	dir = 8
-	},
-/turf/open/floor/iron/showroomfloor,
-/area/service/chapel/monastery)
+/obj/effect/spawner/random/trash/hobo_squat,
+/turf/open/floor/plating,
+/area/maintenance/department/medical)
 "cgP" = (
 /obj/structure/transit_tube,
 /turf/open/floor/plating/airless,
@@ -31884,32 +31884,34 @@
 /turf/open/floor/iron,
 /area/service/chapel/monastery)
 "chc" = (
-/obj/machinery/vending/dinnerware,
-/turf/open/floor/iron,
-/area/service/chapel/monastery)
+/obj/machinery/power/apc/auto_name/directional/north{
+	name = "Monastery Chapel APC"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/service/chapel)
 "chd" = (
 /obj/item/clothing/suit/apron/chef,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/service/chapel/monastery)
 "chf" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
-/area/service/chapel/monastery)
+/obj/structure/table,
+/obj/item/storage/box/mousetraps,
+/turf/open/floor/plating,
+/area/maintenance/department/medical)
 "chi" = (
 /obj/structure/flora/ausbushes/pointybush,
 /obj/structure/flora/ausbushes/sparsegrass,
 /turf/open/floor/grass,
 /area/service/hydroponics/garden/monastery)
 "chj" = (
-/obj/structure/cable,
-/turf/open/floor/grass,
-/area/service/hydroponics/garden/monastery)
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/item/shovel/spade,
+/turf/open/floor/iron,
+/area/service/chapel/monastery)
 "chk" = (
 /obj/structure/water_source/puddle,
 /obj/item/reagent_containers/glass/bucket,
@@ -31921,44 +31923,45 @@
 /turf/open/floor/grass,
 /area/service/hydroponics/garden/monastery)
 "chp" = (
-/obj/machinery/door/airlock{
-	id_tag = "Cell1";
-	name = "Cell 1"
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/grimy,
+/obj/machinery/light/small/directional/south,
+/turf/open/floor/iron/dark,
 /area/service/chapel/monastery)
 "chq" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/showroomfloor,
+/area/service/chapel/monastery)
+"chr" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
-/turf/open/floor/iron/grimy,
-/area/service/chapel/monastery)
-"chr" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/grimy,
+/turf/open/floor/iron/showroomfloor,
 /area/service/chapel/monastery)
 "chs" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
-/turf/open/floor/iron/grimy,
-/area/service/chapel/monastery)
-"cht" = (
-/obj/machinery/door/airlock{
-	name = "Bathroom"
-	},
-/turf/open/floor/iron/grimy,
-/area/service/chapel/monastery)
-"chu" = (
-/obj/structure/sink{
-	dir = 8;
-	pixel_x = 11
-	},
 /turf/open/floor/iron/showroomfloor,
 /area/service/chapel/monastery)
+"cht" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Monastery Maintenance";
+	req_one_access_txt = "22;24;10;11;37;12"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/maintenance/department/chapel/monastery)
+"chu" = (
+/obj/machinery/atmospherics/pipe/layer_manifold/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/maintenance/department/chapel/monastery)
 "chv" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
@@ -32007,10 +32010,13 @@
 /turf/open/floor/iron,
 /area/service/chapel/monastery)
 "chE" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
+/obj/machinery/door/airlock{
+	id_tag = "Cell2";
+	name = "Cell 2"
 	},
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark,
 /area/service/chapel/monastery)
 "chG" = (
 /obj/machinery/hydroponics/soil,
@@ -32032,24 +32038,24 @@
 /turf/open/floor/iron/grimy,
 /area/service/chapel/monastery)
 "chM" = (
-/obj/structure/bed,
-/obj/item/bedsheet/green,
-/turf/open/floor/iron/grimy,
+/obj/machinery/vending/coffee,
+/obj/structure/sign/departments/mait{
+	pixel_x = 32
+	},
+/turf/open/floor/iron/dark,
 /area/service/chapel/monastery)
 "chN" = (
-/obj/machinery/shower{
-	dir = 8;
-	pixel_y = -4
+/obj/machinery/door/airlock/grunge{
+	name = "Obsequy"
 	},
-/obj/item/soap/homemade,
-/turf/open/floor/iron/showroomfloor,
-/area/service/chapel/monastery)
+/turf/open/floor/iron/dark,
+/area/service/chapel/funeral)
 "chU" = (
-/obj/structure/sink{
-	dir = 8;
-	pixel_x = 11
+/obj/structure/chair/wood,
+/obj/structure/window/reinforced{
+	dir = 1
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/checker,
 /area/service/chapel/monastery)
 "chV" = (
 /obj/structure/table,
@@ -32057,29 +32063,26 @@
 /turf/open/floor/iron,
 /area/service/chapel/monastery)
 "chW" = (
-/obj/structure/table,
-/obj/item/reagent_containers/food/condiment/saltshaker{
-	pixel_x = 3;
-	pixel_y = 4
-	},
-/obj/item/reagent_containers/food/condiment/peppermill,
-/obj/item/storage/box/ingredients/wildcard{
-	layer = 3.1
-	},
+/obj/item/reagent_containers/glass/bucket,
+/obj/item/reagent_containers/glass/bucket,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/iron,
 /area/service/chapel/monastery)
 "chX" = (
-/obj/structure/table,
-/obj/item/reagent_containers/food/condiment/flour,
-/obj/item/kitchen/rollingpin,
-/obj/item/knife/kitchen,
-/obj/machinery/light/small,
-/turf/open/floor/iron,
-/area/service/chapel/monastery)
+/obj/structure/table/wood,
+/obj/item/food/grown/poppy,
+/obj/item/food/grown/harebell,
+/obj/machinery/power/apc/auto_name/directional/south{
+	name = "Monastery Obsequy APC"
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/service/chapel/funeral)
 "chY" = (
-/obj/structure/closet/crate/bin,
-/turf/open/floor/iron,
-/area/service/chapel/monastery)
+/obj/structure/flora/ausbushes/reedbush,
+/turf/open/misc/asteroid,
+/area/service/chapel/asteroid/monastery)
 "chZ" = (
 /obj/structure/reagent_dispensers/watertank/high,
 /turf/open/floor/iron,
@@ -32109,18 +32112,15 @@
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
 "cio" = (
-/obj/structure/closet/cabinet,
-/obj/item/clothing/suit/chaplainsuit/holidaypriest,
-/obj/item/clothing/suit/chaplainsuit/nun,
-/obj/item/clothing/head/nun_hood,
-/obj/machinery/button/door{
-	id = "Cell2";
-	name = "Cell Bolt Control";
-	normaldoorcontrol = 1;
-	pixel_x = -25;
-	specialfunctions = 4
+/obj/machinery/light/small{
+	brightness = 3;
+	dir = 8
 	},
-/turf/open/floor/iron/grimy,
+/obj/structure/mirror/directional/north,
+/obj/structure/sink{
+	pixel_y = 15
+	},
+/turf/open/floor/iron/showroomfloor,
 /area/service/chapel/monastery)
 "cip" = (
 /obj/machinery/light/small{
@@ -32131,9 +32131,10 @@
 /turf/open/floor/iron/grimy,
 /area/service/chapel/monastery)
 "ciq" = (
-/obj/structure/toilet{
-	pixel_y = 8
+/obj/machinery/shower{
+	dir = 8
 	},
+/obj/item/soap/homemade,
 /turf/open/floor/iron/showroomfloor,
 /area/service/chapel/monastery)
 "cit" = (
@@ -32141,14 +32142,18 @@
 /turf/open/floor/engine,
 /area/engineering/supermatter)
 "ciy" = (
-/obj/item/reagent_containers/glass/bucket,
-/obj/item/reagent_containers/glass/bucket,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/service/chapel/monastery)
-"ciz" = (
-/obj/structure/closet/crate/coffin,
+/obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/iron/dark,
+/area/service/library)
+"ciz" = (
+/obj/item/storage/bag/plants{
+	pixel_x = -4
+	},
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = 11
+	},
+/turf/open/floor/iron,
 /area/service/chapel/monastery)
 "ciA" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -32157,20 +32162,22 @@
 /turf/open/floor/iron/dark,
 /area/service/chapel/monastery)
 "ciE" = (
-/obj/structure/flora/ausbushes/genericbush,
 /obj/machinery/light/small{
 	dir = 4
 	},
-/turf/open/floor/grass,
-/area/service/hydroponics/garden/monastery)
+/obj/machinery/camera/directional/east{
+	c_tag = "Monastery Dining Room";
+	network = list("ss13","monastery")
+	},
+/turf/open/floor/iron/checker,
+/area/service/chapel/monastery)
 "ciF" = (
 /obj/machinery/door/airlock{
-	id_tag = "Cell2";
-	name = "Cell 2"
+	name = "Bathroom"
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/grimy,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/showroomfloor,
 /area/service/chapel/monastery)
 "ciG" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
@@ -32186,34 +32193,30 @@
 /turf/open/floor/engine,
 /area/engineering/supermatter)
 "ciJ" = (
-/obj/structure/closet/emcloset,
-/obj/effect/decal/cleanable/cobweb,
-/obj/effect/decal/cleanable/blood/old,
-/turf/open/floor/iron/dark,
-/area/service/chapel/monastery)
+/obj/machinery/computer/pandemic,
+/obj/machinery/airalarm/directional/north,
+/obj/effect/turf_decal/tile/green/anticorner/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/medical/virology)
 "ciK" = (
-/obj/structure/table,
-/obj/item/crowbar,
-/obj/item/clothing/mask/gas,
-/turf/open/floor/iron/dark,
-/area/service/chapel/monastery)
+/obj/machinery/navbeacon/wayfinding/chapel,
+/turf/open/floor/carpet,
+/area/service/chapel)
 "ciN" = (
-/obj/structure/closet/crate/bin,
-/turf/open/floor/iron/dark,
-/area/service/chapel/monastery)
+/obj/structure/disposaloutlet,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "ciO" = (
-/obj/structure/table/wood,
-/obj/item/reagent_containers/food/condiment/saltshaker{
-	layer = 3.1;
-	pixel_x = -2;
-	pixel_y = 2
-	},
-/obj/item/reagent_containers/food/condiment/peppermill{
-	pixel_x = 5;
-	pixel_y = 6
+/obj/structure/chair/wood{
+	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/service/chapel/monastery)
+/area/service/chapel/funeral)
 "ciS" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /turf/open/floor/grass,
@@ -32242,22 +32245,22 @@
 /turf/open/floor/iron/grimy,
 /area/service/chapel/monastery)
 "ciY" = (
-/obj/structure/bed,
-/obj/item/bedsheet/yellow,
-/turf/open/floor/iron/grimy,
-/area/service/chapel/monastery)
-"ciZ" = (
-/obj/machinery/shower{
-	dir = 8;
-	pixel_y = -4
-	},
-/obj/machinery/light/small{
-	brightness = 3;
-	dir = 8
-	},
-/obj/item/bikehorn/rubberducky,
+/obj/machinery/recharge_station,
 /turf/open/floor/iron/showroomfloor,
 /area/service/chapel/monastery)
+"ciZ" = (
+/obj/structure/flora/grass/jungle/b,
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/machinery/camera/directional/west{
+	c_tag = "Genetics Monkey Pen Fore";
+	network = list("ss13","medbay")
+	},
+/obj/machinery/light/small{
+	dir = 8
+	},
+/mob/living/simple_animal/butterfly,
+/turf/open/floor/grass,
+/area/medical/psychology)
 "cje" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -32265,27 +32268,31 @@
 /turf/open/floor/iron/dark,
 /area/maintenance/fore)
 "cjf" = (
-/obj/machinery/light/small{
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/maintenance/department/engine)
+"cjk" = (
+/obj/structure/chair/wood{
 	dir = 8
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/iron/dark,
-/area/service/chapel/monastery)
-"cjk" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/checker,
 /area/service/chapel/monastery)
 "cjl" = (
-/obj/machinery/door/airlock/grunge{
-	name = "Monastery Cemetary"
+/obj/structure/chair/wood,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
-/area/service/chapel/monastery)
+/obj/effect/landmark/event_spawn,
+/obj/structure/cable,
+/turf/open/floor/carpet/black,
+/area/service/chapel/office)
 "cjm" = (
 /turf/closed/wall,
 /area/maintenance/department/chapel/monastery)
@@ -32348,150 +32355,149 @@
 /turf/open/space/basic,
 /area/space)
 "cjC" = (
-/obj/structure/sign/warning/vacuum/external{
-	pixel_y = 32
-	},
-/obj/machinery/light/small{
+/obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/turf/open/floor/plating,
-/area/service/chapel/monastery)
+/turf/open/floor/iron,
+/area/science/robotics/lab)
 "cjH" = (
-/obj/machinery/door/airlock/grunge{
-	name = "Chapel Garden"
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/computer/libraryconsole,
+/obj/structure/table/wood,
 /turf/open/floor/iron/dark,
-/area/service/chapel/monastery)
+/area/service/library)
 "cjO" = (
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/obj/item/stack/sheet/glass/fifty{
-	layer = 4
+/obj/machinery/door/airlock/grunge{
+	name = "Chapel"
 	},
-/obj/item/stack/sheet/iron{
-	amount = 20;
-	layer = 3.1
-	},
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plating,
-/area/maintenance/department/chapel/monastery)
+/turf/open/floor/iron/dark,
+/area/service/chapel/dock)
 "cjP" = (
-/obj/item/kirbyplants{
-	icon_state = "plant-22"
-	},
-/obj/item/radio/intercom{
-	pixel_y = 26
+/obj/machinery/door/airlock{
+	name = "Garden"
 	},
 /turf/open/floor/iron/dark,
-/area/service/library/lounge)
+/area/service/hydroponics/garden/monastery)
 "cjQ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/carpet,
 /area/service/library)
 "cjR" = (
-/obj/structure/cable,
-/turf/open/floor/carpet,
-/area/service/library/lounge)
+/obj/structure/window/reinforced/tinted{
+	dir = 4;
+	pixel_x = 3
+	},
+/obj/structure/toilet{
+	dir = 1
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/service/chapel/monastery)
 "cjV" = (
 /obj/machinery/camera/preset/ordnance,
 /turf/open/misc/asteroid/airless,
 /area/asteroid/nearstation/bomb_site)
 "cjZ" = (
-/obj/structure/table,
-/obj/item/storage/crayons,
-/obj/item/wrench,
+/obj/machinery/camera/directional/north{
+	c_tag = "Monastery Garden Fore";
+	network = list("ss13","monastery")
+	},
+/obj/machinery/light/small/directional/north,
 /turf/open/floor/iron/dark,
 /area/service/chapel/monastery)
 "cka" = (
-/obj/structure/chair{
-	dir = 8
+/obj/machinery/power/apc/auto_name/directional/east{
+	name = "Library APC"
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
-/area/service/chapel/monastery)
+/area/service/library)
 "ckb" = (
+/obj/machinery/atmospherics/components/tank/air{
+	dir = 1;
+	piping_layer = 4
+	},
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
+/area/maintenance/department/engine)
+"ckd" = (
 /obj/structure/window/reinforced{
 	dir = 1
 	},
-/turf/open/floor/carpet,
-/area/service/chapel/monastery)
-"ckd" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/checker,
 /area/service/chapel/monastery)
 "ckg" = (
-/obj/item/wrench,
+/obj/effect/spawner/atmos_canister/air,
+/obj/machinery/light/small{
+	dir = 1
+	},
 /turf/open/floor/plating,
-/area/maintenance/department/chapel/monastery)
+/area/maintenance/department/medical)
 "ckh" = (
-/obj/item/stack/cable_coil,
-/obj/item/stack/cable_coil,
-/turf/open/floor/plating,
-/area/maintenance/department/chapel/monastery)
+/obj/structure/flora/ausbushes/ywflowers,
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/machinery/light_switch/directional/north,
+/turf/open/floor/grass,
+/area/service/hydroponics/garden/monastery)
 "ckj" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/maintenance/department/chapel/monastery)
 "ckk" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 24
-	},
-/obj/item/stack/rods/fifty,
-/obj/machinery/atmospherics/pipe/layer_manifold/supply/hidden,
-/turf/open/floor/plating,
-/area/maintenance/department/chapel/monastery)
-"ckl" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/machinery/photocopier,
-/turf/open/floor/iron/dark,
-/area/service/library/lounge)
-"ckm" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/carpet,
 /area/service/library)
+"ckl" = (
+/obj/structure/chair/wood{
+	dir = 8
+	},
+/turf/open/floor/iron/chapel,
+/area/service/chapel)
+"ckm" = (
+/obj/effect/spawner/random/trash/grime,
+/turf/open/floor/plating{
+	icon_state = "platingdmg2"
+	},
+/area/maintenance/department/engine)
 "cko" = (
 /obj/structure/bookcase/random/religion,
 /turf/open/floor/iron/dark,
 /area/service/library)
 "ckp" = (
-/obj/structure/bookcase/random/religion,
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/turf/open/floor/iron/dark,
-/area/service/library/lounge)
+/obj/structure/mirror/directional/north,
+/obj/structure/sink{
+	pixel_y = 15
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/service/chapel/monastery)
 "ckt" = (
 /obj/effect/spawner/random/maintenance,
 /turf/open/misc/asteroid/airless,
 /area/asteroid/nearstation/bomb_site)
 "cku" = (
-/obj/structure/chair/wood,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/carpet,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/pinpointer_dispenser{
+	pixel_y = 32
+	},
+/turf/open/floor/iron/dark,
 /area/service/chapel/monastery)
 "ckv" = (
-/obj/machinery/mass_driver/chapelgun,
-/obj/machinery/door/window/left/directional/east{
-	dir = 8;
-	name = "Mass Driver"
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/window/reinforced,
+/obj/structure/table/wood,
+/obj/item/flashlight/lantern,
 /turf/open/floor/iron/dark,
-/area/service/chapel/monastery)
+/area/service/chapel/funeral)
 "ckw" = (
-/obj/machinery/mass_driver/chapelgun,
-/obj/structure/window/reinforced{
-	dir = 4;
-	layer = 2.9
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/libraryscanner,
 /turf/open/floor/iron/dark,
-/area/service/chapel/monastery)
+/area/service/library)
 "cky" = (
 /obj/machinery/power/smes{
 	charge = 5e+006
@@ -32500,35 +32506,70 @@
 /turf/open/floor/plating,
 /area/maintenance/department/chapel/monastery)
 "ckz" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden,
-/turf/open/floor/plating,
-/area/maintenance/department/chapel/monastery)
-"ckA" = (
-/obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden,
-/turf/open/floor/plating,
-/area/maintenance/department/chapel/monastery)
-"ckC" = (
-/obj/item/extinguisher,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
-/turf/open/floor/plating,
-/area/maintenance/department/chapel/monastery)
-"ckD" = (
-/obj/structure/chair/wood,
-/obj/machinery/firealarm/directional/west,
-/turf/open/floor/iron/dark,
-/area/service/library/lounge)
-"ckF" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/carpet,
-/area/service/library/lounge)
-"ckG" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+/obj/machinery/light{
 	dir = 8
 	},
+/obj/machinery/requests_console{
+	department = "Virology";
+	name = "Virology Requests Console";
+	pixel_x = -32;
+	receive_ore_updates = 1
+	},
+/obj/effect/turf_decal/tile/green/half/contrasted{
+	dir = 8
+	},
+/obj/machinery/vending/wardrobe/viro_wardrobe,
+/turf/open/floor/iron/white,
+/area/medical/virology)
+"ckA" = (
+/obj/item/storage/bag/plants/portaseeder,
+/obj/item/storage/bag/plants/portaseeder,
+/turf/open/floor/iron,
+/area/service/chapel/monastery)
+"ckC" = (
+/obj/structure/lattice,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
+"ckD" = (
+/obj/machinery/door/morgue{
+	name = "Confession Booth"
+	},
 /turf/open/floor/iron/dark,
-/area/service/library/lounge)
+/area/service/chapel)
+"ckF" = (
+/obj/item/toy/crayon/black,
+/obj/item/toy/crayon/white{
+	pixel_x = -4;
+	pixel_y = 4
+	},
+/obj/item/toy/crayon/black,
+/obj/item/toy/crayon/white{
+	pixel_x = -4;
+	pixel_y = 4
+	},
+/obj/structure/table/wood,
+/obj/machinery/power/apc/auto_name/directional/north{
+	name = "Monastery Art Gallery APC"
+	},
+/obj/structure/cable,
+/obj/effect/decal/cleanable/cobweb,
+/turf/open/floor/iron/dark,
+/area/service/library/artgallery)
+"ckG" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/camera/directional/north{
+	c_tag = "Monastery Art Gallery";
+	network = list("ss13","monastery")
+	},
+/turf/open/floor/iron/dark,
+/area/service/library/artgallery)
 "ckH" = (
 /turf/open/floor/iron/dark,
 /area/service/library)
@@ -32544,29 +32585,23 @@
 /turf/open/floor/plating/airless,
 /area/asteroid/nearstation/bomb_site)
 "ckM" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/iron/dark,
 /area/service/chapel/monastery)
 "ckN" = (
-/obj/structure/window/reinforced{
-	dir = 4;
-	layer = 2.9
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/service/chapel/monastery)
-"ckO" = (
-/obj/structure/closet/emcloset,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
-/area/maintenance/department/chapel/monastery)
+/area/service/library/lounge)
+"ckO" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark,
+/area/service/library/lounge)
 "ckP" = (
 /obj/machinery/atmospherics/components/tank/air{
 	dir = 1
@@ -32578,68 +32613,82 @@
 /turf/open/floor/plating,
 /area/maintenance/department/chapel/monastery)
 "ckS" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
+"ckT" = (
 /obj/structure/table/wood,
-/obj/item/folder/yellow,
-/obj/item/pen,
-/obj/machinery/camera/directional/west{
-	c_tag = "Monastery Library";
+/obj/item/reagent_containers/food/drinks/mug/tea,
+/turf/open/floor/iron/checker,
+/area/service/chapel/monastery)
+"ckU" = (
+/obj/machinery/door/airlock/grunge{
+	name = "Art Gallery"
+	},
+/turf/open/floor/iron,
+/area/service/library/artgallery)
+"ckV" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/airalarm/directional/west,
+/turf/open/floor/iron/dark,
+/area/service/chapel/dock)
+"ckW" = (
+/obj/effect/landmark/start/chaplain,
+/turf/open/floor/carpet,
+/area/service/chapel)
+"ckX" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/power/apc/auto_name/directional/east{
+	name = "Monastery Docking Bay APC"
+	},
+/obj/machinery/camera/directional/east{
+	c_tag = "Monastery Aft Dock";
 	network = list("ss13","monastery")
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
-/area/service/library/lounge)
-"ckT" = (
-/obj/machinery/door/airlock/grunge{
-	name = "Library"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
-/area/service/library/lounge)
-"ckU" = (
-/obj/machinery/bookbinder,
-/turf/open/floor/iron/dark,
-/area/service/library/lounge)
-"ckV" = (
-/obj/structure/bookcase/random/reference,
-/turf/open/floor/iron/dark,
-/area/service/library/lounge)
-"ckW" = (
-/obj/machinery/skill_station,
-/turf/open/floor/iron/dark,
-/area/service/library)
-"ckX" = (
-/obj/structure/bookcase/random/fiction,
-/turf/open/floor/iron/dark,
-/area/service/library/lounge)
+/area/service/chapel/dock)
 "clb" = (
-/obj/machinery/door/poddoor/massdriver_chapel,
-/turf/open/floor/plating,
-/area/service/chapel/monastery)
-"cld" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/closed/wall,
-/area/maintenance/department/chapel/monastery)
-"clf" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/item/storage/box/lights/bulbs,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plating,
-/area/maintenance/department/chapel/monastery)
-"clg" = (
 /obj/structure/chair/wood{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/service/library/lounge)
-"cli" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
-/turf/open/floor/iron/dark,
-/area/service/library)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/chapel{
+	dir = 4
+	},
+/area/service/chapel)
+"cld" = (
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = 11
+	},
+/obj/effect/turf_decal/tile/green/half/contrasted{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron/white,
+/area/medical/virology)
+"clf" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/checker,
+/area/service/chapel/monastery)
+"clg" = (
+/obj/structure/table,
+/obj/item/storage/box/lights/mixed,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
+"cli" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/obj/effect/spawner/random/trash/grille_or_waste,
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
 "clj" = (
 /obj/item/flashlight/lantern{
 	icon_state = "lantern-on"
@@ -32647,20 +32696,17 @@
 /turf/open/misc/asteroid/airless,
 /area/asteroid/nearstation/bomb_site)
 "clk" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/machinery/libraryscanner,
-/turf/open/floor/iron/dark,
-/area/service/library/lounge)
+/turf/closed/wall/mineral/iron,
+/area/service/chapel/asteroid/monastery)
 "clm" = (
-/obj/structure/closet/crate/bin,
-/turf/open/floor/iron/dark,
-/area/service/library/lounge)
+/obj/effect/spawner/random/trash/garbage,
+/turf/open/floor/plating,
+/area/maintenance/department/medical)
 "cln" = (
-/obj/structure/bookcase/random/adult,
-/turf/open/floor/iron/dark,
-/area/service/library/lounge)
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/sign/warning/vacuum/external,
+/turf/closed/wall,
+/area/service/chapel/dock)
 "clp" = (
 /obj/structure/table/wood,
 /obj/machinery/computer/libraryconsole/bookmanagement,
@@ -32698,6 +32744,7 @@
 /area/tcommsat/computer)
 "clE" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/closed/wall/r_wall,
 /area/tcommsat/computer)
 "clF" = (
@@ -32738,17 +32785,21 @@
 	dir = 1;
 	name = "Tcomms Sat Waste"
 	},
+/obj/machinery/atmospherics/components/binary/pump/on/general/visible/layer4{
+	name = "Tcomms Air"
+	},
 /turf/open/floor/plating,
 /area/tcommsat/computer)
 "clN" = (
-/obj/machinery/atmospherics/components/tank/air,
+/obj/structure/cable,
+/obj/item/wrench,
 /turf/open/floor/plating,
 /area/tcommsat/computer)
 "clP" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/structure/transit_tube/station/dispenser/reverse{
+/obj/structure/transit_tube/station/dispenser/reverse/flipped{
 	dir = 8
 	},
 /turf/open/floor/plating,
@@ -32773,14 +32824,16 @@
 /turf/open/floor/iron,
 /area/tcommsat/computer)
 "clU" = (
-/obj/item/wrench,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/tcommsat/computer)
 "clV" = (
-/obj/machinery/atmospherics/pipe/layer_manifold,
-/turf/open/floor/plating,
-/area/tcommsat/computer)
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/newscaster/directional/east,
+/obj/machinery/airalarm/directional/west,
+/turf/open/floor/iron/dark,
+/area/service/library/artgallery)
 "clY" = (
 /obj/item/beacon,
 /obj/structure/cable,
@@ -32811,8 +32864,7 @@
 /turf/open/floor/plating,
 /area/tcommsat/computer)
 "cmc" = (
-/obj/item/stack/cable_coil,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/tcommsat/computer)
 "cmf" = (
@@ -33853,16 +33905,14 @@
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
 "cqy" = (
-/obj/structure/sink{
-	dir = 8;
-	pixel_x = 11
+/obj/structure/rack{
+	icon = 'icons/obj/stationobjs.dmi';
+	icon_state = "minibar";
+	name = "skeletal minibar"
 	},
-/obj/effect/turf_decal/tile/green/half/contrasted{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron/white,
-/area/medical/virology)
+/obj/item/book/codex_gigas,
+/turf/open/floor/iron/dark,
+/area/service/library)
 "cqz" = (
 /obj/effect/turf_decal/tile/green/half/contrasted,
 /turf/open/floor/iron,
@@ -33898,29 +33948,18 @@
 /turf/open/floor/iron/dark,
 /area/service/chapel/dock)
 "cqI" = (
-/obj/machinery/pinpointer_dispenser{
-	pixel_x = 32
-	},
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/service/chapel/dock)
-"cqS" = (
-/obj/structure/lattice,
-/obj/structure/window/reinforced{
+/obj/structure/chair{
 	dir = 8
 	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/turf/open/space,
-/area/space/nearstation)
+/turf/open/floor/iron,
+/area/hallway/primary/central)
+"cqS" = (
+/obj/machinery/light_switch/directional/east,
+/turf/open/floor/iron/dark,
+/area/service/chapel/dock)
 "cqU" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced,
-/turf/open/space/basic,
-/area/space/nearstation)
+/turf/open/floor/carpet,
+/area/service/chapel)
 "cqV" = (
 /obj/structure/chair/office/light{
 	dir = 1
@@ -33930,18 +33969,26 @@
 /turf/open/floor/iron,
 /area/command/heads_quarters/ce)
 "cqW" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/closed/mineral,
-/area/service/chapel/asteroid/monastery)
+/obj/structure/table/wood/fancy,
+/obj/item/storage/fancy/candle_box{
+	pixel_y = 13
+	},
+/obj/item/storage/box/matches{
+	pixel_x = -3;
+	pixel_y = 8
+	},
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/service/chapel)
 "cqX" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/lattice,
 /turf/open/space/basic,
 /area/space/nearstation)
 "crb" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating/airless,
-/area/service/chapel/office)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/service/chapel/monastery)
 "crd" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/tile/blue/half/contrasted{
@@ -33950,25 +33997,22 @@
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "cre" = (
-/obj/effect/spawner/random/trash/grime,
-/turf/open/floor/plating{
-	icon_state = "platingdmg2"
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 8
 	},
-/area/maintenance/department/engine)
+/turf/open/space/basic,
+/area/space/nearstation)
 "crg" = (
-/obj/structure/chair/wood,
+/obj/effect/landmark/start/assistant,
 /turf/open/floor/iron/dark,
-/area/service/chapel/office)
+/area/service/library)
 "crh" = (
-/obj/machinery/button/crematorium{
-	id = "foo";
-	pixel_x = 25
-	},
-/obj/structure/bodycontainer/crematorium{
-	id = "foo"
+/obj/structure/window/reinforced{
+	dir = 1
 	},
 /turf/open/floor/iron/dark,
-/area/service/chapel/office)
+/area/service/library/artgallery)
 "cri" = (
 /obj/machinery/door/poddoor{
 	id = "Secure Storage";
@@ -33979,142 +34023,115 @@
 /turf/open/floor/plating,
 /area/engineering/main)
 "crj" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
 /turf/open/floor/iron/dark,
-/area/service/chapel/monastery)
+/area/service/chapel)
 "crk" = (
-/obj/machinery/light/small{
-	dir = 4
+/obj/machinery/door/airlock/grunge{
+	name = "Lounge"
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
-/area/service/chapel/monastery)
+/area/service/library/lounge)
 "crl" = (
-/obj/structure/sign/warning/vacuum/external,
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/service/chapel/asteroid/monastery)
+/obj/structure/sign/plaques/kiddie/library,
+/turf/closed/wall/mineral/iron,
+/area/service/library)
 "crm" = (
-/obj/item/assembly/prox_sensor{
-	pixel_x = -8;
-	pixel_y = 4
-	},
-/obj/item/assembly/prox_sensor{
-	pixel_x = -8;
-	pixel_y = 4
-	},
-/obj/item/assembly/prox_sensor{
-	pixel_x = -8;
-	pixel_y = 4
-	},
-/obj/item/assembly/prox_sensor{
-	pixel_x = -8;
-	pixel_y = 4
-	},
-/obj/item/stock_parts/cell/high,
-/obj/item/stock_parts/cell/high{
-	pixel_x = 5;
-	pixel_y = -5
-	},
-/obj/item/crowbar,
-/obj/structure/table,
-/obj/effect/turf_decal/tile/green/half/contrasted,
-/turf/open/floor/iron,
-/area/science/robotics/lab)
+/obj/structure/table/wood,
+/obj/item/food/grown/poppy,
+/turf/open/floor/iron/dark,
+/area/service/chapel)
 "crt" = (
-/obj/structure/table/wood/fancy,
-/obj/item/folder,
-/obj/item/pen,
-/turf/open/floor/iron/dark,
-/area/service/chapel/office)
-"cru" = (
-/obj/effect/decal/cleanable/blood/old,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
+/obj/structure/sign/warning/vacuum/external{
+	pixel_y = 32
 	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/service/chapel)
+"cru" = (
+/obj/structure/table/wood/fancy,
+/obj/structure/sign/painting/library_secure{
+	pixel_y = -32
+	},
+/obj/item/knife/combat/bone{
+	desc = "An old bone sharpened into a blade. It's rather dull nowadays.";
+	force = 8;
+	name = "ancient bone dagger";
+	pixel_y = 6;
+	throwforce = 8
+	},
+/obj/machinery/light/dim/directional/south,
 /turf/open/floor/iron/dark,
-/area/service/chapel/office)
+/area/service/library/artgallery)
 "crv" = (
 /turf/open/floor/iron/dark,
 /area/service/chapel/office)
 "crx" = (
-/obj/structure/table/wood,
-/obj/item/food/grown/harebell,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron/dark,
 /area/service/chapel/monastery)
 "cry" = (
-/obj/machinery/power/port_gen/pacman,
+/obj/structure/table,
+/obj/item/stack/cable_coil,
+/obj/item/extinguisher,
 /turf/open/floor/plating,
-/area/engineering/main)
+/area/maintenance/department/medical)
 "crz" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/on/layer2{
-	dir = 4;
-	name = "Outlet injector"
-	},
-/turf/open/floor/plating/airless,
-/area/maintenance/department/engine)
-"crA" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
+/area/maintenance/department/medical)
+"crA" = (
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating{
+	icon_state = "platingdmg2"
+	},
 /area/maintenance/department/engine)
 "crB" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/obj/structure/sign/warning/deathsposal{
-	pixel_y = 32
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/engine)
-"crC" = (
-/obj/structure/grille/broken,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
+/obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/maintenance/department/medical)
+"crC" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/meter/monitored/layer2,
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
 /area/maintenance/department/engine)
 "crD" = (
-/obj/structure/table/wood/fancy,
-/obj/item/storage/box/bodybags,
-/turf/open/floor/iron/dark,
-/area/service/chapel/office)
-"crG" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
+/obj/machinery/door/airlock/atmos{
+	name = "Atmospherics Maintenance";
+	req_access_txt = "12;24"
 	},
+/obj/effect/mapping_helpers/airlock/abandoned,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
+"crG" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/navbeacon/wayfinding/library,
 /turf/open/floor/iron/dark,
-/area/service/chapel/office)
+/area/service/library)
 "crH" = (
-/obj/structure/table/wood,
-/obj/item/food/grown/poppy,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/service/chapel/monastery)
 "crK" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/machinery/camera/directional/west{
-	c_tag = "Chapel Port";
-	network = list("ss13","monastery")
-	},
-/turf/open/floor/iron/dark,
-/area/service/chapel/monastery)
+/turf/closed/wall,
+/area/service/chapel)
 "crN" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/machinery/camera/directional/east{
-	c_tag = "Chapel Starboard";
-	network = list("ss13","monastery")
-	},
-/turf/open/floor/iron/dark,
-/area/service/chapel/monastery)
+/turf/closed/wall,
+/area/service/hydroponics/garden/monastery)
 "crO" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -34122,11 +34139,9 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "crT" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/service/chapel/office)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/grimy,
+/area/service/chapel/monastery)
 "crU" = (
 /obj/machinery/power/apc/auto_name/directional/east{
 	name = "Chapel Office APC"
@@ -34139,93 +34154,87 @@
 /turf/open/floor/iron/dark,
 /area/service/chapel/monastery)
 "crY" = (
-/obj/structure/table/wood,
-/obj/item/food/breadslice/plain,
-/obj/item/food/breadslice/plain{
-	pixel_y = 4
+/obj/structure/flora/ausbushes/ywflowers,
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/machinery/camera/directional/north{
+	c_tag = "Monastery Garden";
+	network = list("ss13","monastery")
 	},
-/obj/item/food/breadslice/plain{
-	pixel_y = 8
-	},
-/turf/open/floor/iron/dark,
-/area/service/chapel/monastery)
+/obj/structure/cable,
+/turf/open/floor/grass,
+/area/service/hydroponics/garden/monastery)
 "csd" = (
 /turf/open/floor/carpet/black,
 /area/service/chapel/office)
 "cse" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/carpet/black,
-/area/service/chapel/office)
+/obj/machinery/power/energy_accumulator/tesla_coil,
+/turf/open/floor/plating,
+/area/engineering/main)
 "csg" = (
-/obj/effect/turf_decal/tile/yellow,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/sign/painting/library_private{
+	pixel_y = -32
+	},
 /turf/open/floor/iron/dark,
-/area/service/chapel/office)
+/area/service/library/artgallery)
 "csh" = (
-/obj/effect/turf_decal/tile/yellow,
 /obj/structure/cable,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+/obj/machinery/door/airlock/maintenance{
+	req_access_txt = "12"
+	},
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/maintenance/department/medical)
+"csi" = (
+/obj/item/radio/intercom{
+	pixel_x = 27
+	},
+/obj/machinery/light/small,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/service/chapel/office)
-"csi" = (
-/obj/effect/turf_decal/tile/yellow,
-/turf/open/floor/iron/dark,
-/area/service/chapel/office)
+/area/service/chapel/dock)
 "csk" = (
-/obj/structure/table/wood,
-/obj/item/reagent_containers/food/drinks/bottle/wine{
-	pixel_y = 8
-	},
-/turf/open/floor/iron/dark,
-/area/service/chapel/monastery)
+/obj/structure/flora/ausbushes/ywflowers,
+/obj/structure/flora/ausbushes/brflowers,
+/obj/structure/cable,
+/turf/open/floor/grass,
+/area/service/hydroponics/garden/monastery)
 "csn" = (
-/obj/item/radio/intercom{
-	pixel_y = 26
-	},
-/obj/machinery/requests_console{
-	department = "Chapel";
-	departmentType = 2;
-	pixel_x = -32
-	},
-/obj/structure/closet,
-/obj/item/storage/backpack/cultpack,
-/obj/item/clothing/head/nun_hood,
-/obj/item/clothing/suit/chaplainsuit/nun,
-/obj/item/clothing/suit/chaplainsuit/holidaypriest,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/table/wood,
+/obj/item/storage/photo_album,
 /turf/open/floor/iron/dark,
-/area/service/chapel/office)
+/area/service/library)
 "cso" = (
 /obj/structure/table/wood,
 /obj/item/nullrod,
 /turf/open/floor/carpet/black,
 /area/service/chapel/office)
 "csp" = (
-/obj/structure/chair/wood{
-	dir = 8
+/obj/machinery/light/small{
+	dir = 1
 	},
-/turf/open/floor/carpet/black,
-/area/service/chapel/office)
+/obj/machinery/camera/directional/north{
+	c_tag = "Chapel Crematorium";
+	network = list("ss13","monastery")
+	},
+/turf/open/floor/iron/dark,
+/area/service/chapel/funeral)
 "csq" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/red/anticorner/contrasted{
-	dir = 8
+/obj/structure/sign/poster/official/no_erp{
+	pixel_x = -32
 	},
 /turf/open/floor/iron/dark,
-/area/service/chapel/office)
+/area/service/chapel/monastery)
 "csr" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/red/anticorner/contrasted{
-	dir = 8
+/obj/machinery/door/airlock{
+	name = "Garden"
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
-/area/service/chapel/office)
+/area/service/hydroponics/garden/monastery)
 "csu" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -34235,26 +34244,18 @@
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
 "csv" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
-/area/service/chapel/monastery)
+/obj/structure/transit_tube/diagonal/crossing,
+/obj/structure/lattice/catwalk,
+/turf/open/space/basic,
+/area/space/nearstation)
 "csy" = (
-/obj/effect/spawner/random/maintenance,
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/engine)
-"csB" = (
-/obj/effect/landmark/start/chaplain,
-/obj/structure/chair/wood{
-	dir = 4
-	},
-/turf/open/floor/carpet/black,
+/obj/effect/turf_decal/tile/red/anticorner/contrasted,
+/turf/open/floor/iron/dark,
 /area/service/chapel/office)
+"csB" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/turf/open/floor/plating,
+/area/maintenance/department/medical)
 "csC" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/drinks/bottle/holywater{
@@ -34264,66 +34265,58 @@
 /turf/open/floor/carpet/black,
 /area/service/chapel/office)
 "csE" = (
-/obj/effect/turf_decal/tile/red/fourcorners,
+/obj/machinery/light/small/directional/east,
 /turf/open/floor/iron/dark,
-/area/service/chapel/office)
+/area/service/chapel)
 "csM" = (
-/obj/machinery/camera/directional/south{
-	c_tag = "Chapel Office Tunnel";
-	network = list("ss13","monastery")
+/obj/effect/turf_decal/tile/red/fourcorners,
+/obj/machinery/navbeacon/wayfinding{
+	location = "Chapel Office"
 	},
-/obj/effect/turf_decal/sand,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
 /area/service/chapel/office)
 "csQ" = (
 /obj/effect/spawner/random/trash/food_packaging,
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/dorms)
 "csT" = (
-/obj/machinery/light/small{
-	dir = 1
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/structure/sign/poster/official/walk{
+	pixel_y = -32
 	},
-/obj/machinery/camera/directional/north{
-	c_tag = "Chapel Starboard Access";
-	network = list("ss13","monastery")
-	},
-/obj/structure/chair/wood,
 /turf/open/floor/iron/dark,
 /area/service/chapel/monastery)
 "csU" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating/airless,
-/area/service/chapel/monastery)
-"csY" = (
-/obj/machinery/suit_storage_unit/standard_unit,
-/obj/machinery/newscaster{
-	pixel_x = -32
-	},
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/service/chapel/office)
-"ctb" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/tile/red/anticorner/contrasted{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/service/chapel/office)
-"cth" = (
 /obj/structure/table/wood/fancy,
-/obj/item/storage/fancy/candle_box{
-	pixel_y = 13
-	},
-/obj/machinery/light/small,
-/obj/item/storage/box/matches{
-	pixel_x = -3;
-	pixel_y = 8
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/carpet,
+/area/service/library/lounge)
+"csY" = (
+/obj/structure/bookcase/random/fiction,
 /turf/open/floor/iron/dark,
-/area/service/chapel/monastery)
+/area/service/library)
+"ctb" = (
+/obj/structure/sign/poster/official/corporate_perks_vacation,
+/turf/closed/wall,
+/area/maintenance/department/engine)
+"cth" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/machinery/pinpointer_dispenser{
+	pixel_y = 32
+	},
+/obj/machinery/light/small/directional/east,
+/obj/machinery/light_switch/directional/east,
+/turf/open/floor/iron/dark,
+/area/service/chapel/dock)
 "ctr" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -34331,93 +34324,73 @@
 /turf/open/floor/iron/dark,
 /area/service/chapel/office)
 "ctt" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
+/mob/living/simple_animal/pet/dog/corgi,
+/obj/structure/water_source/puddle,
+/obj/structure/flora/ausbushes/reedbush{
+	pixel_y = 6
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/service/chapel/office)
+/turf/open/floor/grass,
+/area/medical/psychology)
 "ctu" = (
-/obj/machinery/light/small,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
+/obj/machinery/door/airlock/grunge{
+	name = "Lounge"
 	},
 /turf/open/floor/iron/dark,
-/area/service/chapel/office)
+/area/service/library/lounge)
 "ctJ" = (
-/obj/machinery/camera/directional/east{
-	c_tag = "Chapel Office";
-	network = list("ss13","monastery")
+/obj/machinery/pinpointer_dispenser{
+	pixel_x = 32
 	},
-/turf/open/floor/iron/dark,
-/area/service/chapel/office)
-"ctK" = (
-/obj/item/kirbyplants{
-	icon_state = "plant-10"
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
-/area/service/chapel/monastery)
-"ctM" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark,
+/area/service/chapel/dock)
+"ctK" = (
+/obj/structure/table/wood,
+/obj/item/food/grown/harebell,
+/turf/open/floor/iron/dark,
+/area/service/chapel)
+"ctM" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/item/radio/intercom/directional/west,
 /turf/open/floor/iron/dark,
 /area/service/chapel/monastery)
 "ctN" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/machinery/camera/directional/north{
-	c_tag = "Monastery Cloister Fore";
-	network = list("ss13","monastery")
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/service/chapel/monastery)
+/obj/machinery/power/port_gen/pacman,
+/turf/open/floor/plating,
+/area/maintenance/department/chapel/monastery)
 "ctO" = (
-/obj/machinery/airalarm/directional/north{
-	pixel_y = 22
+/obj/machinery/door/airlock/grunge{
+	name = "Lounge"
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
-/area/service/chapel/monastery)
+/area/service/library/lounge)
 "ctP" = (
-/obj/item/kirbyplants{
-	icon_state = "plant-21"
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/closet/crate/bin,
+/obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/iron/dark,
-/area/service/chapel/monastery)
+/area/service/chapel)
 "ctQ" = (
-/obj/structure/closet/emcloset,
-/obj/machinery/light/small{
-	dir = 1
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/turf/open/floor/iron/white,
+/area/science/genetics)
+"ctS" = (
+/obj/machinery/door/airlock/external{
+	req_access_txt = "13"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "monastery-maint-connect"
 	},
 /turf/open/floor/plating,
-/area/service/chapel/monastery)
-"ctS" = (
-/obj/structure/disposaloutlet,
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
+/area/maintenance/department/engine)
 "ctX" = (
-/obj/machinery/vending/wardrobe/chap_wardrobe,
-/turf/open/floor/carpet,
+/obj/structure/cable,
+/turf/open/floor/carpet/black,
 /area/service/chapel/office)
 "cuk" = (
 /obj/structure/closet{
@@ -34446,14 +34419,9 @@
 /turf/open/floor/iron,
 /area/service/chapel/monastery)
 "cun" = (
-/obj/structure/flora/ausbushes/ywflowers,
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/flora/ausbushes/sparsegrass,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/grass,
-/area/service/hydroponics/garden/monastery)
+/obj/machinery/light/small/directional/west,
+/turf/open/floor/iron/dark,
+/area/service/chapel/monastery)
 "cuo" = (
 /obj/structure/flora/ausbushes/ywflowers,
 /obj/structure/flora/ausbushes/ppflowers,
@@ -34484,45 +34452,38 @@
 /turf/open/floor/iron,
 /area/service/chapel/monastery)
 "cuu" = (
-/obj/item/storage/bag/plants,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 24
-	},
-/obj/item/storage/bag/plants/portaseeder,
-/obj/item/storage/bag/plants/portaseeder,
-/turf/open/floor/iron,
+/obj/machinery/biogenerator,
+/turf/open/floor/iron/dark,
 /area/service/chapel/monastery)
 "cuv" = (
+/obj/structure/closet,
+/obj/item/storage/backpack/cultpack,
+/obj/item/clothing/head/nun_hood,
+/obj/item/clothing/suit/chaplainsuit/nun,
+/obj/item/clothing/suit/chaplainsuit/holidaypriest,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/service/chapel/office)
+"cuw" = (
+/obj/structure/closet/crate/bin,
+/obj/machinery/light/small/directional/north,
+/obj/machinery/light_switch/directional/north,
+/turf/open/floor/iron/dark,
+/area/service/library/lounge)
+"cux" = (
+/obj/machinery/suit_storage_unit/standard_unit,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/service/chapel/office)
+"cuz" = (
 /obj/structure/chair/wood{
-	dir = 4
-	},
-/obj/machinery/light/small{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
-/area/service/chapel/monastery)
-"cuw" = (
-/obj/structure/table/wood,
-/obj/item/plate,
-/obj/item/kitchen/fork,
-/turf/open/floor/iron/dark,
-/area/service/chapel/monastery)
-"cux" = (
-/obj/structure/table/wood,
-/obj/item/reagent_containers/food/drinks/mug/tea,
-/turf/open/floor/iron/dark,
-/area/service/chapel/monastery)
-"cuz" = (
-/obj/machinery/camera/directional/west{
-	c_tag = "Monastery Cloister Port";
-	network = list("ss13","monastery")
-	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
-/area/service/chapel/monastery)
+/obj/structure/cable,
+/turf/open/floor/iron/chapel,
+/area/service/chapel)
 "cuA" = (
 /obj/structure/flora/ausbushes/ywflowers,
 /obj/structure/flora/ausbushes/sparsegrass,
@@ -34539,6 +34500,11 @@
 /obj/item/seeds/carrot,
 /turf/open/floor/grass,
 /area/service/hydroponics/garden/monastery)
+"cuF" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/item/radio/intercom/directional/west,
+/turf/open/floor/iron/dark,
+/area/service/library/artgallery)
 "cuG" = (
 /obj/structure/closet/secure_closet/freezer/fridge/open,
 /obj/machinery/light/small,
@@ -34553,19 +34519,14 @@
 /turf/open/floor/iron,
 /area/service/chapel/monastery)
 "cuJ" = (
-/obj/item/shovel/spade,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/service/chapel/monastery)
-"cuK" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/machinery/camera/directional/east{
-	c_tag = "Monastery Dining Room";
-	network = list("ss13","monastery")
-	},
 /turf/open/floor/iron/dark,
+/area/service/chapel/funeral)
+"cuK" = (
+/obj/structure/closet/crate/bin,
+/obj/machinery/light/small,
+/turf/open/floor/iron,
 /area/service/chapel/monastery)
 "cuL" = (
 /obj/machinery/camera/directional/west{
@@ -34612,35 +34573,35 @@
 /turf/open/floor/iron/dark,
 /area/service/chapel/monastery)
 "cuU" = (
-/obj/machinery/door/airlock{
-	name = "Dining Room"
+/obj/structure/closet/crate/coffin,
+/obj/machinery/door/window/left/directional/north{
+	name = "Coffin Storage";
+	req_access_txt = "22"
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
-/area/service/chapel/monastery)
+/area/service/chapel/funeral)
 "cuX" = (
-/obj/machinery/door/airlock{
-	name = "Garden"
+/obj/machinery/disposal/bin,
+/obj/structure/sign/warning/deathsposal{
+	pixel_y = 32
 	},
-/obj/structure/cable,
-/obj/machinery/navbeacon/wayfinding{
-	location = "Garden"
+/obj/structure/disposalpipe/trunk{
+	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/service/chapel/monastery)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
 "cuY" = (
-/obj/machinery/door/airlock{
-	name = "Garden"
-	},
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/service/chapel/monastery)
+/obj/structure/cable,
+/obj/structure/reagent_dispensers/watertank,
+/turf/open/floor/plating,
+/area/maintenance/department/medical)
 "cuZ" = (
-/obj/item/wrench,
-/turf/open/floor/iron,
-/area/service/chapel/monastery)
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark,
+/area/service/chapel/dock)
 "cvb" = (
 /obj/machinery/hydroponics/soil,
 /obj/item/seeds/wheat,
@@ -34650,17 +34611,20 @@
 /turf/open/floor/grass,
 /area/service/hydroponics/garden/monastery)
 "cvd" = (
-/obj/structure/chair/wood{
-	dir = 4
+/obj/machinery/button/crematorium{
+	id = "foo";
+	pixel_x = 25
+	},
+/obj/structure/bodycontainer/crematorium{
+	id = "foo"
 	},
 /turf/open/floor/iron/dark,
-/area/service/chapel/monastery)
+/area/service/chapel/funeral)
 "cve" = (
-/obj/structure/chair/wood{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/service/chapel/monastery)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
 "cvf" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -34669,10 +34633,10 @@
 	},
 /area/cargo/warehouse)
 "cvg" = (
-/obj/structure/flora/ausbushes/ywflowers,
-/obj/structure/flora/ausbushes/brflowers,
-/turf/open/floor/grass,
-/area/service/hydroponics/garden/monastery)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/checker,
+/area/service/chapel/monastery)
 "cvh" = (
 /obj/machinery/hydroponics/soil,
 /obj/item/seeds/poppy,
@@ -34694,53 +34658,42 @@
 /turf/open/floor/grass,
 /area/service/hydroponics/garden/monastery)
 "cvk" = (
-/obj/machinery/light/small{
-	dir = 4
+/obj/machinery/door/airlock/grunge{
+	name = "Monastery"
 	},
-/obj/machinery/camera/directional/east{
-	c_tag = "Monastery Cloister Starboard";
-	network = list("ss13","monastery")
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/service/chapel/monastery)
 "cvq" = (
-/obj/machinery/camera/directional/east{
-	c_tag = "Monastery Secondary Dock";
-	network = list("ss13","monastery")
-	},
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/dark,
-/area/service/chapel/monastery)
+/area/service/library)
 "cvr" = (
-/obj/machinery/door/window/left/directional/east{
-	dir = 1;
-	name = "Coffin Storage";
-	req_one_access_txt = "22"
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/light/small/directional/north,
+/obj/structure/sign/directions/evac{
+	dir = 8;
+	pixel_y = 32
 	},
 /turf/open/floor/iron/dark,
 /area/service/chapel/monastery)
 "cvs" = (
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/service/chapel/monastery)
+/obj/structure/window/reinforced,
+/obj/structure/lattice,
+/turf/open/space,
+/area/space/nearstation)
 "cvt" = (
-/obj/machinery/door/window/left/directional/east{
-	base_state = "right";
-	dir = 1;
-	icon_state = "right";
-	name = "Coffin Storage";
-	req_one_access_txt = "22"
+/obj/structure/lattice,
+/obj/structure/window/reinforced{
+	dir = 4
 	},
-/turf/open/floor/iron/dark,
-/area/service/chapel/monastery)
+/turf/open/space/basic,
+/area/space/nearstation)
 "cvu" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/iron/dark,
 /area/service/chapel/monastery)
 "cvy" = (
@@ -34748,286 +34701,232 @@
 /turf/open/floor/iron/dark,
 /area/service/chapel/monastery)
 "cvA" = (
-/obj/machinery/door/airlock/external{
-	name = "Dock Access"
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/service/chapel/monastery)
 "cvB" = (
-/obj/structure/chair/wood,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/obj/item/storage/fancy/candle_box,
+/obj/structure/table/wood,
+/obj/machinery/light_switch/directional/east,
 /turf/open/floor/iron/dark,
-/area/service/chapel/monastery)
+/area/service/chapel/funeral)
 "cvE" = (
-/obj/item/kirbyplants{
-	icon_state = "plant-21"
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
+/obj/structure/closet/cabinet,
+/obj/item/clothing/suit/chaplainsuit/holidaypriest,
+/obj/item/clothing/suit/chaplainsuit/nun,
+/obj/item/clothing/head/nun_hood,
+/turf/open/floor/iron/grimy,
 /area/service/chapel/monastery)
 "cvI" = (
-/obj/machinery/light/small,
-/obj/machinery/camera/directional/south{
-	c_tag = "Monastery Cloister Aft";
-	network = list("ss13","monastery")
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/service/chapel/monastery)
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
 "cvJ" = (
-/obj/machinery/light/small,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/table,
+/obj/item/storage/crayons,
+/obj/item/wrench,
 /turf/open/floor/iron/dark,
-/area/service/chapel/monastery)
+/area/service/chapel)
 "cvR" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/structure/sign/warning/vacuum/external{
-	pixel_x = -32
-	},
-/obj/machinery/camera/directional/west{
-	c_tag = "Monastery Cemetary";
-	network = list("ss13","monastery")
-	},
+/obj/machinery/light/small/directional/south,
 /turf/open/floor/iron/dark,
-/area/service/chapel/monastery)
+/area/service/chapel)
 "cvS" = (
-/obj/structure/chair/wood,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
+/obj/machinery/door/airlock{
+	name = "Dining Room"
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/service/chapel/monastery)
 "cvT" = (
-/obj/structure/chair/wood,
-/turf/open/floor/carpet,
-/area/service/chapel/monastery)
-"cvV" = (
-/obj/structure/chair/wood,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/light/small/directional/south,
 /turf/open/floor/iron/dark,
-/area/service/chapel/monastery)
+/area/service/library)
+"cvV" = (
+/obj/effect/turf_decal/tile/neutral/half/contrasted,
+/obj/structure/sink{
+	pixel_y = 20
+	},
+/turf/open/floor/iron/dark,
+/area/science/genetics)
 "cwa" = (
 /turf/closed/wall/mineral/iron,
 /area/maintenance/department/chapel/monastery)
 "cwc" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Monastery Maintenance";
-	req_one_access_txt = "22;24;10;11;37"
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/maintenance/department/chapel/monastery)
+/obj/item/flashlight/lantern,
+/obj/item/radio/intercom/directional/south,
+/obj/machinery/light_switch/directional/west,
+/turf/open/floor/iron/dark,
+/area/service/chapel)
 "cwe" = (
 /turf/closed/wall/mineral/iron,
 /area/service/library/lounge)
 "cwg" = (
-/obj/machinery/door/airlock/grunge{
-	name = "Library"
-	},
-/obj/machinery/door/firedoor,
-/obj/structure/cable,
-/obj/machinery/navbeacon/wayfinding/library,
+/obj/structure/displaycase/trophy,
 /turf/open/floor/iron/dark,
-/area/service/library/lounge)
+/area/service/library/artgallery)
 "cwj" = (
-/obj/item/storage/box/matches{
-	pixel_x = -3;
-	pixel_y = 8
+/obj/structure/chair/wood{
+	dir = 4
 	},
-/obj/structure/table/wood,
-/turf/open/floor/iron/dark,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/checker,
 /area/service/chapel/monastery)
 "cwk" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/carpet,
-/area/service/chapel/monastery)
-"cwl" = (
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/obj/item/storage/fancy/candle_box,
-/obj/structure/table/wood,
-/turf/open/floor/iron/dark,
-/area/service/chapel/monastery)
-"cwm" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/spawner/atmos_canister/oxygen,
-/turf/open/floor/plating,
-/area/maintenance/department/chapel/monastery)
-"cwn" = (
-/obj/item/storage/toolbox/mechanical,
-/obj/machinery/light/small{
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/maintenance/department/chapel/monastery)
+/turf/open/floor/iron/dark,
+/area/service/chapel/dock)
+"cwl" = (
+/obj/effect/landmark/start/librarian,
+/turf/open/floor/iron/dark,
+/area/service/library)
+"cwm" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/transit_tube/crossing/horizontal,
+/turf/open/space,
+/area/space/nearstation)
+"cwn" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron/dark,
+/area/service/library/artgallery)
 "cwo" = (
-/obj/machinery/power/apc/auto_name/directional/north{
-	name = "Monastery Maintenance APC"
+/obj/machinery/door/airlock/grunge{
+	name = "Chapel"
 	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/maintenance/department/chapel/monastery)
+/turf/open/floor/iron/dark,
+/area/service/chapel)
 "cwp" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/maintenance/department/chapel/monastery)
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/machinery/door/window/right/directional/north{
+	base_state = "left";
+	dir = 2;
+	icon_state = "left";
+	name = "Curator Desk Door";
+	req_access_txt = "37"
+	},
+/obj/effect/turf_decal/tile/purple/half/contrasted,
+/turf/open/floor/iron/dark,
+/area/service/library)
 "cwr" = (
-/obj/item/kirbyplants{
-	icon_state = "plant-22"
+/obj/machinery/camera/directional/south{
+	c_tag = "Monastery Aft Exterior";
+	network = list("ss13","monastery")
 	},
-/obj/machinery/power/apc/auto_name/directional/east{
-	name = "Library Lounge APC"
-	},
-/obj/machinery/airalarm/directional/north{
-	pixel_y = 22
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/service/library/lounge)
+/turf/open/misc/asteroid,
+/area/service/chapel/asteroid/monastery)
 "cww" = (
-/obj/structure/table/wood,
-/obj/item/food/grown/poppy,
-/obj/item/food/grown/harebell,
-/turf/open/floor/iron/dark,
-/area/service/chapel/monastery)
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/service/chapel/funeral)
 "cwx" = (
-/obj/structure/table/wood/fancy,
-/obj/item/storage/book/bible,
-/turf/open/floor/carpet,
-/area/service/chapel/monastery)
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
+/area/maintenance/department/medical)
 "cwy" = (
-/obj/structure/table/wood/fancy,
-/obj/item/candle,
-/obj/item/candle{
-	pixel_x = 6;
-	pixel_y = 8
-	},
-/obj/item/candle{
-	pixel_x = -8;
-	pixel_y = 6
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/carpet,
-/area/service/chapel/monastery)
-"cwz" = (
-/obj/item/clothing/under/misc/burial,
-/obj/item/clothing/under/misc/burial,
-/obj/item/clothing/under/misc/burial,
-/obj/item/clothing/under/misc/burial,
-/obj/structure/table/wood,
 /turf/open/floor/iron/dark,
-/area/service/chapel/monastery)
+/area/service/chapel/dock)
+"cwz" = (
+/obj/structure/grille/broken,
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/maintenance/department/medical)
 "cwA" = (
 /turf/open/floor/plating,
 /area/maintenance/department/chapel/monastery)
 "cwE" = (
-/obj/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/dark,
-/area/service/chapel/monastery)
+/obj/item/wrench,
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
 "cwG" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/obj/item/wrench,
+/turf/open/floor/iron,
+/area/service/chapel/monastery)
+"cwM" = (
+/obj/structure/flora/ausbushes/genericbush,
 /obj/machinery/light/small{
 	dir = 4
 	},
-/obj/machinery/computer/pod/old/mass_driver_controller/chapelgun{
-	pixel_x = 24
-	},
-/turf/open/floor/iron/dark,
-/area/service/chapel/monastery)
-"cwM" = (
-/obj/structure/window/reinforced{
-	dir = 4;
-	layer = 2.9
-	},
-/turf/open/space,
-/area/space/nearstation)
+/obj/item/radio/intercom/directional/east,
+/turf/open/floor/grass,
+/area/service/hydroponics/garden/monastery)
 "cwO" = (
-/obj/item/flashlight/lantern,
+/obj/machinery/vending/snack/orange,
 /turf/open/floor/iron/dark,
 /area/service/chapel/monastery)
 "cwR" = (
 /obj/structure/window/reinforced{
-	dir = 8;
-	layer = 2.9
+	dir = 1
 	},
-/turf/open/space/basic,
-/area/space/nearstation)
+/turf/open/misc/asteroid,
+/area/service/chapel/asteroid/monastery)
 "cwS" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
 /area/maintenance/department/chapel/monastery)
 "cwU" = (
-/obj/structure/table/wood,
-/obj/machinery/computer/libraryconsole,
-/turf/open/floor/iron/dark,
-/area/service/library/lounge)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
 "cxb" = (
 /obj/effect/turf_decal/tile/purple/half/contrasted,
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
 "cxe" = (
-/obj/structure/cable,
+/obj/structure/chair/wood,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/carpet,
 /area/service/library/lounge)
 "cxg" = (
-/obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
 	},
-/turf/open/space/basic,
-/area/space/nearstation)
+/obj/machinery/door/airlock/external{
+	name = "Auxiliary Dock"
+	},
+/turf/open/floor/plating,
+/area/service/chapel)
 "cxh" = (
-/obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+/obj/machinery/door/airlock/external/glass,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "monastery-maint-connect"
 	},
-/obj/structure/window/reinforced{
-	dir = 4;
-	layer = 2.9
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
 "cxk" = (
-/obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 8;
-	layer = 2.9
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
+/obj/structure/table/wood,
+/obj/item/folder/yellow,
+/obj/item/pen,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/service/library)
 "cxn" = (
-/obj/machinery/newscaster{
-	pixel_x = -32;
-	pixel_y = -32
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/carpet,
-/area/service/library/lounge)
+/turf/closed/wall,
+/area/maintenance/department/engine)
 "cxq" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
@@ -35036,30 +34935,30 @@
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
 "cxz" = (
-/obj/machinery/door/airlock/grunge{
-	name = "Library"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/machinery/door/firedoor,
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/service/library/lounge)
-"cxC" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/stripes/corner{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/machinery/airalarm/directional/east,
+/turf/open/floor/iron/dark,
+/area/service/chapel/monastery)
+"cxC" = (
+/obj/machinery/disposal/bin,
+/obj/structure/sign/warning/deathsposal{
+	pixel_x = -32
+	},
+/obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/service/library/lounge)
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
 "cxD" = (
-/obj/effect/turf_decal/stripes/corner,
-/obj/structure/cable,
+/obj/effect/turf_decal/tile/red/fourcorners,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
-/area/service/library/lounge)
+/area/service/chapel/office)
 "cxJ" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
@@ -35070,152 +34969,133 @@
 /turf/open/floor/iron,
 /area/cargo/sorting)
 "cxK" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/service/library/lounge)
-"cxL" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/service/library/lounge)
-"cxM" = (
-/obj/structure/window/reinforced/fulltile,
-/turf/open/floor/plating,
-/area/service/library/lounge)
-"cxX" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/camera/directional/west{
-	c_tag = "Monastery Archives Access Tunnel";
+/obj/machinery/camera/directional/east{
+	c_tag = "Library Starboard";
 	network = list("ss13","monastery")
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/light/small/directional/east,
 /turf/open/floor/iron/dark,
+/area/service/library)
+"cxL" = (
+/obj/structure/chair/wood{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/carpet,
+/area/service/library/lounge)
+"cxM" = (
+/obj/structure/bed,
+/obj/item/bedsheet/medical,
+/turf/open/floor/iron/freezer,
+/area/medical/virology)
+"cxX" = (
+/obj/structure/table/wood/fancy,
+/obj/item/flashlight/lantern{
+	icon_state = "lantern-on";
+	pixel_y = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/carpet,
 /area/service/library/lounge)
 "cxY" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
 /turf/open/floor/iron/dark,
 /area/service/library/lounge)
 "cyl" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/service/library/lounge)
+/obj/item/radio/intercom/directional/east,
+/obj/machinery/newscaster/directional/south,
+/obj/machinery/light/small/directional/east,
+/turf/open/floor/carpet/black,
+/area/service/chapel/office)
 "cym" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/service/library/lounge)
+/turf/closed/wall,
+/area/service/library/artgallery)
 "cyz" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/service/library/lounge)
+/obj/structure/table,
+/obj/item/folder,
+/obj/item/pen,
+/obj/machinery/light/small,
+/turf/open/floor/iron,
+/area/hallway/secondary/entry)
 "cyA" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
+/obj/item/kirbyplants{
+	icon_state = "plant-21";
+	pixel_y = 3
 	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/camera/directional/west{
+	c_tag = "Chapel Office";
+	network = list("ss13","monastery")
+	},
 /turf/open/floor/iron/dark,
-/area/service/library/lounge)
+/area/service/chapel/office)
 "cyB" = (
 /turf/closed/wall,
 /area/service/library/lounge)
 "cyM" = (
-/obj/structure/lattice,
-/turf/closed/mineral,
-/area/service/chapel/asteroid/monastery)
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/service/library/artgallery)
 "cyP" = (
-/obj/structure/bookcase/random/nonfiction,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/service/library)
+/obj/structure/table/wood/fancy,
+/obj/item/storage/photo_album,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/carpet,
+/area/service/library/lounge)
 "cyQ" = (
-/obj/item/kirbyplants{
-	icon_state = "plant-22"
-	},
-/obj/machinery/camera/directional/north{
-	c_tag = "Monastery Archives Fore";
-	network = list("ss13","monastery")
-	},
-/obj/machinery/firealarm/directional/north,
+/obj/structure/closet,
+/obj/item/storage/book/bible,
+/obj/item/storage/book/bible,
+/obj/item/storage/book/bible,
+/obj/machinery/light/small/directional/east,
 /turf/open/floor/iron/dark,
-/area/service/library)
+/area/service/chapel/office)
 "cyR" = (
 /obj/item/kirbyplants{
 	icon_state = "plant-22"
 	},
+/obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/iron/dark,
 /area/service/library)
 "cyS" = (
-/obj/structure/bookcase/random/religion,
-/obj/machinery/light/small{
+/obj/structure/closet/crate/coffin,
+/obj/machinery/door/window/left/directional/north{
+	name = "Coffin Storage";
+	req_access_txt = "22"
+	},
+/obj/machinery/light/small/directional/south,
+/turf/open/floor/iron/dark,
+/area/service/chapel/funeral)
+"cyT" = (
+/obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
 /turf/open/floor/iron/dark,
-/area/service/library)
-"cyT" = (
-/obj/structure/table/wood,
-/obj/item/paper_bin{
-	layer = 2.9;
-	pixel_x = -2;
-	pixel_y = 4
-	},
-/obj/item/pen,
-/turf/open/floor/iron/dark,
-/area/service/library)
+/area/service/chapel/office)
 "cyU" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/service/library)
 "cyY" = (
-/obj/machinery/light/small{
-	dir = 8
+/obj/structure/window/reinforced{
+	dir = 1
 	},
-/turf/open/floor/iron/dark,
-/area/service/library)
+/obj/item/flashlight/lantern{
+	icon_state = "lantern-on"
+	},
+/turf/open/misc/asteroid,
+/area/service/chapel/asteroid/monastery)
 "cyZ" = (
-/obj/structure/displaycase/trophy,
-/turf/open/floor/iron/dark,
-/area/service/library)
+/obj/structure/table/wood/fancy,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/carpet,
+/area/service/library/lounge)
 "czd" = (
 /obj/structure/table/optable,
 /obj/effect/turf_decal/tile/blue/half/contrasted{
@@ -35224,9 +35104,11 @@
 /turf/open/floor/iron/white,
 /area/medical/surgery)
 "czl" = (
-/obj/structure/chair/wood,
-/turf/open/floor/carpet,
-/area/service/library)
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/service/chapel)
 "czo" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp/green{
@@ -35246,14 +35128,15 @@
 /turf/open/floor/iron/dark,
 /area/service/library)
 "czr" = (
-/obj/structure/table/wood/fancy,
-/turf/open/floor/carpet,
+/obj/structure/closet/crate/bin,
+/turf/open/floor/iron/dark,
 /area/service/library)
 "czt" = (
-/obj/structure/table/wood/fancy,
-/obj/item/storage/photo_album,
-/turf/open/floor/carpet,
-/area/service/library)
+/obj/machinery/door/airlock/grunge{
+	name = "Monastery"
+	},
+/turf/open/floor/iron/dark,
+/area/service/chapel/monastery)
 "czu" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin{
@@ -35270,23 +35153,20 @@
 /turf/open/floor/iron/dark,
 /area/service/library)
 "czw" = (
-/obj/machinery/newscaster{
-	pixel_x = 32
+/obj/structure/chair/wood{
+	dir = 8
 	},
-/turf/open/floor/iron/dark,
-/area/service/library)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/chapel,
+/area/service/chapel)
 "czB" = (
-/obj/structure/table/wood/fancy,
-/obj/item/storage/fancy/candle_box,
-/turf/open/floor/carpet,
-/area/service/library)
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/cable,
+/turf/open/floor/grass,
+/area/service/hydroponics/garden/monastery)
 "czC" = (
-/obj/structure/table/wood/fancy,
-/obj/item/flashlight/lantern{
-	icon_state = "lantern-on";
-	pixel_y = 8
-	},
-/turf/open/floor/carpet,
+/obj/structure/bookcase/random/reference,
+/turf/open/floor/iron/dark,
 /area/service/library)
 "czD" = (
 /obj/structure/table/wood,
@@ -35295,25 +35175,23 @@
 /turf/open/floor/iron/dark,
 /area/service/library)
 "czH" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/machinery/camera/directional/west{
-	c_tag = "Monastery Archives Port";
-	network = list("ss13","monastery")
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/door/airlock/grunge{
+	name = "Chapel"
 	},
 /turf/open/floor/iron/dark,
-/area/service/library)
+/area/service/chapel/dock)
 "czI" = (
-/obj/structure/chair/wood{
-	dir = 1
-	},
-/turf/open/floor/carpet,
+/obj/structure/table/wood,
+/obj/item/newspaper,
+/obj/item/reagent_containers/food/drinks/coffee,
+/obj/machinery/light/small/directional/south,
+/turf/open/floor/iron/dark,
 /area/service/library)
 "czL" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
-/area/service/library)
+/area/service/chapel)
 "czM" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
@@ -35335,54 +35213,47 @@
 /turf/open/floor/iron/dark,
 /area/service/library)
 "czQ" = (
-/obj/machinery/light/small{
-	dir = 4
+/obj/structure/window/reinforced{
+	dir = 8
 	},
-/obj/machinery/camera/directional/east{
-	c_tag = "Monastery Archives Starboard";
-	network = list("ss13","monastery")
-	},
-/turf/open/floor/iron/dark,
-/area/service/library)
+/obj/structure/flora/ausbushes/fernybush,
+/turf/open/misc/asteroid,
+/area/service/chapel/asteroid/monastery)
 "czV" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/service/library)
-"czY" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
+"czY" = (
+/obj/structure/chair/wood{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
-/area/service/library)
+/area/service/chapel/funeral)
 "cAg" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/service/library)
 "cAi" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/service/library)
+/obj/effect/spawner/random/trash/food_packaging,
+/turf/open/floor/plating,
+/area/maintenance/department/medical)
 "cAj" = (
+/obj/machinery/door/airlock/grunge{
+	name = "Crematorium";
+	req_access_txt = "27"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
-/area/service/library)
+/area/service/chapel/funeral)
 "cAr" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/machinery/door/window/right/directional/north{
-	base_state = "left";
-	dir = 2;
-	icon_state = "left";
-	name = "Curator Desk Door";
-	req_access_txt = "37"
-	},
-/obj/effect/turf_decal/tile/red/half/contrasted,
-/turf/open/floor/iron/dark,
-/area/service/library)
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/service/chapel/asteroid/monastery)
 "cAs" = (
 /obj/structure/table/wood,
 /obj/item/kirbyplants{
@@ -35415,21 +35286,13 @@
 /turf/open/floor/iron/dark,
 /area/service/library)
 "cAy" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/machinery/door/window/right/directional/north{
-	dir = 2;
-	name = "Curator Desk Door";
-	req_access_txt = "37"
-	},
-/obj/effect/turf_decal/tile/red/half/contrasted,
+/obj/structure/bookcase/random/nonfiction,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/service/library)
 "cAB" = (
-/obj/effect/turf_decal/tile/purple/half/contrasted{
-	dir = 1
-	},
+/obj/structure/chair/wood,
 /turf/open/floor/iron/dark,
 /area/service/library)
 "cAC" = (
@@ -35448,36 +35311,30 @@
 /turf/open/floor/iron/dark,
 /area/service/library)
 "cAH" = (
-/obj/machinery/light/small,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/service/library)
+/obj/structure/disposalpipe/junction/flip,
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
 "cAM" = (
-/obj/machinery/light/small,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/hallway/secondary/entry)
+"cAS" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
-/turf/open/floor/iron/dark,
-/area/service/library)
-"cAS" = (
-/obj/machinery/vending/wardrobe/curator_wardrobe,
-/turf/open/floor/iron/dark,
-/area/service/library)
+/obj/machinery/camera/directional/east{
+	c_tag = "Virology Isolation A";
+	network = list("ss13","medbay")
+	},
+/turf/open/floor/iron/freezer,
+/area/medical/virology)
 "cAU" = (
-/obj/structure/rack{
-	icon = 'icons/obj/stationobjs.dmi';
-	icon_state = "minibar";
-	name = "skeletal minibar"
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/item/book/codex_gigas,
-/obj/machinery/camera/directional/south{
-	c_tag = "Monastery Archives Aft";
-	network = list("ss13","monastery")
-	},
-/turf/open/floor/iron/dark,
-/area/service/library)
+/turf/open/space/basic,
+/area/space/nearstation)
 "cAV" = (
 /obj/structure/bookcase{
 	name = "Forbidden Knowledge"
@@ -35697,9 +35554,12 @@
 /turf/open/floor/iron,
 /area/engineering/lobby)
 "cCW" = (
-/obj/machinery/vending/games,
-/turf/open/floor/iron/dark,
-/area/service/library)
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/open/floor/iron/checker,
+/area/service/chapel/monastery)
 "cCY" = (
 /turf/open/floor/plating,
 /area/cargo/warehouse)
@@ -35727,13 +35587,15 @@
 /turf/open/space/basic,
 /area/space)
 "cFX" = (
-/obj/structure/lattice,
-/obj/structure/window/reinforced{
-	dir = 8
+/obj/docking_port/stationary{
+	dwidth = 2;
+	height = 6;
+	id = "monastery_shuttle_asteroid";
+	name = "Monastery Fore";
+	width = 5
 	},
-/obj/structure/window/reinforced,
-/turf/open/space,
-/area/space/nearstation)
+/turf/open/space/basic,
+/area/space)
 "cHS" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Firing Range"
@@ -35814,8 +35676,9 @@
 	},
 /area/maintenance/department/crew_quarters/dorms)
 "cPT" = (
-/turf/closed/wall/r_wall,
-/area/science/genetics)
+/obj/structure/sign/poster/contraband/random/directional/south,
+/turf/open/floor/iron/showroomfloor,
+/area/service/chapel/monastery)
 "cQN" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -35825,14 +35688,8 @@
 /turf/open/floor/plating,
 /area/maintenance/port/lesser)
 "cSf" = (
-/obj/machinery/door/airlock/atmos{
-	name = "Atmospherics Maintenance";
-	req_access_txt = "12;24"
-	},
-/obj/effect/mapping_helpers/airlock/abandoned,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/maintenance/department/engine)
+/turf/open/floor/carpet/purple,
+/area/medical/psychology)
 "cSJ" = (
 /obj/machinery/light{
 	dir = 4
@@ -35890,13 +35747,18 @@
 /obj/structure/cable,
 /turf/open/floor/engine,
 /area/engineering/main)
+"cZF" = (
+/obj/structure/table,
+/obj/effect/spawner/random/maintenance,
+/turf/open/floor/plating,
+/area/maintenance/department/medical)
 "dbI" = (
-/obj/structure/sign/painting/library{
-	pixel_x = -32
+/obj/machinery/atmospherics/components/binary/pump/off/general/visible/layer4{
+	dir = 1;
+	name = "Supply to Virology"
 	},
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/service/library/artgallery)
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
 "dbJ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -36049,6 +35911,16 @@
 /obj/machinery/vending/wallmed/directional/west,
 /turf/open/floor/iron/white,
 /area/medical/virology)
+"doz" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/camera/directional/east{
+	c_tag = "Monastery Garden Starboard";
+	network = list("ss13","monastery")
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/service/chapel/monastery)
 "doQ" = (
 /obj/machinery/computer/cargo{
 	dir = 1
@@ -36238,11 +36110,11 @@
 /turf/open/floor/iron/white,
 /area/medical/storage)
 "dAG" = (
-/obj/structure/grille/broken,
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
+/obj/structure/chair/wood{
+	dir = 1
 	},
-/area/maintenance/department/medical)
+/turf/open/floor/carpet,
+/area/service/library/lounge)
 "dBm" = (
 /obj/machinery/mineral/stacking_unit_console{
 	machinedir = 8;
@@ -36256,16 +36128,18 @@
 /turf/open/floor/iron,
 /area/maintenance/disposal)
 "dCh" = (
-/obj/structure/sign/painting/library_private{
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/service/chapel/funeral)
+"dES" = (
+/obj/structure/chair/wood,
+/obj/structure/sign/poster/official/periodic_table{
 	pixel_x = -32
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
-/area/service/library/artgallery)
-"dES" = (
-/obj/structure/closet/firecloset,
-/turf/open/floor/plating,
-/area/maintenance/department/engine)
+/area/service/library)
 "dGH" = (
 /obj/structure/chair{
 	dir = 4
@@ -36285,6 +36159,10 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/tcommsat/computer)
+"dJJ" = (
+/obj/structure/chair/wood,
+/turf/open/floor/iron/dark,
+/area/service/chapel/funeral)
 "dJN" = (
 /obj/structure/window/reinforced/spawner,
 /obj/structure/window/reinforced/spawner/north,
@@ -36491,15 +36369,16 @@
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/dorms)
 "ebp" = (
-/obj/structure/sign/plaques/kiddie{
-	desc = "It reads: PRIVATE EXHIBIT -  Please inquire with library staff for guided tours.";
-	name = "\improper Private Section Notice";
-	pixel_y = 32
+/obj/structure/table/wood,
+/obj/item/food/breadslice/plain,
+/obj/item/food/breadslice/plain{
+	pixel_y = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/item/food/breadslice/plain{
+	pixel_y = 8
+	},
 /turf/open/floor/iron/dark,
-/area/service/library/artgallery)
+/area/service/chapel)
 "ebw" = (
 /obj/effect/turf_decal/trimline/brown/filled/line,
 /obj/structure/cable,
@@ -36610,11 +36489,13 @@
 /turf/open/floor/wood,
 /area/service/lawoffice)
 "elH" = (
-/obj/structure/sign/painting/library{
-	pixel_x = -32
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/cable,
+/obj/machinery/light/small/directional/east,
 /turf/open/floor/iron/dark,
-/area/service/library/artgallery)
+/area/service/chapel/monastery)
 "elL" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -36753,15 +36634,23 @@
 /turf/open/floor/plating,
 /area/engineering/main)
 "evR" = (
-/obj/structure/window/reinforced{
-	dir = 8
+/obj/structure/table,
+/obj/item/reagent_containers/food/condiment/saltshaker{
+	pixel_x = 3;
+	pixel_y = 4
 	},
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/space/nearstation)
+/obj/item/reagent_containers/food/condiment/peppermill,
+/obj/item/storage/box/ingredients/wildcard{
+	layer = 3.1
+	},
+/obj/structure/sign/poster/official/random/directional/south,
+/turf/open/floor/iron,
+/area/service/chapel/monastery)
 "ewV" = (
-/turf/open/floor/carpet,
-/area/service/library/artgallery)
+/obj/structure/disposalpipe/segment,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
 "ezn" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -36846,6 +36735,12 @@
 /obj/item/clothing/mask/surgical,
 /turf/open/floor/iron/white,
 /area/medical/exam_room)
+"eFu" = (
+/obj/structure/chair/wood{
+	dir = 4
+	},
+/turf/open/floor/iron/checker,
+/area/service/chapel/monastery)
 "eHI" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -36877,17 +36772,9 @@
 /turf/open/floor/iron/dark,
 /area/hallway/secondary/exit/departure_lounge)
 "eNy" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/purple/anticorner/contrasted{
-	dir = 8
-	},
-/obj/machinery/airalarm/directional/south,
-/turf/open/floor/iron/white,
-/area/science/genetics)
+/obj/effect/decal/cleanable/cobweb,
+/turf/open/floor/iron/dark,
+/area/service/chapel)
 "eNF" = (
 /obj/structure/grille,
 /obj/structure/lattice,
@@ -37264,19 +37151,19 @@
 /turf/open/floor/iron/dark,
 /area/maintenance/disposal/incinerator)
 "fnq" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/carpet,
-/area/service/library/artgallery)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/turf/closed/wall,
+/area/maintenance/department/engine)
 "fon" = (
 /obj/structure/lattice,
 /obj/structure/grille,
 /turf/open/space/basic,
 /area/space/nearstation)
 "fov" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/closed/wall,
-/area/maintenance/department/engine)
+/obj/machinery/newscaster/directional/east,
+/obj/machinery/light/small/directional/east,
+/turf/open/floor/iron/dark,
+/area/service/library)
 "fow" = (
 /obj/structure/chair/office{
 	dir = 1
@@ -37358,11 +37245,9 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
 "fwg" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating{
-	icon_state = "platingdmg2"
-	},
-/area/maintenance/department/medical)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark,
+/area/service/chapel/funeral)
 "fwi" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -37416,12 +37301,15 @@
 /turf/open/floor/iron/white,
 /area/medical/surgery)
 "fAe" = (
-/obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 2
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/turf/open/floor/iron/dark,
-/area/service/library/artgallery)
+/obj/effect/spawner/random/trash/grime,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
 "fAE" = (
 /obj/structure/chair/sofa/left{
 	dir = 8
@@ -37510,11 +37398,9 @@
 /turf/open/floor/iron/showroomfloor,
 /area/security/lockers)
 "fGm" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/light/directional/south,
 /turf/open/floor/iron/dark,
-/area/service/library/artgallery)
+/area/service/chapel)
 "fGz" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/tile/blue/half/contrasted{
@@ -37581,15 +37467,11 @@
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "fMm" = (
-/obj/structure/flora/grass/jungle/b,
-/obj/structure/flora/ausbushes/lavendergrass,
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/machinery/door/window/left/directional/east{
-	dir = 1;
-	name = "Petting Garden"
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
 	},
-/turf/open/floor/grass,
-/area/medical/psychology)
+/turf/open/floor/iron/dark,
+/area/service/chapel/funeral)
 "fNv" = (
 /obj/structure/chair{
 	dir = 8
@@ -37600,10 +37482,10 @@
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "fNX" = (
-/obj/structure/table,
-/obj/effect/spawner/random/maintenance,
-/turf/open/floor/plating,
-/area/maintenance/department/medical)
+/obj/machinery/vending/wardrobe/chap_wardrobe,
+/obj/structure/sign/poster/official/random/directional/east,
+/turf/open/floor/iron/dark,
+/area/service/chapel/office)
 "fQd" = (
 /obj/machinery/conveyor{
 	id = "CargoLoad"
@@ -37696,15 +37578,17 @@
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "fWv" = (
-/obj/structure/bookcase/random/religion,
-/turf/open/floor/iron/dark,
-/area/service/library/lounge)
-"fWL" = (
-/obj/structure/disposalpipe/segment{
-	dir = 5
+/obj/machinery/door/airlock/grunge{
+	name = "Monastery Transit"
 	},
-/turf/open/floor/iron/white,
-/area/science/genetics)
+/turf/open/floor/iron/dark,
+/area/service/chapel/dock)
+"fWL" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/maintenance/department/medical)
 "fYY" = (
 /obj/structure/sign/poster/official/random{
 	pixel_y = 32
@@ -37760,11 +37644,12 @@
 /turf/open/floor/iron,
 /area/cargo/storage)
 "gdJ" = (
+/obj/machinery/power/apc/auto_name/directional/east{
+	name = "Library Lounge APC"
+	},
 /obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/obj/effect/spawner/random/trash/grille_or_waste,
-/turf/open/floor/plating,
-/area/maintenance/department/engine)
+/turf/open/floor/iron/dark,
+/area/service/library/lounge)
 "gfi" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -37794,10 +37679,11 @@
 /area/cargo/storage)
 "giI" = (
 /obj/machinery/light/small{
-	dir = 1
+	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
-/area/service/chapel/office)
+/area/maintenance/department/engine)
 "gjp" = (
 /obj/structure/table/wood,
 /obj/structure/bedsheetbin,
@@ -37854,9 +37740,15 @@
 /turf/open/floor/iron,
 /area/commons/storage/primary)
 "gkS" = (
-/obj/machinery/rnd/experimentor,
-/turf/open/floor/engine,
-/area/science/explab)
+/obj/structure/chair/wood{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron/chapel{
+	dir = 1
+	},
+/area/service/chapel)
 "gkX" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Storage";
@@ -37910,6 +37802,13 @@
 /obj/effect/turf_decal/tile/yellow/half/contrasted,
 /turf/open/floor/iron,
 /area/engineering/main)
+"goT" = (
+/obj/effect/landmark/start/assistant,
+/obj/machinery/navbeacon/wayfinding{
+	location = "Garden"
+	},
+/turf/open/floor/grass,
+/area/service/hydroponics/garden/monastery)
 "gpu" = (
 /obj/structure/sign/directions/medical{
 	pixel_x = 32;
@@ -37956,26 +37855,9 @@
 /turf/open/floor/grass,
 /area/medical/psychology)
 "gtl" = (
-/obj/item/toy/crayon/black,
-/obj/item/toy/crayon/white{
-	pixel_x = -4;
-	pixel_y = 4
-	},
-/obj/item/toy/crayon/black,
-/obj/item/toy/crayon/white{
-	pixel_x = -4;
-	pixel_y = 4
-	},
-/obj/structure/table/wood,
-/obj/machinery/airalarm/directional/west{
-	pixel_x = -22
-	},
-/obj/machinery/power/apc/auto_name/directional/north{
-	name = "Monastery Art Gallery APC"
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/service/library/artgallery)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden,
+/turf/open/floor/plating,
+/area/maintenance/department/chapel/monastery)
 "gue" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -37985,10 +37867,9 @@
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
 "gum" = (
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
-	},
-/area/maintenance/department/medical)
+/obj/structure/extinguisher_cabinet/directional/south,
+/turf/open/floor/carpet,
+/area/service/library)
 "gup" = (
 /obj/machinery/navbeacon/wayfinding{
 	location = "AI Satellite"
@@ -38242,35 +38123,34 @@
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
 "gKz" = (
-/obj/structure/table/wood,
-/obj/item/kirbyplants{
-	icon_state = "plant-22";
-	pixel_y = 8
+/obj/structure/table,
+/obj/item/crowbar,
+/obj/item/clothing/mask/gas,
+/obj/machinery/camera/directional/east{
+	c_tag = "Monastery Auxiliary Dock";
+	network = list("ss13","monastery")
 	},
+/obj/machinery/light/small/directional/north,
 /turf/open/floor/iron/dark,
-/area/service/chapel/office)
+/area/service/chapel)
 "gKG" = (
 /obj/effect/spawner/random/maintenance,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
-"gKZ" = (
-/obj/structure/mopbucket,
-/obj/item/mop,
-/turf/open/floor/plating,
-/area/maintenance/department/medical)
 "gLF" = (
 /obj/effect/spawner/random/vending/snackvend,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/hallway/secondary/exit/departure_lounge)
 "gMG" = (
-/obj/structure/table/wood,
-/obj/item/newspaper,
-/obj/item/reagent_containers/food/drinks/coffee,
+/obj/machinery/camera/directional/north{
+	c_tag = "Library Fore";
+	network = list("ss13","monastery")
+	},
 /turf/open/floor/iron/dark,
-/area/service/library/artgallery)
+/area/service/library)
 "gMO" = (
 /obj/structure/plasticflaps/opaque,
 /obj/structure/window/reinforced,
@@ -38300,12 +38180,10 @@
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/hos)
 "gOS" = (
-/obj/machinery/power/terminal{
-	dir = 1
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/department/chapel/monastery)
+/obj/structure/displaycase/trophy,
+/obj/machinery/light/directional/west,
+/turf/open/floor/iron/dark,
+/area/service/library/artgallery)
 "gOV" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -38363,6 +38241,13 @@
 /obj/effect/spawner/random/maintenance/three,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
+"gSS" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/service/chapel/dock)
 "gUb" = (
 /obj/structure/chair/office{
 	dir = 4
@@ -38384,20 +38269,36 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/lesser)
+"gVY" = (
+/obj/effect/turf_decal/tile/green/anticorner/contrasted{
+	dir = 4
+	},
+/obj/machinery/camera/directional/east{
+	c_tag = "Virology Lab";
+	network = list("ss13","medbay")
+	},
+/obj/machinery/disposal/bin,
+/obj/structure/sign/warning/deathsposal{
+	pixel_y = 32
+	},
+/obj/structure/disposalpipe/trunk,
+/turf/open/floor/iron/white,
+/area/medical/virology)
 "gXg" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
 "gXh" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/painting/library_private{
-	pixel_x = 32
+/obj/structure/chair/wood{
+	dir = 8
 	},
-/obj/machinery/newscaster{
-	pixel_y = -32
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron/chapel{
+	dir = 4
 	},
-/turf/open/floor/iron/dark,
-/area/service/library/artgallery)
+/area/service/chapel)
 "gXQ" = (
 /obj/effect/turf_decal/tile/yellow,
 /obj/structure/cable,
@@ -38415,9 +38316,14 @@
 /turf/open/floor/engine/co2,
 /area/engineering/atmos)
 "gZg" = (
+/obj/machinery/door/airlock/grunge{
+	name = "Art Gallery"
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/maintenance/department/engine)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron/showroomfloor,
+/area/service/library/artgallery)
 "hae" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -38463,9 +38369,8 @@
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/dorms)
 "hfZ" = (
-/obj/structure/closet/secure_closet/cytology,
-/turf/open/floor/iron/dark,
-/area/science/xenobiology)
+/turf/closed/wall/r_wall,
+/area/science/genetics)
 "hgV" = (
 /obj/structure/table/wood,
 /obj/item/storage/box/seccarts{
@@ -38539,13 +38444,11 @@
 /turf/open/floor/iron,
 /area/security/checkpoint/medical)
 "hko" = (
-/obj/item/wrench,
-/obj/machinery/atmospherics/components/binary/pump/off/general/visible/layer4{
-	dir = 1;
-	name = "Supply to Virology"
+/obj/structure/window/reinforced{
+	dir = 4
 	},
-/turf/open/floor/plating,
-/area/maintenance/department/engine)
+/turf/open/misc/asteroid,
+/area/service/chapel/asteroid/monastery)
 "hkQ" = (
 /obj/machinery/light{
 	dir = 4
@@ -38674,13 +38577,14 @@
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "hwY" = (
-/obj/structure/cable,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -24
+/obj/structure/window/reinforced{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/dark,
-/area/service/library/artgallery)
+/obj/item/flashlight/lantern{
+	icon_state = "lantern-on"
+	},
+/turf/open/misc/asteroid,
+/area/service/chapel/asteroid/monastery)
 "hyA" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden,
 /turf/open/floor/iron,
@@ -38724,20 +38628,22 @@
 /turf/open/floor/iron/white,
 /area/command/heads_quarters/cmo)
 "hBY" = (
-/obj/machinery/disposal/bin,
-/obj/structure/sign/warning/deathsposal{
-	pixel_x = -32
-	},
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/engine)
+/turf/open/floor/carpet,
+/area/service/library)
 "hCE" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/engine,
 /area/engineering/main)
+"hDe" = (
+/obj/machinery/requests_console{
+	department = "Chapel";
+	departmentType = 2;
+	pixel_x = -32
+	},
+/obj/machinery/light/small/directional/west,
+/turf/open/floor/carpet/black,
+/area/service/chapel/office)
 "hDG" = (
 /obj/machinery/door/airlock/engineering{
 	name = "Auxiliary Base Construction";
@@ -38934,9 +38840,11 @@
 /turf/open/floor/wood,
 /area/command/heads_quarters/hop)
 "hRH" = (
-/obj/effect/spawner/random/trash/graffiti,
-/turf/open/floor/plating,
-/area/maintenance/department/engine)
+/obj/machinery/door/airlock/grunge{
+	name = "Library"
+	},
+/turf/open/floor/iron/dark,
+/area/service/library)
 "hSM" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
@@ -39007,6 +38915,13 @@
 /obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/plating,
 /area/maintenance/disposal)
+"hWE" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/item/radio/intercom/directional/east,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/service/chapel/monastery)
 "hWT" = (
 /obj/machinery/pinpointer_dispenser,
 /turf/closed/wall,
@@ -39061,15 +38976,9 @@
 /turf/open/floor/iron/dark,
 /area/service/library)
 "icy" = (
-/obj/machinery/door/airlock/grunge{
-	name = "Art Storage"
-	},
 /obj/structure/cable,
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
-/area/service/library/artgallery)
+/turf/open/floor/plating,
+/area/maintenance/department/chapel/monastery)
 "icU" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
 /obj/machinery/meter,
@@ -39098,10 +39007,10 @@
 /turf/open/floor/iron,
 /area/cargo/storage)
 "idA" = (
-/obj/structure/cable,
-/obj/machinery/power/port_gen/pacman,
-/turf/open/floor/plating,
-/area/maintenance/department/chapel/monastery)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/carpet,
+/area/service/chapel)
 "iga" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -39197,10 +39106,14 @@
 /turf/open/floor/iron/dark,
 /area/service/library/artgallery)
 "ijF" = (
-/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/door/airlock/grunge{
+	name = "Monastery Transit"
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/carpet,
-/area/service/library)
+/turf/open/floor/iron/dark,
+/area/service/chapel/dock)
 "ijU" = (
 /obj/effect/spawner/random/medical/organs,
 /obj/structure/closet/crate,
@@ -39264,6 +39177,12 @@
 /obj/effect/spawner/random/trash/botanical_waste,
 /turf/open/floor/iron/cafeteria,
 /area/security/prison)
+"itI" = (
+/obj/structure/closet/emcloset,
+/obj/machinery/light/small/directional/west,
+/obj/structure/extinguisher_cabinet/directional/west,
+/turf/open/floor/iron/dark,
+/area/service/chapel/dock)
 "iuM" = (
 /obj/machinery/button/door{
 	id = "misclab";
@@ -39370,8 +39289,9 @@
 	network = list("tcomms");
 	start_active = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/plating/airless,
-/area/tcommsat/computer)
+/area/space/nearstation)
 "iCe" = (
 /obj/machinery/atmospherics/components/trinary/mixer{
 	dir = 4;
@@ -39405,9 +39325,9 @@
 /turf/open/floor/iron,
 /area/cargo/storage)
 "iEQ" = (
-/obj/effect/spawner/random/trash/garbage,
-/turf/open/floor/plating,
-/area/maintenance/department/medical)
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/carpet,
+/area/service/chapel)
 "iEU" = (
 /obj/item/clothing/suit/apron/chef,
 /turf/open/floor/plating,
@@ -39420,12 +39340,11 @@
 /turf/open/floor/iron,
 /area/engineering/main)
 "iGp" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/meter/monitored/layer2,
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating{
-	icon_state = "panelscorched"
+	luminosity = 2
 	},
-/area/maintenance/department/engine)
+/area/service/library)
 "iGx" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/structure/plasticflaps/opaque,
@@ -39440,37 +39359,29 @@
 /obj/structure/grille,
 /turf/open/floor/plating,
 /area/maintenance/department/science/xenobiology)
-"iHi" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
-/obj/machinery/camera/directional/east{
-	c_tag = "Virology Isolation A";
-	network = list("ss13","medbay")
-	},
-/turf/open/floor/iron/freezer,
-/area/medical/virology)
 "iIB" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/cargo/storage)
 "iJb" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/service/library/artgallery)
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/purple/anticorner/contrasted{
+	dir = 8
+	},
+/obj/machinery/airalarm/directional/south,
+/turf/open/floor/iron/white,
+/area/science/genetics)
 "iJI" = (
-/obj/structure/cable,
-/obj/machinery/door/airlock/maintenance{
-	req_access_txt = "12"
-	},
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
-	},
-/area/maintenance/department/medical)
+/obj/structure/table/wood,
+/obj/item/plate,
+/obj/item/kitchen/fork,
+/turf/open/floor/iron/checker,
+/area/service/chapel/monastery)
 "iKb" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -39514,6 +39425,22 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/medical/virology)
+"iMK" = (
+/obj/machinery/door/airlock/grunge{
+	name = "Chapel Office";
+	req_access_txt = "22"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/service/chapel/office)
+"iNe" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/iron/checker,
+/area/service/chapel/monastery)
 "iOj" = (
 /obj/structure/bodycontainer/morgue{
 	dir = 2
@@ -39658,15 +39585,14 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/warehouse)
+"jgn" = (
+/obj/machinery/computer/shuttle/monastery_shuttle{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/service/chapel/dock)
 "jgr" = (
-/obj/machinery/door/airlock/grunge{
-	name = "Library"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/light/small/directional/west,
 /turf/open/floor/iron/dark,
 /area/service/library)
 "jhk" = (
@@ -39746,6 +39672,12 @@
 	},
 /turf/closed/wall/r_wall,
 /area/engineering/main)
+"jmE" = (
+/obj/machinery/airalarm/directional/north{
+	pixel_y = 22
+	},
+/turf/open/floor/iron/dark,
+/area/service/chapel)
 "jnG" = (
 /obj/machinery/door/airlock/virology{
 	autoclose = 0;
@@ -39831,15 +39763,15 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "jsD" = (
-/obj/item/kirbyplants{
-	icon_state = "plant-21";
-	pixel_y = 3
+/obj/structure/flora/grass/jungle/b,
+/obj/structure/flora/ausbushes/lavendergrass,
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/machinery/door/window/left/directional/east{
+	dir = 1;
+	name = "Petting Garden"
 	},
-/obj/structure/sign/picture_frame/portrait{
-	pixel_y = 30
-	},
-/turf/open/floor/iron/dark,
-/area/service/chapel/office)
+/turf/open/floor/grass,
+/area/medical/psychology)
 "jtf" = (
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 1
@@ -39990,6 +39922,12 @@
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/department/science/xenobiology)
+"jEC" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/open/misc/asteroid,
+/area/service/chapel/asteroid/monastery)
 "jFw" = (
 /obj/effect/spawner/random/structure/crate,
 /turf/open/floor/plating,
@@ -40090,10 +40028,9 @@
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
 "jMS" = (
-/obj/effect/spawner/xmastree,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/carpet,
-/area/service/library)
+/obj/machinery/door/poddoor/massdriver_chapel,
+/turf/open/floor/plating,
+/area/service/chapel/funeral)
 "jNK" = (
 /obj/machinery/computer/cargo/request{
 	dir = 8
@@ -40128,16 +40065,9 @@
 /turf/open/floor/iron,
 /area/cargo/storage)
 "jOw" = (
-/obj/structure/table/wood/fancy,
-/obj/structure/sign/painting/library_secure{
-	pixel_y = -32
-	},
-/obj/machinery/light/dim,
-/obj/item/reagent_containers/food/drinks/trophy{
-	pixel_y = 10
-	},
-/turf/open/floor/iron/dark,
-/area/service/library/artgallery)
+/obj/item/beacon,
+/turf/open/floor/engine,
+/area/science/explab)
 "jOB" = (
 /turf/open/floor/plating,
 /area/commons/storage/emergency/starboard)
@@ -40223,10 +40153,23 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "jVS" = (
-/obj/effect/landmark/xeno_spawn,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/plating,
-/area/maintenance/department/medical)
+/obj/structure/table/glass,
+/obj/item/paper_bin{
+	layer = 2.9
+	},
+/obj/item/pen/red,
+/obj/item/stack/medical/gauze,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/item/hand_labeler,
+/obj/item/book/manual/wiki/infections,
+/obj/effect/turf_decal/tile/green/half/contrasted{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron/white,
+/area/medical/virology)
 "jVZ" = (
 /obj/machinery/navbeacon/wayfinding{
 	location = "Service Hall"
@@ -40253,11 +40196,15 @@
 /turf/open/floor/iron/dark,
 /area/engineering/atmos)
 "jXh" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/navbeacon/wayfinding{
+	location = "Art Gallery"
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
-/area/service/library/lounge)
+/area/service/library/artgallery)
 "jXA" = (
 /obj/structure/table,
 /obj/item/stack/ore/iron,
@@ -40277,17 +40224,6 @@
 	},
 /turf/closed/wall,
 /area/maintenance/department/cargo)
-"kaf" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
-	},
-/area/maintenance/department/engine)
 "kbV" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -40309,11 +40245,13 @@
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "kdF" = (
-/obj/structure/chair{
-	dir = 8
+/obj/machinery/light/small{
+	dir = 1
 	},
-/turf/open/floor/iron,
-/area/hallway/primary/central)
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/maintenance/department/engine)
 "kee" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -40333,13 +40271,15 @@
 /turf/open/floor/iron,
 /area/cargo/storage)
 "kfM" = (
-/obj/structure/closet,
-/obj/machinery/light/small,
-/obj/item/storage/book/bible,
-/obj/item/storage/book/bible,
-/obj/item/storage/book/bible,
-/turf/open/floor/carpet,
-/area/service/chapel/office)
+/obj/structure/chair/wood{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron/chapel{
+	dir = 8
+	},
+/area/service/chapel)
 "kfS" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -40547,13 +40487,11 @@
 /turf/open/floor/iron,
 /area/engineering/main)
 "kzj" = (
-/obj/structure/chair/wood,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/service/library/artgallery)
+/obj/effect/spawner/random/structure/crate,
+/turf/open/floor/plating{
+	icon_state = "platingdmg2"
+	},
+/area/maintenance/department/engine)
 "kAa" = (
 /obj/structure/chair{
 	dir = 8
@@ -40600,9 +40538,15 @@
 /turf/open/floor/iron,
 /area/engineering/lobby)
 "kDf" = (
-/obj/machinery/light/small,
-/turf/open/floor/carpet/black,
-/area/service/chapel/office)
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron/dark,
+/area/service/library/artgallery)
 "kDJ" = (
 /obj/machinery/light{
 	dir = 8
@@ -40674,13 +40618,12 @@
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
 "kFP" = (
-/obj/structure/table/wood,
-/obj/machinery/newscaster{
-	pixel_y = -32
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 8
 	},
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/service/library/artgallery)
+/turf/open/floor/plating,
+/area/service/chapel/asteroid/monastery)
 "kGb" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
@@ -40881,12 +40824,9 @@
 /turf/open/floor/plating,
 /area/construction/mining/aux_base)
 "kVM" = (
-/obj/structure/sign/painting/library_private{
-	pixel_x = 32
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/dark,
-/area/service/library/artgallery)
+/obj/structure/flora/junglebush/b,
+/turf/open/floor/grass,
+/area/medical/psychology)
 "kVN" = (
 /obj/machinery/door/airlock/medical/glass{
 	name = "Chemistry Lab";
@@ -40937,20 +40877,14 @@
 /turf/open/floor/grass,
 /area/medical/psychology)
 "kZU" = (
-/obj/structure/table/wood/fancy,
-/obj/structure/sign/painting/library_secure{
-	pixel_y = -32
+/obj/structure/window/reinforced{
+	dir = 8
 	},
-/obj/item/knife/combat/bone{
-	desc = "An old bone sharpened into a blade. It's rather dull nowadays.";
-	force = 8;
-	name = "ancient bone dagger";
-	pixel_y = 6;
-	throwforce = 8
+/obj/structure/window/reinforced{
+	dir = 1
 	},
-/obj/machinery/light/dim,
-/turf/open/floor/iron/dark,
-/area/service/library/artgallery)
+/turf/open/space/basic,
+/area/space/nearstation)
 "lba" = (
 /obj/structure/flora/ausbushes/lavendergrass,
 /obj/structure/flora/ausbushes/fullgrass,
@@ -41111,11 +41045,9 @@
 /turf/open/floor/iron,
 /area/commons/storage/primary)
 "lor" = (
-/obj/effect/spawner/random/structure/crate,
-/turf/open/floor/plating{
-	icon_state = "platingdmg2"
-	},
-/area/maintenance/department/engine)
+/obj/structure/chair/wood,
+/turf/open/floor/iron/checker,
+/area/service/chapel/monastery)
 "lov" = (
 /obj/effect/landmark/start/paramedic,
 /turf/open/floor/iron/white,
@@ -41126,27 +41058,24 @@
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
 "lqy" = (
-/obj/machinery/door/airlock/grunge{
-	name = "Library"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
-/area/service/library/lounge)
-"lrI" = (
-/obj/structure/table,
-/obj/item/storage/box/mousetraps,
-/turf/open/floor/plating,
-/area/maintenance/department/medical)
-"lsq" = (
-/obj/structure/transit_tube/curved{
+/obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 1
 	},
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/space/nearstation)
+/turf/open/floor/iron/dark,
+/area/service/library)
+"lrI" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/service/chapel)
+"lsq" = (
+/obj/structure/mopbucket,
+/obj/item/mop,
+/turf/open/floor/plating,
+/area/maintenance/department/medical)
 "lsr" = (
 /obj/effect/spawner/random/trash/botanical_waste,
 /turf/open/floor/iron/dark,
@@ -41168,17 +41097,19 @@
 /turf/open/space,
 /area/space/nearstation)
 "lto" = (
-/obj/structure/cable,
-/obj/machinery/light/dim{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/dark,
-/area/service/library/artgallery)
+/obj/structure/cable,
+/turf/open/floor/carpet,
+/area/service/chapel)
 "ltu" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
 /turf/closed/wall/r_wall,
 /area/maintenance/disposal/incinerator)
+"lvV" = (
+/obj/effect/spawner/random/trash/mess,
+/turf/open/floor/iron/dark,
+/area/service/chapel/funeral)
 "lxx" = (
 /obj/structure/table,
 /obj/item/stack/medical/gauze{
@@ -41202,9 +41133,11 @@
 /turf/open/floor/iron/freezer,
 /area/medical/virology)
 "lzJ" = (
-/obj/structure/closet/crate/bin,
-/turf/open/floor/carpet,
-/area/service/chapel/office)
+/obj/structure/sign/poster/official/bless_this_spess{
+	pixel_y = -32
+	},
+/turf/open/floor/iron/dark,
+/area/service/chapel)
 "lzZ" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/structure/cable,
@@ -41213,12 +41146,9 @@
 /turf/open/floor/iron/dark,
 /area/command/bridge)
 "lAf" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow,
-/turf/open/floor/iron/dark,
-/area/service/chapel/office)
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/service/chapel)
 "lAs" = (
 /turf/closed/wall,
 /area/security/checkpoint/supply)
@@ -41282,15 +41212,13 @@
 /turf/open/floor/iron/dark,
 /area/security/prison)
 "lGv" = (
-/obj/docking_port/stationary{
-	dwidth = 2;
-	height = 6;
-	id = "monastery_shuttle_asteroid";
-	name = "monastery";
-	width = 5
+/obj/structure/chair/wood{
+	dir = 8
 	},
-/turf/open/space,
-/area/space)
+/turf/open/floor/iron/chapel{
+	dir = 4
+	},
+/area/service/chapel)
 "lGS" = (
 /obj/item/clothing/mask/gas,
 /obj/item/clothing/mask/gas,
@@ -41323,11 +41251,9 @@
 /turf/open/floor/plating,
 /area/commons/storage/emergency/starboard)
 "lLQ" = (
-/obj/structure/disposalpipe/junction{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/engine)
+/obj/structure/closet/crate/bin,
+/turf/open/floor/iron/checker,
+/area/service/chapel/monastery)
 "lLS" = (
 /obj/machinery/conveyor{
 	dir = 8;
@@ -41342,15 +41268,12 @@
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
 "lNy" = (
-/obj/structure/sign/departments/science{
-	pixel_y = 32
-	},
-/obj/machinery/power/terminal{
-	dir = 8
-	},
+/obj/structure/chair/wood,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/department/engine)
+/turf/open/floor/carpet/black,
+/area/service/chapel/office)
 "lNW" = (
 /obj/effect/spawner/random/trash/graffiti,
 /turf/open/floor/plating,
@@ -41393,10 +41316,13 @@
 /turf/open/floor/iron/dark,
 /area/command/bridge)
 "lQX" = (
-/obj/machinery/smartfridge/petri/preloaded,
-/obj/machinery/firealarm/directional/south,
+/obj/item/clothing/under/misc/burial,
+/obj/item/clothing/under/misc/burial,
+/obj/item/clothing/under/misc/burial,
+/obj/item/clothing/under/misc/burial,
+/obj/structure/table/wood,
 /turf/open/floor/iron/dark,
-/area/science/xenobiology)
+/area/service/chapel/funeral)
 "lRS" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron/dark,
@@ -41613,14 +41539,12 @@
 /turf/open/floor/wood,
 /area/service/lawoffice)
 "mpU" = (
-/obj/structure/window/reinforced{
-	dir = 8;
-	layer = 2.9
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
 	},
-/obj/structure/lattice/catwalk,
-/obj/structure/transit_tube/crossing/horizontal,
-/turf/open/space,
-/area/space/nearstation)
+/turf/open/floor/iron/dark,
+/area/service/library/lounge)
 "mqg" = (
 /obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 4
@@ -41704,6 +41628,13 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/tcommsat/computer)
+"mxQ" = (
+/obj/structure/chair/wood{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/service/library)
 "mxV" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -41787,6 +41718,10 @@
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/open/floor/grass,
 /area/medical/storage)
+"mAq" = (
+/obj/structure/table/wood/fancy,
+/turf/open/floor/carpet,
+/area/service/library/lounge)
 "mBU" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
@@ -41803,9 +41738,7 @@
 /turf/open/floor/plating,
 /area/security/checkpoint/engineering)
 "mDW" = (
-/obj/machinery/power/terminal{
-	dir = 8
-	},
+/obj/machinery/power/port_gen/pacman,
 /turf/open/floor/plating,
 /area/tcommsat/computer)
 "mES" = (
@@ -41816,11 +41749,9 @@
 /turf/open/floor/plating,
 /area/maintenance/department/science/xenobiology)
 "mFu" = (
-/obj/machinery/light/dim{
-	dir = 4
-	},
+/obj/machinery/light/small/directional/west,
 /turf/open/floor/iron/dark,
-/area/service/library/artgallery)
+/area/service/chapel/office)
 "mHy" = (
 /obj/item/storage/fancy/cigarettes/cigpack_shadyjims,
 /turf/open/floor/wood,
@@ -41832,10 +41763,18 @@
 	},
 /area/maintenance/department/science/xenobiology)
 "mIa" = (
+/obj/effect/spawner/random/maintenance,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron,
-/area/science/robotics/lab)
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
+"mIc" = (
+/obj/machinery/shower{
+	dir = 8
+	},
+/obj/item/bikehorn/rubberducky,
+/turf/open/floor/iron/showroomfloor,
+/area/service/chapel/monastery)
 "mIW" = (
 /obj/machinery/atmospherics/components/binary/thermomachine/heater{
 	dir = 4
@@ -41852,16 +41791,20 @@
 /turf/open/floor/iron,
 /area/security/brig)
 "mKc" = (
-/obj/structure/bookcase/random/nonfiction,
-/turf/open/floor/iron/dark,
-/area/service/library/lounge)
-"mKz" = (
-/obj/machinery/holopad,
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
-/turf/open/floor/iron,
-/area/science/robotics/lab)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/service/chapel/dock)
+"mKz" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/service/chapel/monastery)
 "mKE" = (
 /turf/closed/wall,
 /area/medical/medbay/lobby)
@@ -41977,12 +41920,10 @@
 /turf/open/floor/iron,
 /area/cargo/storage)
 "mTp" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/service/library/artgallery)
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
 "mTS" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -42033,11 +41974,9 @@
 /turf/open/floor/carpet/purple,
 /area/medical/psychology)
 "nbP" = (
-/obj/effect/spawner/random/maintenance,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/department/engine)
+/obj/machinery/skill_station,
+/turf/open/floor/iron/dark,
+/area/service/library/lounge)
 "ndc" = (
 /obj/structure/table/reinforced,
 /obj/machinery/button/door{
@@ -42203,18 +42142,16 @@
 /turf/open/floor/iron/dark,
 /area/service/library/artgallery)
 "njB" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
-/area/service/library/artgallery)
-"nku" = (
-/obj/machinery/door/airlock/grunge{
-	name = "Crematorium";
-	req_access_txt = "27"
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/service/chapel)
+"nku" = (
+/obj/structure/sign/picture_frame/portrait{
+	pixel_x = -30
+	},
 /turf/open/floor/iron/dark,
 /area/service/chapel/office)
 "nls" = (
@@ -42234,6 +42171,10 @@
 	},
 /turf/open/floor/plating,
 /area/engineering/supermatter)
+"nmI" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron/dark,
+/area/service/chapel/dock)
 "nnf" = (
 /obj/machinery/navbeacon/wayfinding/incinerator,
 /obj/machinery/door/airlock/atmos{
@@ -42339,9 +42280,14 @@
 /turf/open/floor/iron/dark,
 /area/engineering/atmos/hfr_room)
 "nvG" = (
-/obj/effect/spawner/random/trash/mess,
+/obj/machinery/door/airlock/grunge{
+	name = "Art Gallery"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
-/area/service/chapel/office)
+/area/service/library/artgallery)
 "nwg" = (
 /obj/effect/spawner/random/trash/cigbutt,
 /turf/open/floor/iron,
@@ -42395,10 +42341,6 @@
 	},
 /turf/open/floor/engine,
 /area/engineering/main)
-"nAp" = (
-/obj/effect/landmark/xeno_spawn,
-/turf/open/floor/plating,
-/area/maintenance/department/engine)
 "nAs" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -42420,11 +42362,13 @@
 /turf/open/floor/carpet,
 /area/security/detectives_office)
 "nBO" = (
-/obj/machinery/light/dim{
-	dir = 8
+/obj/machinery/camera/directional/west{
+	c_tag = "Monastery Garden Port";
+	network = list("ss13","monastery")
 	},
+/obj/machinery/light/small/directional/west,
 /turf/open/floor/iron/dark,
-/area/service/library/artgallery)
+/area/service/chapel/monastery)
 "nCe" = (
 /obj/machinery/smartfridge/chemistry/virology/preloaded,
 /obj/effect/turf_decal/tile/green/half/contrasted{
@@ -42544,15 +42488,17 @@
 /turf/open/floor/engine,
 /area/science/explab)
 "nKQ" = (
-/obj/structure/sign/painting/library_private{
-	pixel_x = 32
+/obj/machinery/light/small{
+	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
+/obj/machinery/door/window/right/directional/north{
+	dir = 2;
+	name = "Curator Desk Door";
+	req_access_txt = "37"
 	},
+/obj/effect/turf_decal/tile/purple/half/contrasted,
 /turf/open/floor/iron/dark,
-/area/service/library/artgallery)
+/area/service/library)
 "nMG" = (
 /obj/item/radio/intercom{
 	pixel_y = 26
@@ -42577,9 +42523,11 @@
 /turf/open/floor/engine,
 /area/engineering/main)
 "nMV" = (
-/obj/effect/spawner/random/trash/hobo_squat,
-/turf/open/floor/plating,
-/area/maintenance/department/medical)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/service/chapel)
 "nNk" = (
 /obj/machinery/recharge_station,
 /obj/effect/turf_decal/stripes/line{
@@ -42612,13 +42560,10 @@
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
 "nPg" = (
-/mob/living/simple_animal/pet/dog/corgi,
-/obj/structure/water_source/puddle,
-/obj/structure/flora/ausbushes/reedbush{
-	pixel_y = 6
-	},
-/turf/open/floor/grass,
-/area/medical/psychology)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/junction,
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
 "nPh" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -42626,12 +42571,11 @@
 /turf/open/floor/iron,
 /area/engineering/main)
 "nPm" = (
-/obj/machinery/light/dim{
-	dir = 1
+/obj/structure/cable,
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
 	},
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/service/library/artgallery)
+/area/maintenance/department/medical)
 "nPn" = (
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
@@ -42649,10 +42593,9 @@
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
 "nQb" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/service/library/artgallery)
+/obj/effect/spawner/random/trash/graffiti,
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
 "nQc" = (
 /obj/structure/table,
 /obj/item/stack/sheet/iron/fifty,
@@ -42671,6 +42614,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
 /turf/open/floor/engine,
 /area/engineering/main)
+"nRK" = (
+/obj/structure/sign/painting/library_private{
+	pixel_x = -32
+	},
+/obj/structure/sign/painting/library_private{
+	pixel_y = -32
+	},
+/turf/open/floor/iron/dark,
+/area/service/library/artgallery)
 "nSe" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment,
@@ -42763,11 +42715,12 @@
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "nWF" = (
-/obj/structure/sign/painting/library_private{
-	pixel_x = 32
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/turf/open/floor/iron/dark,
-/area/service/library/artgallery)
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
 "nWP" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
@@ -43090,11 +43043,16 @@
 /turf/open/floor/iron,
 /area/engineering/main)
 "ouv" = (
-/obj/structure/grille/broken,
-/turf/open/floor/plating{
-	luminosity = 2
+/obj/structure/table/wood/fancy,
+/obj/structure/sign/painting/library_secure{
+	pixel_y = -32
 	},
-/area/maintenance/department/medical)
+/obj/item/reagent_containers/food/drinks/trophy{
+	pixel_y = 10
+	},
+/obj/machinery/light/dim/directional/south,
+/turf/open/floor/iron/dark,
+/area/service/library/artgallery)
 "ovM" = (
 /obj/machinery/camera/directional/north{
 	c_tag = "Arrivals Port Fore"
@@ -43118,16 +43076,22 @@
 	},
 /turf/open/floor/iron/dark,
 /area/service/chapel/office)
-"oya" = (
-/obj/machinery/camera/directional/east{
-	c_tag = "Monastery Art Gallery";
-	network = list("ss13","monastery")
+"oxb" = (
+/obj/machinery/door/airlock/grunge{
+	name = "Art Storage"
 	},
-/obj/machinery/navbeacon/wayfinding{
-	location = "Art Gallery"
-	},
-/turf/open/floor/carpet,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
 /area/service/library/artgallery)
+"oya" = (
+/obj/machinery/holopad,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/science/robotics/lab)
 "oyF" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
@@ -43175,6 +43139,13 @@
 /obj/effect/landmark/start/lawyer,
 /turf/open/floor/carpet,
 /area/service/lawoffice)
+"oCw" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/service/library/lounge)
 "oCX" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -43298,9 +43269,10 @@
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "oKD" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
-/turf/open/floor/plating,
-/area/maintenance/department/medical)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/checker,
+/area/service/chapel/monastery)
 "oKI" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -43495,6 +43467,18 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/sorting)
+"oZy" = (
+/obj/docking_port/stationary{
+	dwidth = 2;
+	height = 6;
+	id = "monastery_shuttle_asteroid";
+	name = "Monastery Aft";
+	width = 5;
+	dir = 2
+	},
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space/nearstation)
 "pbm" = (
 /obj/machinery/door/airlock/external{
 	name = "Pod Docking Bay"
@@ -43534,9 +43518,14 @@
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
 "pds" = (
-/obj/structure/sign/poster/official/corporate_perks_vacation,
-/turf/closed/wall,
-/area/maintenance/department/engine)
+/obj/machinery/atmospherics/components/unary/passive_vent/layer2{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "pdW" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -43621,11 +43610,11 @@
 /turf/open/floor/iron/dark,
 /area/medical/morgue)
 "pkM" = (
-/obj/machinery/door/airlock/external{
-	req_access_txt = "22"
-	},
-/turf/open/floor/plating,
-/area/service/chapel/office)
+/obj/structure/closet/emcloset,
+/obj/effect/decal/cleanable/cobweb,
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/iron/dark,
+/area/service/chapel)
 "pkU" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobio7";
@@ -43675,12 +43664,11 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "pnF" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/power/terminal,
 /turf/open/floor/plating,
-/area/maintenance/department/engine)
+/area/maintenance/department/chapel/monastery)
 "pnU" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
 	dir = 4;
@@ -43713,6 +43701,9 @@
 /obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
+"pqe" = (
+/turf/open/space/basic,
+/area/space/nearstation)
 "prD" = (
 /obj/vehicle/ridden/wheelchair{
 	dir = 8
@@ -43764,6 +43755,13 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
+"pyQ" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/firealarm/directional/west,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/service/library/artgallery)
 "pzm" = (
 /obj/effect/spawner/random/trash/mess,
 /turf/open/floor/plating{
@@ -43841,13 +43839,9 @@
 /turf/open/floor/carpet/purple,
 /area/medical/psychology)
 "pEv" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/plating{
-	icon_state = "platingdmg1"
-	},
-/area/maintenance/department/engine)
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/service/library/lounge)
 "pEL" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -43864,6 +43858,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
+"pFM" = (
+/obj/structure/cable,
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
+/area/maintenance/department/engine)
 "pFS" = (
 /obj/machinery/computer/atmos_control/nocontrol/ordnancemix{
 	dir = 8
@@ -43900,6 +43900,14 @@
 "pHo" = (
 /turf/open/floor/wood,
 /area/command/heads_quarters/hop)
+"pHK" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/machinery/light/small/directional/east,
+/turf/open/floor/iron/dark,
+/area/service/chapel/monastery)
 "pHN" = (
 /obj/structure/chair/sofa{
 	dir = 8
@@ -43929,11 +43937,15 @@
 /turf/open/floor/plating,
 /area/maintenance/department/science)
 "pIy" = (
-/obj/structure/sign/painting/library{
-	pixel_y = 32
+/obj/structure/table/wood,
+/obj/item/paper_bin{
+	layer = 2.9;
+	pixel_x = -2;
+	pixel_y = 4
 	},
+/obj/item/pen,
 /turf/open/floor/iron/dark,
-/area/service/library/artgallery)
+/area/service/library/lounge)
 "pIW" = (
 /obj/structure/closet/l3closet/scientist,
 /obj/structure/sign/warning/nosmoking{
@@ -44016,6 +44028,11 @@
 /obj/machinery/light/small,
 /turf/open/floor/iron/freezer,
 /area/medical/virology)
+"pOp" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/iron/dark,
+/area/service/library)
 "pOr" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -44037,27 +44054,25 @@
 /turf/open/floor/iron/white,
 /area/medical/exam_room)
 "pQA" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/carpet,
-/area/service/library/artgallery)
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/condiment/saltshaker{
+	layer = 3.1;
+	pixel_x = -2;
+	pixel_y = 2
+	},
+/obj/item/reagent_containers/food/condiment/peppermill{
+	pixel_x = 5;
+	pixel_y = 6
+	},
+/turf/open/floor/iron/checker,
+/area/service/chapel/monastery)
 "pQQ" = (
-/obj/structure/table/glass,
-/obj/item/paper_bin{
-	layer = 2.9
+/obj/structure/chair/wood{
+	dir = 8
 	},
-/obj/item/pen/red,
-/obj/item/stack/medical/gauze,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/item/hand_labeler,
-/obj/item/book/manual/wiki/infections,
-/obj/effect/turf_decal/tile/green/half/contrasted{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron/white,
-/area/medical/virology)
+/obj/item/radio/intercom/directional/east,
+/turf/open/floor/iron/checker,
+/area/service/chapel/monastery)
 "pTy" = (
 /obj/structure/flora/grass/jungle,
 /obj/structure/flora/ausbushes/brflowers,
@@ -44088,6 +44103,15 @@
 /turf/open/floor/wood{
 	icon_state = "wood-broken5"
 	},
+/area/maintenance/department/engine)
+"pWe" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/sorting/mail/flip{
+	dir = 1;
+	sortType = 27
+	},
+/turf/open/floor/plating,
 /area/maintenance/department/engine)
 "pWm" = (
 /obj/machinery/door/window/left/directional/south{
@@ -44210,11 +44234,9 @@
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
 "qdj" = (
-/obj/structure/cable,
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
-	},
-/area/maintenance/department/medical)
+/obj/item/radio/intercom/directional/north,
+/turf/open/floor/iron/dark,
+/area/service/library)
 "qgq" = (
 /obj/effect/spawner/random/trash/grime,
 /turf/open/floor/plating,
@@ -44367,10 +44389,10 @@
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "qpT" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/transit_tube/horizontal,
-/turf/open/space/basic,
-/area/space/nearstation)
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron,
+/area/science/robotics/lab)
 "qqa" = (
 /obj/structure/window/reinforced/plasma/spawner/west,
 /obj/structure/cable,
@@ -44454,11 +44476,14 @@
 /turf/open/floor/engine/vacuum,
 /area/maintenance/disposal/incinerator)
 "qvx" = (
-/obj/effect/turf_decal/tile/purple/half/contrasted{
-	dir = 1
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/iron/white,
 /area/science/genetics)
@@ -44492,9 +44517,8 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/binary/pump/on{
-	name = "Air Out"
-	},
+/obj/structure/cable,
+/obj/machinery/power/terminal,
 /turf/open/floor/plating,
 /area/tcommsat/computer)
 "qxU" = (
@@ -44517,13 +44541,14 @@
 /turf/open/floor/iron,
 /area/commons/storage/primary)
 "qCG" = (
-/obj/machinery/light/small{
-	dir = 1
+/obj/machinery/door/airlock/grunge{
+	name = "Obsequy"
 	},
-/turf/open/floor/plating{
-	icon_state = "platingdmg3"
-	},
-/area/maintenance/department/engine)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/service/chapel/funeral)
 "qEf" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -44842,15 +44867,14 @@
 /turf/open/floor/wood,
 /area/maintenance/department/engine)
 "reR" = (
-/obj/structure/table/wood,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/airalarm/directional/north{
-	pixel_y = 22
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/extinguisher_cabinet/directional/west,
+/obj/machinery/light/small{
+	brightness = 3;
+	dir = 8
 	},
-/obj/effect/decal/cleanable/cobweb,
-/obj/item/camera,
 /turf/open/floor/iron/dark,
-/area/service/library/artgallery)
+/area/service/chapel/monastery)
 "reV" = (
 /obj/structure/table,
 /obj/item/storage/toolbox/mechanical,
@@ -44903,21 +44927,16 @@
 	},
 /area/maintenance/department/engine)
 "rhT" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/spawner/random/trash/grime,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
-/turf/open/floor/plating,
-/area/maintenance/department/engine)
-"rie" = (
-/obj/structure/chair/wood{
-	dir = 8
-	},
+/obj/structure/table/wood,
+/obj/machinery/light/dim/directional/east,
 /turf/open/floor/iron/dark,
 /area/service/library/artgallery)
+"rie" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating{
+	icon_state = "platingdmg2"
+	},
+/area/maintenance/department/medical)
 "riF" = (
 /obj/effect/spawner/random/entertainment/arcade,
 /obj/effect/turf_decal/tile/neutral{
@@ -44981,12 +45000,15 @@
 /area/service/hydroponics)
 "rnr" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
 "rnE" = (
-/obj/structure/flora/junglebush/b,
-/turf/open/floor/grass,
-/area/medical/psychology)
+/obj/structure/chair,
+/obj/item/cigbutt,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
 "roa" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -44997,9 +45019,9 @@
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
 "roy" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/photocopier,
 /turf/open/floor/iron/dark,
-/area/service/library/artgallery)
+/area/service/library)
 "rpX" = (
 /obj/structure/sign/poster/contraband/random{
 	pixel_x = -32
@@ -45039,9 +45061,7 @@
 	},
 /area/maintenance/department/security/brig)
 "rrU" = (
-/obj/effect/turf_decal/tile/red/anticorner/contrasted{
-	dir = 1
-	},
+/obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron/dark,
 /area/service/chapel/office)
 "rse" = (
@@ -45085,12 +45105,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/hos)
-"rtA" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/engine)
 "rtD" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -45211,14 +45225,19 @@
 /turf/open/floor/engine,
 /area/medical/chemistry)
 "rzp" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/structure/disposalpipe/junction/yjunction{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
-/turf/open/floor/plating,
-/area/maintenance/department/engine)
+/obj/structure/closet/crate,
+/obj/item/canvas/twentythree_twentythree,
+/obj/item/canvas/twentythree_twentythree,
+/obj/item/canvas/twentythree_twentythree,
+/obj/item/canvas/twentythree_nineteen,
+/obj/item/canvas/twentythree_nineteen,
+/obj/item/canvas/twentythree_nineteen,
+/obj/item/canvas/nineteen_nineteen,
+/obj/item/canvas/nineteen_nineteen,
+/obj/item/canvas/nineteen_nineteen,
+/obj/item/wirecutters,
+/turf/open/floor/iron/dark,
+/area/service/library/artgallery)
 "rAE" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -45355,10 +45374,11 @@
 /turf/open/floor/iron/white,
 /area/medical/exam_room)
 "rJg" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/maintenance/department/engine)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/carpet,
+/area/service/library)
 "rJZ" = (
 /obj/docking_port/stationary{
 	dheight = 3;
@@ -45418,9 +45438,9 @@
 /turf/open/floor/plating,
 /area/cargo/sorting)
 "rMV" = (
-/turf/open/floor/plating{
-	icon_state = "platingdmg1"
-	},
+/obj/structure/rack,
+/obj/effect/spawner/random/entertainment/drugs,
+/turf/open/floor/plating,
 /area/maintenance/department/medical)
 "rMZ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -45513,10 +45533,13 @@
 /turf/open/floor/iron/dark,
 /area/service/bar)
 "rXJ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/sign/departments/science{
+	pixel_y = 32
 	},
+/obj/machinery/power/terminal{
+	dir = 8
+	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "rXT" = (
@@ -45788,9 +45811,14 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "stQ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
-/turf/closed/wall,
-/area/maintenance/department/engine)
+/obj/item/kirbyplants{
+	icon_state = "plant-22"
+	},
+/obj/structure/sign/poster/official/anniversary_vintage_reprint{
+	pixel_y = -32
+	},
+/turf/open/floor/iron/dark,
+/area/service/library)
 "sut" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -45886,23 +45914,26 @@
 /turf/open/floor/iron,
 /area/security/brig)
 "sBW" = (
-/obj/structure/closet/crate/bin,
-/obj/item/reagent_containers/glass/rag,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/dark,
-/area/service/library/artgallery)
+/obj/structure/cable,
+/obj/structure/sign/poster/contraband/arc_slimes{
+	pixel_x = -32
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/science/xenobiology)
 "sCf" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/purple/visible,
 /turf/open/space/basic,
 /area/space/nearstation)
 "sDQ" = (
-/obj/structure/transit_tube/curved/flipped{
+/obj/machinery/mass_driver/chapelgun{
 	dir = 8
 	},
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/space/nearstation)
+/obj/machinery/door/window/left/directional/east{
+	name = "Mass Driver"
+	},
+/turf/open/floor/iron/dark,
+/area/service/chapel/funeral)
 "sEz" = (
 /obj/machinery/pinpointer_dispenser,
 /turf/closed/wall/r_wall,
@@ -45969,12 +46000,17 @@
 /turf/open/floor/iron,
 /area/engineering/main)
 "sKe" = (
-/obj/effect/turf_decal/tile/neutral/half/contrasted,
-/obj/structure/sink{
-	pixel_y = 20
+/obj/structure/disposalpipe/segment{
+	dir = 6
 	},
-/turf/open/floor/iron/dark,
-/area/science/genetics)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/item/kirbyplants{
+	icon_state = "plant-21"
+	},
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/maintenance/department/engine)
 "sLv" = (
 /obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 8
@@ -46069,12 +46105,17 @@
 /turf/open/floor/engine,
 /area/engineering/main)
 "sXi" = (
-/obj/structure/table,
-/obj/item/folder,
-/obj/item/pen,
-/obj/machinery/light/small,
-/turf/open/floor/iron,
-/area/hallway/secondary/entry)
+/obj/item/extinguisher,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden,
+/turf/open/floor/plating,
+/area/maintenance/department/chapel/monastery)
+"sXx" = (
+/obj/structure/lattice,
+/obj/structure/transit_tube/curved/flipped{
+	dir = 8
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "sXR" = (
 /obj/structure/disposalpipe/junction,
 /turf/closed/wall/r_wall,
@@ -46086,9 +46127,11 @@
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
 "sYe" = (
-/obj/machinery/pinpointer_dispenser,
-/turf/closed/wall,
-/area/service/chapel/monastery)
+/obj/structure/chair/wood{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/service/library)
 "sYp" = (
 /obj/machinery/drone_dispenser,
 /turf/open/floor/plating,
@@ -46148,16 +46191,8 @@
 /turf/open/floor/iron/white,
 /area/medical/exam_room)
 "tan" = (
-/obj/machinery/door/airlock/grunge{
-	name = "Chapel Office";
-	req_access_txt = "22"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/light/small/directional/north,
+/obj/machinery/light_switch/directional/north,
 /turf/open/floor/iron/dark,
 /area/service/chapel/office)
 "taA" = (
@@ -46308,9 +46343,8 @@
 /area/maintenance/department/cargo)
 "tix" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
-/obj/machinery/atmospherics/components/unary/outlet_injector/on/layer2{
-	dir = 1;
-	name = "Outlet Injector"
+/obj/machinery/atmospherics/components/unary/passive_vent/layer2{
+	dir = 1
 	},
 /turf/open/floor/plating/airless,
 /area/engineering/atmos)
@@ -46365,21 +46399,19 @@
 /turf/open/floor/plating,
 /area/maintenance/port/lesser)
 "tml" = (
-/obj/machinery/light{
-	dir = 8
+/obj/structure/table/wood/fancy,
+/obj/item/candle,
+/obj/item/candle{
+	pixel_x = 6;
+	pixel_y = 8
 	},
-/obj/machinery/requests_console{
-	department = "Virology";
-	name = "Virology Requests Console";
-	pixel_x = -32;
-	receive_ore_updates = 1
+/obj/item/candle{
+	pixel_x = -8;
+	pixel_y = 6
 	},
-/obj/effect/turf_decal/tile/green/half/contrasted{
-	dir = 8
-	},
-/obj/machinery/vending/wardrobe/viro_wardrobe,
-/turf/open/floor/iron/white,
-/area/medical/virology)
+/obj/item/radio/intercom/directional/north,
+/turf/open/floor/iron/dark,
+/area/service/chapel/funeral)
 "tnY" = (
 /obj/machinery/button/door{
 	id = "aux_base_shutters";
@@ -46406,13 +46438,13 @@
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "tpI" = (
-/obj/structure/window/reinforced{
-	dir = 4
+/obj/structure/chair/wood{
+	dir = 8
 	},
-/obj/structure/lattice,
-/obj/structure/window/reinforced,
-/turf/open/space,
-/area/space/nearstation)
+/turf/open/floor/iron/chapel{
+	dir = 1
+	},
+/area/service/chapel)
 "tqC" = (
 /turf/closed/wall,
 /area/medical/storage)
@@ -46518,10 +46550,14 @@
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "txB" = (
-/obj/structure/bookcase/random/adult,
-/obj/machinery/light/small,
-/turf/open/floor/iron/dark,
-/area/service/library/lounge)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/structure/disposalpipe/junction/yjunction{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
 "typ" = (
 /obj/structure/table/glass,
 /obj/item/hemostat,
@@ -46547,14 +46583,17 @@
 /turf/open/floor/iron/white,
 /area/medical/exam_room)
 "tBb" = (
-/obj/machinery/camera/directional/west{
-	c_tag = "Monastery Art Storage";
-	network = list("ss13","monastery")
+/obj/structure/bed,
+/obj/item/bedsheet/green,
+/obj/machinery/button/door{
+	id = "Cell1";
+	name = "Cell Bolt Control";
+	normaldoorcontrol = 1;
+	pixel_x = 25;
+	specialfunctions = 4
 	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/dark,
-/area/service/library/artgallery)
+/turf/open/floor/iron/grimy,
+/area/service/chapel/monastery)
 "tBP" = (
 /obj/effect/spawner/random/structure/crate,
 /obj/structure/disposalpipe/segment{
@@ -46615,13 +46654,13 @@
 /turf/open/floor/iron/white,
 /area/medical/storage)
 "tFt" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/painting/library_private{
-	pixel_x = -32
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/iron/dark,
-/area/service/library/artgallery)
+/obj/structure/cable,
+/obj/structure/rack,
+/obj/item/storage/toolbox/mechanical,
+/obj/item/storage/box/lights/bulbs,
+/obj/item/stack/cable_coil,
+/turf/open/floor/plating,
+/area/maintenance/department/chapel/monastery)
 "tHk" = (
 /obj/machinery/door/firedoor,
 /obj/structure/sign/directions/security{
@@ -46660,8 +46699,8 @@
 /turf/open/floor/iron,
 /area/cargo/storage)
 "tJH" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/iron/dark,
 /area/service/library/artgallery)
 "tJX" = (
@@ -46673,11 +46712,9 @@
 /turf/open/floor/engine,
 /area/engineering/main)
 "tKm" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/service/library/artgallery)
+/obj/structure/closet/firecloset,
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
 "tKt" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/newscaster{
@@ -46723,6 +46760,10 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
+"tOP" = (
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/iron/dark,
+/area/service/chapel/funeral)
 "tPm" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -46852,15 +46893,14 @@
 /turf/open/floor/iron/white,
 /area/medical/exam_room)
 "tXV" = (
-/obj/machinery/door/airlock/grunge{
-	name = "Art Gallery"
-	},
 /obj/structure/cable,
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
-/area/service/library/artgallery)
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 8;
+	name = "Air Out"
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/chapel/monastery)
 "tYu" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/maintenance,
@@ -46868,24 +46908,30 @@
 /turf/open/floor/iron,
 /area/cargo/storage)
 "tYF" = (
-/obj/effect/turf_decal/stripes/line{
+/obj/machinery/light/small{
 	dir = 1
 	},
-/obj/machinery/atmospherics/components/unary/outlet_injector/on/layer2{
-	dir = 1;
-	name = "Outlet Injector"
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/turf/open/floor/plating/airless,
-/area/maintenance/department/chapel/monastery)
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
 "tYU" = (
 /obj/structure/reflector/box/anchored,
 /turf/open/floor/plating,
 /area/engineering/main)
 "tZa" = (
+/obj/machinery/door/airlock/grunge{
+	name = "Art Gallery"
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plating,
-/area/maintenance/department/engine)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/service/library)
 "uaC" = (
 /obj/structure/chair/comfy/black{
 	dir = 8
@@ -47101,26 +47147,23 @@
 /turf/open/floor/iron/white,
 /area/command/heads_quarters/cmo)
 "umO" = (
-/obj/machinery/door/morgue{
-	name = "Private Exhibit";
-	req_access_txt = "37"
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/closet/crate/bin,
+/obj/item/reagent_containers/glass/rag,
 /turf/open/floor/iron/dark,
 /area/service/library/artgallery)
 "umV" = (
-/obj/structure/bed,
-/obj/item/bedsheet/medical,
-/turf/open/floor/iron/freezer,
-/area/medical/virology)
-"und" = (
-/obj/effect/spawner/atmos_canister/air,
-/obj/machinery/light/small{
+/obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 1
 	},
-/turf/open/floor/plating,
-/area/maintenance/department/medical)
+/obj/structure/sign/poster/official/nanomichi_ad{
+	pixel_x = 32
+	},
+/turf/open/floor/iron/dark,
+/area/service/library)
+"und" = (
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/carpet,
+/area/service/library)
 "uok" = (
 /obj/structure/cable,
 /obj/effect/spawner/random/trash/garbage,
@@ -47174,18 +47217,12 @@
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "urP" = (
-/obj/structure/flora/grass/jungle/b,
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/machinery/camera/directional/west{
-	c_tag = "Genetics Monkey Pen Fore";
-	network = list("ss13","medbay")
+/obj/machinery/door/airlock/maintenance{
+	name = "Monastery Maintenance";
+	req_one_access_txt = "22;24;10;11;37;12"
 	},
-/obj/machinery/light/small{
-	dir = 8
-	},
-/mob/living/simple_animal/butterfly,
-/turf/open/floor/grass,
-/area/medical/psychology)
+/turf/open/floor/plating,
+/area/maintenance/department/chapel/monastery)
 "usl" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
 /turf/open/floor/iron/dark,
@@ -47268,6 +47305,12 @@
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
+/area/maintenance/department/medical)
+"uyZ" = (
+/obj/structure/grille/broken,
+/turf/open/floor/plating{
+	luminosity = 2
+	},
 /area/maintenance/department/medical)
 "uzn" = (
 /obj/structure/cable,
@@ -47360,9 +47403,9 @@
 /turf/open/floor/iron,
 /area/construction/mining/aux_base)
 "uDA" = (
-/obj/machinery/navbeacon/wayfinding/chapel,
+/obj/machinery/light/small/directional/south,
 /turf/open/floor/iron/dark,
-/area/service/chapel/monastery)
+/area/service/library/lounge)
 "uDR" = (
 /obj/docking_port/stationary{
 	dir = 4;
@@ -47425,10 +47468,11 @@
 /turf/open/floor/iron,
 /area/security)
 "uIv" = (
-/obj/structure/bookcase/random/adult,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/dark,
-/area/service/library/artgallery)
+/obj/machinery/atmospherics/components/unary/passive_vent/layer2{
+	dir = 4
+	},
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "uKD" = (
 /obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 1
@@ -47439,10 +47483,9 @@
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
 "uLp" = (
-/obj/structure/cable,
-/obj/structure/reagent_dispensers/watertank,
-/turf/open/floor/plating,
-/area/maintenance/department/medical)
+/obj/machinery/vending/games,
+/turf/open/floor/iron/dark,
+/area/service/library/lounge)
 "uLF" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/red{
@@ -47689,12 +47732,11 @@
 /turf/open/floor/iron,
 /area/commons/fitness/recreation)
 "vek" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/table/wood/fancy,
+/obj/item/folder,
+/obj/item/pen,
 /turf/open/floor/iron/dark,
-/area/service/library/artgallery)
+/area/service/chapel/funeral)
 "veM" = (
 /obj/effect/turf_decal/loading_area{
 	dir = 4
@@ -47749,11 +47791,10 @@
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "viB" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/science/robotics/lab)
+/obj/machinery/light/small/directional/north,
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/iron/dark,
+/area/service/library/lounge)
 "vjH" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/reagent_dispensers/fueltank/large,
@@ -47832,11 +47873,9 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "vmY" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
-	},
-/area/maintenance/department/medical)
+/obj/machinery/oven,
+/turf/open/floor/iron,
+/area/service/chapel/monastery)
 "voI" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -47944,14 +47983,11 @@
 /turf/open/floor/plating,
 /area/maintenance/department/science/xenobiology)
 "vvY" = (
-/obj/structure/cable,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 24
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/table/wood/fancy,
+/obj/item/storage/book/bible,
+/obj/machinery/light/small/directional/north,
 /turf/open/floor/iron/dark,
-/area/service/library/artgallery)
+/area/service/chapel/funeral)
 "vxg" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -48017,29 +48053,15 @@
 /turf/closed/wall/r_wall,
 /area/engineering/main)
 "vFZ" = (
-/obj/structure/chair/wood{
-	dir = 1
-	},
-/obj/item/radio/intercom/chapel{
-	pixel_x = 29
-	},
+/obj/machinery/vending/wardrobe/curator_wardrobe,
+/obj/machinery/light/small/directional/east,
 /turf/open/floor/iron/dark,
-/area/service/chapel/monastery)
+/area/service/library)
 "vGg" = (
-/obj/effect/turf_decal/tile/green/anticorner/contrasted{
-	dir = 4
-	},
-/obj/machinery/camera/directional/east{
-	c_tag = "Virology Lab";
-	network = list("ss13","medbay")
-	},
-/obj/machinery/disposal/bin,
-/obj/structure/sign/warning/deathsposal{
-	pixel_y = 32
-	},
-/obj/structure/disposalpipe/trunk,
-/turf/open/floor/iron/white,
-/area/medical/virology)
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
 "vHj" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -48096,7 +48118,7 @@
 /turf/open/floor/engine,
 /area/science/misc_lab)
 "vKD" = (
-/obj/machinery/power/energy_accumulator/tesla_coil/anchored,
+/obj/machinery/power/port_gen/pacman,
 /turf/open/floor/plating,
 /area/engineering/main)
 "vLy" = (
@@ -48126,17 +48148,10 @@
 /turf/open/floor/iron,
 /area/commons/fitness/recreation)
 "vOw" = (
-/obj/machinery/door/airlock/grunge{
-	name = "Library"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/obj/machinery/door/firedoor,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/dark,
-/area/service/library)
+/obj/item/chair,
+/obj/effect/spawner/random/trash/cigbutt,
+/turf/open/floor/plating,
+/area/maintenance/department/medical)
 "vOB" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -48335,10 +48350,11 @@
 /turf/open/floor/engine,
 /area/engineering/main)
 "wdx" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/maintenance/department/engine)
+/obj/structure/sign/departments/holy{
+	pixel_x = -32
+	},
+/turf/open/misc/asteroid,
+/area/service/chapel/asteroid/monastery)
 "wem" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
@@ -48393,16 +48409,19 @@
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "wha" = (
-/obj/effect/spawner/random/trash/food_packaging,
-/turf/open/floor/plating,
-/area/maintenance/department/medical)
+/obj/effect/spawner/xmastree,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/carpet,
+/area/service/library)
 "whH" = (
-/obj/structure/chair/wood,
-/obj/item/radio/intercom/chapel{
-	pixel_x = -27
+/obj/item/radio/intercom/chapel/directional/north,
+/obj/structure/chair/wood{
+	dir = 4
 	},
+/obj/machinery/light/small/directional/west,
 /turf/open/floor/iron/dark,
-/area/service/chapel/monastery)
+/area/service/chapel)
 "whJ" = (
 /turf/closed/wall/mineral/iron,
 /area/service/library/artgallery)
@@ -48598,6 +48617,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /turf/closed/wall/r_wall,
 /area/engineering/supermatter)
+"wzJ" = (
+/obj/machinery/light/small/directional/east,
+/turf/open/floor/iron/dark,
+/area/service/library)
 "wAC" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -48748,13 +48771,17 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/service/library/artgallery)
+"wJl" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/stool/directional/west,
+/turf/open/floor/plating,
+/area/maintenance/department/medical)
 "wJL" = (
-/obj/structure/sign/painting/library{
-	pixel_x = 32
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
 	},
-/obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
-/area/service/library/artgallery)
+/area/service/chapel)
 "wKa" = (
 /obj/machinery/light/small,
 /turf/open/floor/plating,
@@ -48796,12 +48823,9 @@
 /turf/open/floor/iron/dark,
 /area/maintenance/disposal/incinerator)
 "wMn" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/science/robotics/lab)
+/obj/item/radio/intercom/directional/east,
+/turf/open/floor/iron/dark,
+/area/service/library)
 "wMF" = (
 /obj/effect/spawner/random/food_or_drink/three_course_meal,
 /obj/effect/spawner/random/food_or_drink/three_course_meal,
@@ -48830,6 +48854,11 @@
 	},
 /turf/open/floor/plating,
 /area/security/checkpoint/science)
+"wNX" = (
+/obj/structure/table/wood/fancy,
+/obj/item/storage/box/bodybags,
+/turf/open/floor/iron/dark,
+/area/service/chapel/funeral)
 "wOa" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -48992,10 +49021,16 @@
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "wVV" = (
-/obj/item/chair,
-/obj/effect/spawner/random/trash/cigbutt,
-/turf/open/floor/plating,
-/area/maintenance/department/medical)
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/camera/directional/east{
+	c_tag = "Monastery Garden Aft";
+	network = list("ss13","monastery")
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/service/chapel/monastery)
 "wWC" = (
 /obj/structure/chair,
 /obj/effect/turf_decal/bot,
@@ -49004,9 +49039,12 @@
 /turf/open/floor/iron/dark,
 /area/hallway/primary/aft)
 "wWO" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/maintenance/department/medical)
+/obj/structure/lattice,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "wXu" = (
 /obj/machinery/door/window/left/directional/south{
 	dir = 8;
@@ -49031,12 +49069,10 @@
 	},
 /area/maintenance/department/cargo)
 "xan" = (
-/obj/effect/turf_decal/tile/blue/half/contrasted,
-/obj/structure/chair{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
+/obj/machinery/meter,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden,
+/turf/open/floor/plating,
+/area/maintenance/department/chapel/monastery)
 "xau" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -49138,9 +49174,9 @@
 /turf/open/floor/wood,
 /area/service/lawoffice)
 "xeI" = (
-/obj/item/beacon,
-/turf/open/floor/engine,
-/area/science/explab)
+/obj/machinery/light/directional/north,
+/turf/open/floor/iron/dark,
+/area/service/chapel)
 "xgt" = (
 /obj/machinery/dna_scannernew,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -49166,10 +49202,11 @@
 /turf/open/floor/iron/dark,
 /area/engineering/atmos/hfr_room)
 "xhj" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/carpet,
-/area/service/library/lounge)
+/obj/structure/chair{
+	dir = 8
+	},
+/turf/open/misc/asteroid,
+/area/service/chapel/asteroid/monastery)
 "xhE" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 27
@@ -49196,15 +49233,12 @@
 /turf/closed/wall,
 /area/maintenance/department/cargo)
 "xja" = (
-/obj/machinery/light/small{
-	dir = 4
+/obj/effect/turf_decal/tile/blue/half/contrasted,
+/obj/structure/chair{
+	dir = 1
 	},
-/obj/machinery/power/apc/auto_name/directional/east{
-	name = "Library APC"
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/service/library)
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "xje" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
@@ -49225,20 +49259,12 @@
 /turf/open/floor/iron/grimy,
 /area/security/detectives_office)
 "xkB" = (
-/obj/structure/closet/crate,
-/obj/item/canvas/twentythree_twentythree,
-/obj/item/canvas/twentythree_twentythree,
-/obj/item/canvas/twentythree_twentythree,
-/obj/item/canvas/twentythree_nineteen,
-/obj/item/canvas/twentythree_nineteen,
-/obj/item/canvas/twentythree_nineteen,
-/obj/item/canvas/nineteen_nineteen,
-/obj/item/canvas/nineteen_nineteen,
-/obj/item/canvas/nineteen_nineteen,
-/obj/item/wirecutters,
-/obj/machinery/firealarm/directional/south,
-/turf/open/floor/iron/dark,
-/area/service/library/artgallery)
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/grimy,
+/area/service/chapel/monastery)
 "xkT" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -49298,8 +49324,11 @@
 /turf/open/floor/iron/dark,
 /area/engineering/atmos/hfr_room)
 "xnm" = (
-/obj/machinery/power/port_gen/pacman,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/tank/air{
+	piping_layer = 4
+	},
 /turf/open/floor/plating,
 /area/tcommsat/computer)
 "xnP" = (
@@ -49616,27 +49645,25 @@
 /turf/open/floor/iron/dark,
 /area/service/lawoffice)
 "xMQ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/dim{
-	dir = 4
+/obj/structure/lattice,
+/obj/structure/window/reinforced{
+	dir = 8
 	},
-/turf/open/floor/iron/dark,
-/area/service/library/artgallery)
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "xNx" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/sorting/mail/flip{
-	dir = 1;
-	sortType = 27
+/obj/machinery/light/small/directional/east,
+/obj/structure/sign/warning/vacuum/external{
+	pixel_x = 32
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "xNS" = (
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plating{
-	icon_state = "platingdmg2"
-	},
-/area/maintenance/department/engine)
+/turf/closed/wall/mineral/iron,
+/area/service/chapel)
 "xOC" = (
 /obj/machinery/door/airlock/external{
 	name = "Construction Zone"
@@ -49688,12 +49715,32 @@
 /turf/open/floor/iron/dark,
 /area/medical/morgue)
 "xSX" = (
-/obj/machinery/airalarm/unlocked{
-	pixel_y = 23;
-	dir = 1
+/obj/item/assembly/prox_sensor{
+	pixel_x = -8;
+	pixel_y = 4
 	},
-/turf/open/floor/iron/dark,
-/area/service/chapel/office)
+/obj/item/assembly/prox_sensor{
+	pixel_x = -8;
+	pixel_y = 4
+	},
+/obj/item/assembly/prox_sensor{
+	pixel_x = -8;
+	pixel_y = 4
+	},
+/obj/item/assembly/prox_sensor{
+	pixel_x = -8;
+	pixel_y = 4
+	},
+/obj/item/stock_parts/cell/high,
+/obj/item/stock_parts/cell/high{
+	pixel_x = 5;
+	pixel_y = -5
+	},
+/obj/item/crowbar,
+/obj/structure/table,
+/obj/effect/turf_decal/tile/green/half/contrasted,
+/turf/open/floor/iron,
+/area/science/robotics/lab)
 "xSZ" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -49758,9 +49805,12 @@
 	},
 /area/maintenance/department/science)
 "xXB" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/structure/sign/departments/restroom{
+	pixel_x = 32
+	},
 /turf/open/floor/iron/dark,
 /area/service/chapel/monastery)
 "xYz" = (
@@ -49875,10 +49925,11 @@
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "yii" = (
-/obj/machinery/airalarm/directional/north,
-/obj/machinery/firealarm/directional/west,
-/turf/open/floor/iron/dark,
-/area/service/library/artgallery)
+/obj/structure/transit_tube/station/dispenser/reverse{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/service/chapel/dock)
 "yjs" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -60361,7 +60412,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+cjB
 aaa
 aaa
 aaa
@@ -60617,6 +60668,9 @@ aaa
 aaa
 aaa
 aaa
+lAf
+cds
+lAf
 aaa
 aaa
 aaa
@@ -60634,9 +60688,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-cjB
 aaa
 aaa
 aaa
@@ -60865,22 +60916,26 @@ aaa
 aaa
 aaa
 aaa
+lAf
+lAf
+lAf
+lAf
+lAf
+lAf
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+lAf
+crt
+lAf
+bZY
 bZY
 bZY
 cBM
+cBM
 bZY
 bZY
+bZY
 aaa
 aaa
 aaa
@@ -60890,12 +60945,8 @@ aaa
 aaa
 aaa
 aaa
-cfN
-cfN
-fIT
-cfH
-fIT
-cfN
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -61115,45 +61166,45 @@ aaa
 aaa
 aaa
 aaa
+cww
+cww
+jMS
+cww
+cww
+bOv
+lAf
+lAf
+aeq
+czL
+czL
+cqW
+lAf
+lAf
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+crK
+lAf
+cxg
+lAf
 bZY
+crv
+rrU
+crv
+mFu
+nku
+cyA
 bZY
-csn
-ceF
-csY
-bZY
-bZY
+cBM
 aaa
 aaa
 aaa
 aaa
-cfN
-cfN
-cfN
-cfN
-cfN
-cfN
-fIT
-cfI
-fIT
-cfN
-cfN
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -61372,45 +61423,45 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cww
+ckv
+sDQ
+bTW
+cww
+bOv
+crK
+eNy
+cqU
+cqU
+ckW
+cqU
+fGm
+crK
+crK
+crK
+pkM
+crj
+cvJ
+bZY
+tan
+ctr
+ctr
+ctr
+csd
+csd
+hDe
 cBM
-csd
-csd
-csB
-csd
-csd
 cBM
 aaa
 aaa
-cfN
-cfN
-cfN
-cfN
-cfN
-cfN
-cfN
-cfN
-fIT
-cjC
-fIT
-cfN
-cfN
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -61624,51 +61675,51 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cfN
+cfN
 aaa
 cfN
 cfN
-cfN
-bZY
-bZY
-cse
+bOv
+bHM
+cfH
+cfH
+bNr
+bOv
+atx
+crj
+cqU
+cdE
+cen
+cqU
+crj
+cwc
+crK
+crK
+gKz
+crj
+ccu
+ceB
+csy
+csy
+csy
+csy
+bLo
 cso
-csC
-cdp
-kDf
-bZY
-bZY
-cfN
-cfN
-cfN
-cfN
-cfN
-cfN
-cfN
-bWV
-bWV
-fIT
-cfJ
-fIT
-bWV
-cfN
-cfN
+csd
+cuv
+cBM
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -61879,53 +61930,53 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-cfN
-bZY
-bZY
-bZY
-bZY
-jsD
-csd
-csp
-csp
-csp
-csd
-dpb
-bZY
-bZY
 cfN
 cfN
 cfN
 cfN
 cfN
 cfN
-bWV
-ciJ
-cjf
-cdw
-cjZ
-bWV
+cfN
+bOv
+vvY
+cfH
+cfH
+cyS
+bOv
+xeI
+crj
+cqU
+iEQ
+cqU
+cqU
+crj
+crj
+ctP
+crK
+crK
+czl
+nMV
+iMK
+csM
+cxD
+cxD
+cxD
+lNy
+csC
+cdC
+ceF
+cBM
+aaa
+aaa
 cfN
 cfN
+cfN
+cfN
+cfN
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -62134,55 +62185,55 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-bZY
-bZY
-crt
-crD
-bZY
-xSX
-csi
+cfN
+cfN
+cfN
+cfN
+cfN
+cfN
+cfN
+cfN
+cfN
+bOv
+tml
+cfH
+cfH
+bNr
+bOv
+bKd
+tpI
+bGG
+cqU
+caS
+gkS
+kfM
+njB
+cdx
+cdx
+aeI
+lrI
+nMV
+ceB
 owS
-csE
-rrU
-ctr
-cdo
-ctX
-bWV
-bWV
-bWV
-bWV
-bWV
-bWV
-bWV
-bWV
-ciK
-bXJ
-cjk
-cka
-bWV
+owS
+owS
+owS
+cjl
+cdp
+csd
+cux
+cBM
 cfN
 cfN
+cfN
+cfN
+cfN
+cfN
+cfN
+cfN
+cfN
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -62390,58 +62441,58 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-crb
-crg
-cru
-nvG
+cfN
+cfN
+cfN
+cfN
+cfN
+cfN
+cfN
+cfN
+cfN
+cfN
+bOv
+tOP
+fMm
+cfH
+cuU
+bOv
+jmE
+lGv
+ckl
+cqU
+lto
+clb
+czw
+wJL
+crj
+cvR
+crK
+chc
+cek
 bZY
-crT
-csi
-owS
-csE
-rrU
-ctr
-cdo
-kfM
-bWV
-cuk
-cus
-cuG
-bWV
-chC
-chV
-bWV
-bWV
-cvq
-aTf
-bWV
-bWV
-bWV
-bWV
-cwM
-bIT
+cef
+cyT
+cyT
+cyT
+ctX
+csd
+cyl
+bZY
+bZY
+cfN
+cfN
+cfN
+cfN
+cfN
+cfN
+cfN
+cfN
+cfN
+cfN
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -62646,60 +62697,60 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
 cfN
+cfN
+cfN
+cfN
+cfN
+cfN
+cfN
+cfN
+bOv
+bOv
+bOv
+bOv
+ciO
+czY
+dCh
+bNr
+bOv
+crj
+tpI
+bGG
+cqU
+lto
+tpI
+bGG
+crj
+ebp
+ccL
+crK
+bBV
+crK
 bZY
-ceC
-aRJ
-ceE
-nku
-ceE
-csg
-csq
-aTd
-rrU
-ctr
-cdo
-lzJ
-bWV
-cgb
-cut
-cuH
-chb
-chD
-chW
+ceg
+crv
+fNX
+cyQ
+crU
+dpb
+bZY
+bZY
 bWV
 bWV
 bWV
-cvA
 bWV
-cwj
-cww
 bWV
-fIT
-fIT
-cxg
+bWV
+bWV
+cfN
+cfN
+cfN
+cfN
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -62902,61 +62953,61 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
 cfN
 cfN
-bZY
-crh
-crv
-crG
-bZY
-crU
-csh
-csr
-aTe
-ctb
-ctt
-ctJ
-bZY
+cfN
+cfN
+cfN
+cfN
+cfN
+cfN
+bOv
+bOv
+vek
+wNX
+bOv
+bGD
+czY
+cfH
+bSt
+bOv
+ceo
+lGv
+ckl
+cqU
+lto
+lGv
+ckl
+lzJ
+crK
+crK
+crK
+cdr
+bYz
+cfD
+cfD
+cfD
+cfD
+cfD
+cfD
+cfD
+cfD
+cfD
+cuk
+cus
+cuG
 bWV
-cul
-chB
-cuI
-chc
-cuZ
-chX
+chC
+chV
 bWV
-ciz
-cvr
-aTf
-cvR
-bXJ
-bXJ
-crj
-cwO
-fIT
-cxh
+cfN
+cfN
+cfN
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -63160,61 +63211,61 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-bVp
 cfN
 cfN
-bZY
-bZY
-bZY
-bZY
-bZY
-bZY
-lAf
-owS
-aTe
-rrU
-ctu
-bZY
-bZY
+cfN
+cfN
+cfN
+cfN
+cfN
+bOv
+dJJ
+bTX
+lvV
+bOv
+cfJ
+czY
+cfH
+bVv
+bOv
+xeI
+tpI
+bGG
+cqU
+lto
+tpI
+bGG
+fGm
+crK
+whH
+caT
+cdr
+cyY
+cfm
+cvE
+ceH
+chK
+cfm
+cvE
+ceH
+ciX
+cfm
+cgb
+cut
+cuH
+chb
+chD
+evR
 bWV
-cum
-cgd
-cuJ
-chd
-chE
-chY
-bWV
-ciz
-cvs
-cvB
-cvS
-bXJ
-bXJ
-bXJ
-bXJ
-fIT
-fIT
-cxg
+cfN
+cfN
+cfN
+cfN
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -63415,63 +63466,63 @@ aaa
 aaa
 aaa
 aaa
+bBW
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-bGI
-bNs
-cfN
-cqW
-cqW
 cfN
 cfN
-bZY
-giI
-pkM
-crv
-owS
-aTe
-rrU
-gKz
-bZY
 cfN
+cfN
+cfN
+cfN
+bOv
+csp
+fwg
+cuJ
+cAj
+bQc
+bQc
+bQc
+bOx
+qCG
+nMV
+gXh
+cuz
+lto
+lto
+lGv
+ckl
+crj
+crK
+cbP
+crK
+cdr
+cwR
+cfm
+cgM
+crT
+chL
+cfm
+cgM
+crT
+chL
+cfm
+cul
+chB
+cuI
+vmY
+chD
+cei
 bWV
-cfC
-cuu
-chU
-cuR
-ciy
-chZ
-bWV
-ciz
-ckb
-cku
-cvT
-bZo
-cwx
-cwE
-ckv
-ckM
-clb
+cfN
+cfN
+cfN
+cfN
+cfN
 aaa
+aaa
+aaa
+cFB
 aaa
 aaa
 aaa
@@ -63672,62 +63723,62 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-bGI
+aby
+aht
+aYE
 bNs
-cfN
-cfN
-cfN
-cfN
+bNs
+bNs
+bNs
 bOw
-bZY
-pkM
-bZY
-bZY
-bZY
-tan
-bZY
-bZY
-bZY
+bOw
+bOv
+cvd
+cfH
+ceC
+bOv
+cbO
+cfH
+cfH
+chX
+bOv
+crj
+crj
+crj
+ciK
+idA
+crj
+crj
+crj
+ckD
+aTd
+crK
+cdr
+cdw
+cfm
+cgN
+xkB
+tBb
+cfm
+cip
+xkB
+cfl
+cfm
+cum
+chj
+crb
+chd
+cwG
+cuK
+bWV
 cfN
-bWV
-bWV
-bWV
-bWV
-cuS
-bWV
-bWV
-bWV
-ciz
-ckb
-cku
-cvT
-cwk
-cwy
-cwE
-ckw
-ckN
-clb
+cfN
+cfN
+cfN
+cfN
+cfN
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -63929,69 +63980,69 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-bGI
+aed
+bBW
+bQQ
 bNs
-cqW
-bOw
-cfN
+bSm
 bOw
 bOw
 bOw
 bOw
-bOw
-ccu
-ceB
-cef
-ceB
-cfN
-cfN
-cfN
-bWV
-cdr
-cuv
-cdw
-aTf
-crj
-ciN
-bWV
-ciz
-cvs
+bOv
+bOv
+bOv
+bOv
+bOv
 cvB
-cvV
-cdx
-ciA
-bXJ
-bXJ
-fIT
-fIT
-cxg
+cfH
+cfH
+lQX
+bOv
+ctK
+crj
+csE
+cqU
+idA
+csE
+crm
+xNS
+cfm
+cfm
+cfm
+bYA
+cfm
+cfm
+cfm
+ceK
+cfm
+cfm
+cfm
+chE
+cfm
+cfm
+cfm
+ciz
+ckA
+cuR
+chW
+chZ
+bWV
+cfN
+cfN
+cfN
+bNs
+sut
 aaa
 aaa
 aaa
 aaa
 aaa
 aaa
+aaa
+cfN
+cfN
+cfN
 aaa
 aaa
 aaa
@@ -64183,73 +64234,73 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+bHI
 aby
 aby
 aby
-aby
-cqU
+cvs
 bNs
-bUC
+bNs
 bOw
 bOw
 bOw
 bOw
 bOw
+bKa
 bOw
-bUC
 bOw
-ceB
-csM
-ceB
-cfN
-cfN
-cfN
-bWV
-cdC
-cuw
-cbK
-aTf
-ciA
-cvd
-bWV
-ciz
-cvt
-aTf
-crk
+bOw
+bOv
+bOv
+chN
+bOv
+bOv
+bOv
+crK
+crK
+crK
+cwo
+bLy
+crK
+crK
+xNS
+bFE
 bXJ
+bZm
+crH
+cbM
+cvu
 bXJ
-cwG
-cwO
-fIT
-cxk
+ceL
+nBO
+ctM
+csq
+bWX
+cun
+bXM
+cfm
+bWV
+cuu
+cuS
+bWV
+bWV
+bWV
+cfN
+cfN
+cfN
+bNs
+sut
 aaa
 aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
+cfN
+cfN
+cfN
+cfN
+cfN
+cfN
 aaa
 aaa
 aaa
@@ -64440,31 +64491,11 @@ aaa
 aaa
 aaa
 aaa
+bBW
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aby
-aaa
-aaa
-tpI
-bNs
+bJZ
+bIT
+bMr
 bNs
 bOw
 bOw
@@ -64475,51 +64506,71 @@ bOw
 bOw
 bOw
 bOw
-ceB
-cee
-ceB
-cfN
-cfN
-cfN
-bWV
-cdC
-cux
-cbK
-aTf
-cdC
-ciO
-bWV
-bWV
-bWV
-cjl
-bWV
-cwl
-cwz
-bWV
+bOw
+bOw
+bOw
+bQg
+wdx
+bQe
+cyB
+pIy
+bTg
+bQf
+aSr
+ckO
+bWW
+bXI
+cwe
+bZn
+aVY
+aVY
+aVY
+bWX
+bWX
+bWX
+bWX
+bWX
+bWX
+bWX
+bWX
+bWX
+bXJ
+ckd
+cfL
+bUD
+oKD
+iNe
+lLQ
 fIT
-fIT
-cxg
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+bUC
+bOw
+bOw
+bNs
+ckC
+aht
+aht
+aht
+aht
 cfN
 cfN
 cfN
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
 cfN
 cfN
+cfN
+cfN
+cfN
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -64699,67 +64750,61 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-abI
-bGD
-bQQ
+bGE
+bGE
+bGE
+bNw
+bNw
+bNw
+bNw
+bOw
+bQd
+bOw
+bQd
+bOw
+bQd
+bOw
+bQd
+bOw
+bQg
+bQg
+bOw
+cyB
+cuw
+qOE
+qOE
+mpU
+ckO
+qOE
+uDA
+cwe
+cvy
+aVY
+crN
+aTf
+aTf
+crN
+aTf
+aTf
+crN
+aTf
+aTf
+crN
+bWX
+cvy
+cCW
+cwj
+clf
+cvg
+cbK
+eFu
+fIT
+bOw
+bOw
+bOw
 bNs
 bNs
-bQe
-bOw
-bOw
-bOw
-bOw
-bOw
-bOw
-bSm
-bOw
-bUC
-ceB
-cef
-ceB
-cfN
-cfN
-cfN
-bWV
-bXJ
-cve
-cuK
-aTf
-bXJ
-cve
-bWV
-aTf
-ckd
-aTf
-cjm
-cjm
-cjm
-cjm
-cwR
-cwR
-aaa
-aaa
-aaa
-aaa
-aaa
+sut
 aaa
 aaa
 aaa
@@ -64768,17 +64813,23 @@ cfN
 cfN
 cfN
 cfN
-cyM
+aaa
+aaa
+aht
 aaa
 aaa
 aaa
-cfN
-cfN
-cfN
-cfN
-cfN
-cfN
-cfN
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -64955,73 +65006,65 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aby
-abI
-aby
-aby
-aby
-aby
-aaa
-bNr
-bNs
-bNs
-bNs
-bOw
-bOw
-bOw
+cFX
+bGF
+bHJ
+pbm
+cqH
+cdu
+bTc
+bNw
+bNw
+bQe
 bOw
 bOw
 bOw
 bOw
 bQe
-bWV
-bWV
-bWV
-bWV
-ceg
-bWV
-cfm
-cfm
-cfm
-cfm
-cfm
-cfm
-cfm
-cuU
-cfm
-cfm
-cfm
-cjH
-cfm
-cfm
-cwa
-cky
-gOS
-cjm
-cld
-tYF
+bOw
+bOw
+bQg
+bQg
+bQg
+ctu
+aSr
+aSr
+bPo
+cyZ
+csU
+dAG
+aSr
+ctu
+bXJ
+aVY
+aTf
+chi
+cuA
+cuM
+cgH
+cuo
+cvb
+cid
+chG
+aTf
+bWX
+bXJ
+chU
+iJI
+bZl
+cvg
+lor
+pQA
+fIT
+bOw
+bOw
+bOw
+bOw
+bNs
+ckS
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-cfN
-cfN
-cfN
-cfN
 cfN
 cfN
 cfN
@@ -65029,15 +65072,23 @@ aht
 aaa
 aaa
 aaa
-cfN
-cyM
-cfN
-cfN
-cfN
-cfN
-cfN
-cfN
-cfN
+aht
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -65213,88 +65264,88 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aby
-aaa
-aaa
-bOv
-bGD
-bOv
-bQQ
+bGE
+bGE
+bIV
+aHE
+cgU
+bLn
+cgU
+czH
+bQg
+bQg
+bQg
+bQg
+bQg
+bQg
+bQg
+bQg
+bQg
+bQg
+bUC
+ckN
+qOE
+qOE
+bJi
+mAq
+bWi
+dAG
+qOE
+cwe
+cvr
+aVY
+aTf
+cid
+cuB
+ccH
+cgH
+ciV
+ciT
+ciS
+ciT
+aTf
+bWX
+cvy
+chU
+ckT
+bZl
+cvg
+bUD
+cjk
+fIT
+bOw
+bOw
+bOw
+bOw
 bNs
 bNs
-bOw
-bOw
-bOw
-bOw
-bOw
-bOw
-bOw
-bOw
-bWV
-bWV
-bWV
-bXJ
-bYz
-cdr
-cfD
-bXJ
-cfm
-ctK
-cvu
-cfD
-chf
-cuz
-cvu
-cfD
-cvu
-cfD
-chf
-cfD
-cvu
-cvE
-cwa
-cky
-gOS
-idA
-cld
-cjm
+sut
 aaa
 aaa
 aaa
+aht
+aaa
+aht
 aaa
 aaa
-aaa
-cfN
-cfN
-cfN
-cyM
-cfN
-cyM
 aaa
 aht
 aaa
 aaa
 aaa
 aaa
-aht
 aaa
-cfN
-cfN
-cfN
-cfN
-cfN
-cfN
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -65470,88 +65521,88 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aed
-abI
-bNr
-bNs
-bNs
-bNs
-bNs
-bNs
-bSm
-bOw
-bOw
-bOw
-bOw
-bOw
-bOw
-bOw
-bUC
-bWV
-whH
-caT
-vFZ
-bWV
-cds
-cfD
-ceH
-cfl
-cvu
-cvy
-cvy
-cvy
-cvy
-cvy
-bXI
-cvy
-cvy
-cvy
-cvy
-cvy
-cvu
-cwa
-cwm
-ckj
-ckj
+bHN
+bGE
+bKc
+cwy
+cuZ
+caV
+ctJ
+cjO
+bNx
+bNx
+bNx
+bNx
+bNx
+bNx
+bNx
+bNx
+bNx
+bNx
+bNx
+ctO
 ckO
-cjm
+ckO
+cxe
+cyP
+cxX
+cxL
+oCw
+crk
+crH
+aVY
+crN
+ckh
+cuA
+cgn
+cgH
+chl
+cvh
+cgH
+cjo
+crN
+bWX
+ciA
+ckd
+pQQ
+ciE
+cvg
+aTe
+bVp
+fIT
+bOw
+bOw
+bOw
+bOw
+bOw
+bNs
+sut
+aaa
+aaa
+aaa
+aht
+aht
+aht
+aht
+aht
+aht
+aht
+aht
+aht
+aht
+aht
+aht
 cfN
 aaa
 aaa
 aaa
 aaa
 aaa
-cfN
-cfN
-cfN
-aht
 aaa
-aht
 aaa
-aht
-aht
-aht
-aht
-aht
-aht
 aaa
-cfN
-cfN
-cyM
-cfN
-cfN
-cfN
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -65727,65 +65778,67 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-bHI
-aby
-aby
-aby
 bGH
-bNs
-bNs
-bOw
-bQc
-bOw
-bOw
-bOw
-bOw
-bOw
-bOw
+bGE
+bKf
+caV
+cqS
+csi
+bNw
+bNw
+bQe
 bOw
 bOw
 bOw
-bWV
-bWV
-bWV
-bYz
-bWV
-bWV
-bWV
-bWV
-cei
-bWV
+bOw
+bQe
+bOw
+bOw
+bQg
+bQg
+bOw
+cyB
+viB
+qOE
+qOE
+aSr
+cxY
+pEv
+uDA
+cwe
+crx
+crH
+csr
+crY
+csk
+czB
+chk
+goT
+cvi
+cgI
+cgH
+cjP
+ceL
+cgG
 cfm
-cfD
-cvy
+cfm
+cfm
+cvS
 bWV
-cgG
-cgG
 bWV
-cuX
 bWV
-cgG
-cgG
-bWV
-cvy
-cfD
-cwa
-cwn
-ckg
-ckz
-ckP
-cjm
-cfN
-cfN
-cfN
+bOw
+bQe
+cwr
+bNw
+bNw
+bNw
+bNw
+bNw
+cvt
+cvt
+aht
+aaa
 aaa
 aaa
 aaa
@@ -65794,20 +65847,18 @@ aaa
 aaa
 aht
 aaa
-aht
 aaa
-aht
-aaa
-aaa
-aaa
-aaa
-aht
-aaa
-aaa
-aaa
-aht
 cfN
 cfN
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -65983,86 +66034,86 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-bGD
-bGD
-bIT
-bJZ
-bIT
-bMr
-bNs
+gYo
+aht
+bNw
+bNw
+ijF
+bNw
+bNw
+bNw
 bOw
+bQd
 bOw
+bQd
 bOw
+bQd
 bOw
+bQd
 bOw
+bQg
 bOw
-bOw
-bOw
-bOw
-bOw
-bOw
-bOw
-bWV
-crj
+bQe
+cyB
+uLp
+nbP
+bry
+aSr
+aSr
+gdJ
+bXI
+cwe
+crX
+csT
+crN
+cup
+cgH
+cgm
+cgJ
+cib
+cgH
+cgj
+cvj
+crN
+bWX
 bXJ
+cvy
 bXJ
-crK
-cdr
-cdw
-csv
-cfD
-bWV
-cfm
-cfF
-cvy
-cgG
-chi
-cid
-cuM
-chj
-cvb
-ciT
-cvh
-cgG
-cvy
-cvu
-cwa
-cwo
-ckh
-ckA
-ckP
-cjm
-cfN
-cfN
-cfN
-cfN
-aaa
-aaa
-aaa
-aaa
-aaa
-cjp
-cyU
-cjp
-cyU
-cjp
-cjp
-cyU
-cjp
-cyU
-cjp
-cyU
+reR
+ceL
+czt
+bQg
+bQg
+bQg
+bQg
+bQg
+fWv
+cfI
+ckV
+itI
+cln
+bGE
+bGE
 aht
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aht
-aht
+aaa
+aaa
+cfN
+cfN
+cfN
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -66240,86 +66291,86 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+gYo
+bGI
 bGE
-bGE
-bIU
-bHM
-bHM
-bHM
-bHM
+nmI
+caV
+bMw
+yii
 bNw
 bOw
-bQd
 bOw
-bQd
 bOw
-bQd
 bOw
-bQd
 bOw
-bQd
-bWV
-bWV
-bXJ
-bZl
-bYA
-bZl
-bYA
-cbP
-cdu
-cfD
-ceK
-cfm
+bOw
+bOw
+cjp
+cjp
+bQi
+cjp
+cjp
+cjp
+cjp
+cjp
+cjp
+hRH
+hRH
+cjp
+cjp
+bXN
+cku
+aVY
+aTf
+cuE
+ciV
+cuE
+cid
+cgH
+cic
+ciV
+cjq
+aTf
+aVY
+aVY
+bOG
+wVV
 xXB
-cvy
-cgG
-cid
-cuA
-cib
-cgH
-cgH
-ciS
-cid
-cgG
-cvy
-cvu
-cwc
-cwp
-cwA
-ckz
-ckP
-cjm
-caS
-caS
-caS
-caS
-aht
-aht
-aht
-aht
-cjp
-cjp
-ckH
-cyY
-ckH
-ckH
-ckH
-ckH
-czH
-ckH
-cyR
-cyU
+aVY
+cvk
+cdr
+cdr
+cdr
+cdr
+cdr
+bHH
+gSS
+mKc
+cwk
+bGF
+bHJ
+pbm
+oZy
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aht
+aht
+aht
+cfN
+cfN
+cfN
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -66497,86 +66548,86 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-lGv
-bGF
-bHJ
-pbm
-bKa
-cqH
+gYo
+bGI
+bGE
+bKf
 aIP
-bNt
+bMw
+bNy
 bNw
-bNw
-bQe
 bOw
 bOw
 bOw
-bQe
 bOw
 bOw
 bOw
-bQe
-bWV
-bXJ
-bXJ
-bZm
-bYB
-bZm
-caV
-cbM
-ccH
-cfD
-ceL
-cfm
-ctM
-cvy
-bWV
-cun
-cuB
-cic
+bOw
+cjp
+cyR
+ckH
+ciy
+jgr
+dES
+czD
+sYe
+jgr
+cAg
+cAg
+bUE
+czr
+bXN
+cjZ
+aVY
+aTf
+cgK
 cgH
-chG
-ciT
-cjo
+cuO
+cgH
+cid
+cwM
+ciW
+cjr
+aTf
+aVY
+chp
+cfm
+cfm
+cfm
+ciF
 bWV
-cvy
-cvI
-cwa
-clf
-cwA
-bgc
-cwS
-cjm
-cfN
-caS
-cfN
-aaa
-aaa
-aaa
-aaa
-aaa
-cjp
-cCW
-ckH
-cyZ
-ckH
-czl
-czr
-czr
-czI
-ckH
-ckH
-cjp
-cjp
-cyU
+bWV
+bOw
+bQg
+bQe
+bOw
+bNw
+cth
+ckX
+jgn
+bGE
+bGE
+bGE
 aht
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aht
+aaa
+cfN
+cfN
+cfN
+cfN
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -66754,86 +66805,86 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+bHI
+aqG
 bGE
-bGE
-bIV
-bNu
-bLo
-bOx
-bNu
-bOx
-bPn
-bQf
-bQf
-bQf
-bQf
-bQf
-bQf
-bQf
-bQf
-bQf
-bWW
-bXI
-bZn
-bZn
-bZn
-bZn
-bZn
-bZn
-cbN
-ccE
-bXJ
-bWX
+bKg
+aIP
+bMx
+bNz
+bNw
+bNs
+bNs
+bOw
+bOw
+bOw
+bOw
+bOw
+cjp
+cjH
+sYe
+ckH
+ckH
+ckH
+hBY
+hBY
+ckH
+crG
+cAg
+cAg
+cAg
+hRH
+cvy
+aVY
+crN
 aTf
+aTf
+crN
+aTf
+aTf
+crN
+aTf
+aTf
+crN
+aVY
 cvy
-cgG
-cgk
-cuA
-ciS
-chk
-cgH
-cgH
-cvi
-cgG
-cvy
-cfD
-cwa
-cjO
-ckk
-ckC
-ckR
-cjm
+bYB
+cfm
+cio
+chq
+cjR
+bWV
+bOw
+bQg
+bOw
+bQd
+bNw
+bNw
+bNw
+bNw
+bNw
+wWO
+wWO
+aht
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aht
+aaa
 cfN
-caS
-caS
-aht
-aht
-aht
-aht
-aht
-cjp
-ckW
-ckH
-ckH
-ckH
-czl
-czr
-czB
-czI
-czV
-ckH
-cAr
-cAB
-cyU
-cjp
+cfN
+cfN
+cfN
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -67012,91 +67063,91 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-bGG
-bHL
-bIW
-bKc
-aHE
-cgU
-bLn
-cqI
-bPo
-bQg
-bQg
-bQg
-bQg
-bQg
-bQg
-bQg
-bQg
-bQg
-bWX
-uDA
-bZo
-bZo
-bZo
-bZo
-bZo
-bZo
-cbO
-ccF
-aTf
-cek
-aTf
+aht
+bNw
+bGE
+bGE
+bNw
+bNA
+bNw
+bQR
+bNs
+bNs
+bOw
+bOw
+bOw
+bOw
+cjp
+cjp
+cjp
+qdj
+cko
+cko
+hBY
+hBY
+bwv
+ckH
+csY
+ckH
+cvT
+crl
+bXJ
+aVY
 cvy
-cgG
-cuo
-ciV
-cgI
-chl
-cib
-cvg
-cid
-cgG
 cvy
-cfD
-cwa
-cwa
-cwa
-cwa
-cwa
-cwa
-cwe
-cwe
+cvy
+cvy
+cvy
+cvy
+cvy
+cvy
+cvy
+cvy
+aVY
+bXJ
+cwO
+cfm
+ckp
+chr
+cjR
+bWV
+bUC
+bOw
+bOw
+bOw
+bOw
+cfN
+cfN
+cfN
+cfN
+cfN
+cfN
+aht
+aht
+aht
+aht
+aht
+aht
+aht
+aht
+aht
+aht
+cfN
+cfN
+cfN
 cfN
 aaa
 aaa
 aaa
 aaa
 aaa
-cjp
-cyP
-ckH
-cyZ
-ckH
-czl
-czt
-czC
-czI
-czM
-cAg
-cAs
-ckH
-cAH
-cjp
-cyU
 aaa
 aaa
 aaa
 aaa
-cfN
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -67269,92 +67320,92 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-bGH
-bGE
-bIX
-bKd
-bLp
-bMu
-bNv
-bNw
-bNw
-bQe
+aht
+pqe
+bIY
+bLs
+abI
+cwm
+abI
+abI
+bRC
+bNs
+bNs
 bOw
 bOw
-bOw
-bQe
-bOw
-bOw
-bOw
-bQe
-bWV
-bXJ
-bXJ
-bZl
-bYA
-bZl
-caW
-cbP
-cdu
-cdx
-cth
-cfm
-ctN
-cvy
-bWV
-cup
-cuE
-cgK
-cgJ
-cgH
-cgj
-cvj
-bWV
-cvy
-cvJ
-cwe
-cjP
-ckl
-ckD
-ckS
-clg
-clk
-cwe
-cwe
-cyB
-cxM
-cxM
-cxM
-cyB
+amC
 cjp
-cyQ
+ccE
+cwp
+lqy
 ckH
 ckH
+hBY
+hBY
+bwv
+crg
+csY
 ckH
-ckH
-ckH
-ckH
-ckH
-czM
-cAg
-cAt
-ckH
-czM
-cAS
-cyU
-aht
-aht
-aht
-cyM
+bPn
+bXN
+bXM
+crH
+pHK
+aej
+cxz
+crH
+ccM
+doz
+crH
+ckM
+crH
+elH
+hWE
+cvA
+chM
+cfm
+ckp
+chs
+ciY
+bWV
+bOw
+bQg
+bOw
+bOw
 cfN
 cfN
+cfN
+cfN
+cfN
+cfN
+cfN
+aht
+aaa
+aht
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+cfN
+cfN
+cfN
+cfN
+cfN
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -67527,91 +67578,91 @@ aaa
 aaa
 aaa
 aaa
+bzy
+bBW
+aht
+aaa
+sXx
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-bGI
-bHM
-bHM
-bHM
-bLq
-bNw
-bNw
-bNw
-bOw
-bQd
-bOw
-bQd
-bOw
-bQd
-bOw
-bQd
-bOw
-bWi
-bWV
-bWV
-bXJ
-bZm
-bYB
-bZm
-bYB
-cbM
-ccH
-cdx
-ceK
-cfm
-xXB
-cvy
-cgG
-ciV
-cgH
-cgH
-cgH
-cic
-ciV
-cjq
-cgG
-cvy
-cvu
-ckT
-xhj
-xhj
-xhj
-xhj
-xhj
-cxn
-xhj
-lqy
-cxC
-cxK
-cxX
-cyl
-cyz
-jgr
-cjQ
-cjQ
-cjQ
-cjQ
-cjQ
-cjQ
-jMS
-czL
-czY
-cAi
-cAu
-cAC
-czY
+cre
+bNs
+bNs
+bNs
+cjp
+cjp
+gMG
+cAs
+cAg
+czC
+czC
+hBY
+hBY
+bwv
 ckH
-cyU
+csY
+bSZ
+ckw
+bXN
+bXN
+clk
+clk
+clk
+whJ
+whJ
+whJ
+whJ
+nvG
+whJ
+whJ
+whJ
+cwa
+cht
+cwa
+cwa
+mKz
+cPT
+bWV
+bWV
+bOw
+bQg
+bOw
+cfN
+cfN
+cfN
+cfN
+cfN
+cfN
+cfN
+cfN
+cfN
+aaa
+aht
+aaa
+aaa
 aaa
 aaa
 aaa
 cfN
 cfN
 cfN
+cfN
+cfN
+cfN
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -67783,92 +67834,92 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-bHN
-bGE
-bKe
-bLp
-bMw
-bNx
-bNw
-bOw
-bOw
-bOw
-bOw
-bOw
-bOw
-bOw
-bOw
-bOw
-bOw
-bOw
-bWV
-crk
-bXJ
-bXJ
-crN
-crX
-cdx
-cgn
-cdx
-bWV
-cfm
-ctO
-cvy
-cgG
-cgm
-cuE
-cuO
-cgH
-ciE
-ciW
-cjr
-cgG
-cvy
-cvu
+bBW
+gYo
+aht
+abI
+csv
+abI
+aht
+aht
+aht
+abI
+wWO
+wWO
+wWO
+iGp
+cAV
+ckH
+cAt
+cAg
+ckH
+ckH
+und
+hBY
+hBY
+hBY
+hBY
+cjQ
+hBY
+gum
+cjp
+bUF
+hko
+cbR
+whJ
 cwg
-cjR
-cjR
-ckF
-cjR
-cxe
-cjR
-cjR
-cxz
-cxD
-cxL
-cxY
-cym
-cyA
-vOw
-ijF
-ijF
-ckm
-ckm
-ckm
-ckm
-ckm
-czM
-czY
-cAj
-cAv
-cAD
-czY
-cAU
-cyU
+gOS
+cuF
+cgL
+whJ
+cfM
+nRK
+cwa
+chu
+cwS
+cjm
+ciq
+mIc
+bWV
+bOw
+bOw
+bOw
+bOw
+cfN
+cfN
+cfN
+cfN
+cfN
+cfN
+cfN
+cfN
+cfN
+cfN
+aht
+aaa
+aaa
 aaa
 aaa
 aaa
 cfN
 cfN
 cfN
+cfN
+cfN
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -68038,94 +68089,94 @@ aaa
 aaa
 aaa
 aaa
+bHI
+aht
+aht
+aht
+aaa
+csv
 aaa
 aaa
 aaa
 aaa
 aaa
 aaa
+aht
 aaa
 aaa
-aaa
-aaa
-bGI
-bGE
-bKf
-aIP
-bMw
-bNy
-bNw
-bOw
-bQh
-bOw
-bOw
-bOw
-bSm
-bOw
-bOw
-bOw
-bOw
-bOw
-bWV
-bWV
-crx
-crH
-bWV
-crY
-csk
-bWV
-cbR
-bWV
-cfm
-aTf
-cvy
-bWV
-cgG
-cgG
-bWV
-cuY
-bWV
-cgG
-cgG
-sYe
-cvy
-cfD
-cwe
-cwr
-clm
-ckG
-cwU
+iGp
+cqy
+cAC
+cAu
+pOp
+cAy
+cAy
+ckk
+wha
+ckk
+ckk
+rJg
+rJg
+rJg
+rJg
+tZa
+cdr
+cdr
+cdr
+gZg
+cgL
+cgL
+cgL
 jXh
-ckU
-cwe
-cwe
-cyB
-cxM
-cxM
-cxM
-cyB
-cjp
-cyR
-ick
-ckH
-ckH
-ckH
-ckH
-ckH
-ckH
-czL
-cAg
-cAt
-ckH
-czL
-cAV
-cyU
+bNB
+iYT
+csg
+cwa
+tXV
+ckR
+cjm
+cjm
+bWV
+bWV
+bOw
+bOw
+bOw
+bOw
+cfN
+cfN
+cfN
+cfN
+cfN
+cfN
+cfN
+cfN
+cfN
+cfN
+cfN
 aaa
 aaa
+aaa
+aaa
+aaa
 cfN
 cfN
+aaa
 cfN
 cfN
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -68295,6 +68346,11 @@ aaa
 aaa
 aaa
 aaa
+gYo
+aht
+aaa
+aht
+csv
 aaa
 aaa
 aaa
@@ -68302,87 +68358,82 @@ aaa
 aaa
 aaa
 aaa
+aht
 aaa
 aaa
-aaa
-bGI
-bGE
-bKg
-aIP
-bMx
-bNz
-bHM
-bNs
-bNs
-bNs
-bNs
-bOw
-bOw
-bOw
-bOw
-bOw
-bOw
-bOw
-bOw
-bWV
-bWV
-bWV
-bWV
-bWV
-bWV
-bWV
-ccJ
-aTf
-cel
-xXB
-cvy
-cvy
-cvy
-cvy
-cvy
-bXJ
-cvy
-cvy
-cvy
-cvy
-cvy
-cvu
-cwe
-cwe
-fWv
-qOE
-ckV
-qOE
-cln
-cwe
-cfN
-aaa
-aaa
-aaa
-aaa
-aaa
-cjp
-cyS
-ick
-cyZ
+iGp
 ckH
+cAD
+cAv
+cvq
+czM
+ckH
+hBY
+hBY
 czo
 czu
-czD
+cxk
 czN
-czL
-cAg
-cAs
-ckH
-cAM
+bFI
+stQ
 cjp
-cyU
+czQ
+hwY
+jEC
+whJ
+tJH
+tNT
+tNT
+cfF
+whJ
+bKq
+umO
+cwa
+bVs
+gtl
+ckP
+cjm
+bOw
+bOw
+bOw
+bOw
+bOw
+bOw
+cfN
+cfN
+cfN
+cfN
+cfN
+cfN
+cfN
+cfN
+cfN
+cfN
+cfN
 aaa
 aaa
-cfN
-cfN
-cfN
-cfN
+aaa
+cFB
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -68552,94 +68603,94 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-bGI
-bHM
-bGE
-bGE
-bHM
-bNA
-bHM
-cqS
-bQi
-bQR
-bNs
-bNs
-bOw
-bOw
-bOw
-bOw
-bOw
-bOw
-bOw
-bOw
-bOw
-bOw
-bUC
-bOw
-bQg
-cbR
-bXJ
-cdx
-cfm
-ctP
-xXB
-aTf
-aVY
-aTf
-xXB
-aTf
-xXB
-aTf
-cvk
-aTf
-xXB
-cfD
-cfm
-cwe
-bHH
-qOE
-mKc
-qOE
-txB
-cwe
-caS
+gYo
 aht
+aaa
+csv
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aht
-aht
-aht
-aht
-cjp
-cko
-ick
+aaa
+aaa
+iGp
+vFZ
 ckH
-ckH
+cAt
+cAg
+cAB
+csn
+hBY
+hBY
 clp
 czv
-czv
+mxQ
 czO
-cli
 ckH
-cAy
-cAB
-cyU
-cjp
-aht
-aht
-aht
-cyM
+czI
+cym
+cym
+cym
+cym
+whJ
+cwg
+bNu
+tNT
+cgL
+whJ
+whJ
+whJ
+cwa
+bKe
+xan
+ckP
+cjm
+ceE
+bOw
+bOw
+bOw
+bOw
+bOw
+chY
 cfN
 cfN
 cfN
+cfN
+cfN
+cfN
+cfN
+cfN
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -68807,96 +68858,96 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-cwR
-bIY
-bLs
-bMy
-mpU
-bMy
-abI
-aby
-abI
-bRC
-bNs
-bNs
-bNs
-bOw
-bOw
-bOw
-bOw
-bOw
-bOw
-bOw
-bOw
-bOw
-bOw
-bQg
-cbR
-bXJ
-cdB
-cfm
-cfm
-cfH
-cfm
-cfm
-chp
-cfm
-cfm
-cfm
-ciF
-cfm
-cfm
-whJ
-tXV
-whJ
-cwe
-ckp
-qOE
-ckX
-qOE
-cln
-cwe
-cfN
-cfN
-aaa
-aaa
-aaa
-aaa
-cjp
-cyT
-ick
-cyZ
-ckH
-czp
-ckH
-ckH
-czP
-ckH
-ckH
-cjp
-cjp
-cyU
+gYo
+aht
+aht
+aht
+csv
 aht
 aaa
 aaa
 aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aht
+aaa
+aaa
+cjp
+cjp
+ckH
+cAs
+cAg
+ckH
+ckH
+hBY
+hBY
+czp
+cwl
+ick
+czP
+ckH
+czv
+cym
+ckF
+cyM
+ccF
+whJ
+whJ
+whJ
+ckG
+bKH
+bsj
+clV
+tNT
+urP
+bMu
+sXi
+bTb
+cjm
+cdD
+bQe
+bOw
+bOw
+bOw
+bNs
+bNs
+bNs
+bNs
+bNs
 cfN
 cfN
 cfN
-cfN
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -69064,96 +69115,96 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-bBW
-bzy
+gYo
 aht
 aaa
-amC
+csv
 aaa
 aht
-aby
-aby
-abI
-bSn
-cFX
-bNs
-bNs
-bQe
-bOw
-bOw
-bOw
-bOw
-bOw
-bOw
-bOw
-bOw
-ccL
-bWV
-csT
-cen
-bWV
-ctQ
-cfI
-cfm
-cgL
-chq
-chK
-cfm
-cio
-chq
-ciX
-cfm
-yii
-iJb
-fdN
-cwe
-cwe
-cwe
-cwe
-cwe
-cwe
-cwe
-caS
-caS
+aaa
+aaa
+aaa
+cFB
+aaa
+aaa
+aaa
+aaa
 aht
-aht
-aht
-aht
+aaa
+aaa
+aaa
 cjp
-cjp
-ick
-xja
 ckH
+nKQ
+umV
 czq
-czw
+wzJ
+roy
 ckH
-czQ
+fov
 ckH
-cyR
-cyU
+cka
+cxK
+wMn
+ckH
+cym
+wCj
+cwn
+bHL
+pyQ
+cfC
+oxb
+cgL
+kDf
+whJ
+whJ
+cwa
+cwa
+bIU
+tFt
+cjm
+cjm
+xhj
+bOw
+bOw
+bOw
+bNs
+bNs
+xMQ
+crO
+crO
+crO
 aaa
 aaa
-aht
 aaa
 aaa
-cfN
-cfN
-cfN
-cfN
-cfN
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -69321,95 +69372,95 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-bBW
-aaa
-gYo
+bHI
 aht
-aht
-amB
-aht
+csv
+aaa
+aaa
 aht
 aaa
 aaa
-abI
-abI
-abI
-bRC
-bNs
-bNs
-bNs
-bUC
-bOw
-bOw
-bOw
-bOw
-bOw
-bOw
-bOw
-bWV
-csU
-bWV
-bWV
-bWV
-cfJ
-cfm
-cgM
-chr
-chL
-cfm
-cgM
-chr
-chL
-cfm
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aht
+aaa
+aaa
+aaa
+cjp
+cyU
+cjp
+cjp
+cjp
+cjp
+cyU
+cyU
+cjp
+cjp
+cjp
+cjp
+cjp
+cjp
+cym
+wBO
+fdN
+qtD
+qtD
+kEk
+whJ
 niN
-njB
-kFP
-whJ
-elH
-dbI
-nBO
-dbI
-elH
-whJ
-whJ
-whJ
-cfN
+caW
+crh
+cru
+cwa
+bWl
+ckj
+icy
+urP
+bQg
+bOw
+bOw
+bOw
+bNs
+bNs
+kZU
+aht
+aht
 aaa
 aaa
 aaa
-aht
-cjp
-cyU
-cjp
-cyU
-cjp
-cjp
-cyU
-cjp
-cyU
-cjp
-cyU
-aht
-aht
-aht
-aht
-cyM
-cfN
-cfN
-cfN
-cfN
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -69579,12 +69630,29 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+csv
+aht
+aht
+aht
+aht
+aht
+aht
+aht
+aht
+aht
+aht
+aht
+aht
+aht
+aht
+aht
+aht
+aht
+aht
+aht
+aht
+aht
+aht
 aaa
 aaa
 aaa
@@ -69593,80 +69661,63 @@ aaa
 aaa
 aaa
 aht
-aaa
-aaa
-sDQ
-aaa
-aht
-aaa
-aaa
-aaa
-aaa
-abI
-aaa
-crO
-bQR
-bNs
-bNs
-bNs
-bOw
-bOw
-bQg
-bQg
-bQg
-bOw
-bOw
-ccM
-cdD
-ceo
-bOw
-bQg
-cfm
-cgN
-chs
-chM
-cfm
-cip
-chs
-ciY
-cfm
-pIy
-iJb
-rie
+cym
+nVN
+gkQ
+rhT
+gkQ
+rzp
 whJ
-tNT
-mTp
-tNT
-tNT
-tNT
-fAe
-kZU
-whJ
-cfN
-aaa
-aaa
-aaa
+niN
+bQh
+iiJ
+fwx
+cwa
+ctN
+ckj
+cgd
+cjm
+bQg
+bOw
+bVC
+bNs
+kFP
+xMQ
 aht
-aaa
-aaa
 aht
-aaa
-aaa
-aht
-aaa
-aht
-aaa
-aht
+gYo
 aaa
 aaa
 aaa
 aaa
 aaa
-cfN
-cfN
 aaa
-cfN
-cfN
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -69835,88 +69886,88 @@ aaa
 aaa
 aaa
 aaa
+bMy
+aht
+aht
 aaa
-bBV
-bWl
-bWl
-bWl
-bWl
-bwv
-bwv
-bwv
-bwv
-bwv
-bwv
-bwv
-bwv
-bwv
-bwv
-lsq
+aaa
 aht
+aaa
+aaa
+aaa
 aht
+aaa
+aaa
+aaa
+aaa
 aht
+aaa
+aaa
+aaa
+aaa
 aht
+aaa
 aht
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aht
-aht
-aht
-aht
-aht
-aht
-bSZ
-cFX
-bNs
-bNs
-bNs
-crl
-bXL
-bNs
-bOw
-bOw
-bOw
-bQe
-bOw
-bOw
-cfL
-cfm
-cfm
-cht
-cfm
-cfm
-cfm
-cht
-cfm
-cfm
-nPm
-njB
-fGm
-fnq
-fnq
-pQA
-ewV
-ewV
-ewV
-iiJ
-fwx
+cym
+cym
+cym
+cym
+cym
+cym
 whJ
-cfN
-cfN
+niN
+tNT
+tqW
+woX
+cwa
+cwA
+pnF
+cky
+cjm
+bNs
+bNs
+bNs
+bNs
+kZU
 aaa
 aaa
 aht
-aht
-aht
-aht
+gYo
 aaa
 aaa
-aht
-aht
-aht
 aaa
-aht
 aaa
-cfN
-cfN
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -70091,16 +70142,16 @@ aaa
 aaa
 aaa
 aaa
-aaa
-bAI
+aht
+amB
 aaa
 aht
 aaa
-aht
 aaa
+aht
 eZM
-vmY
-vmY
+fWL
+fWL
 eZM
 eZM
 eZM
@@ -70121,59 +70172,59 @@ bva
 bIZ
 bIZ
 bva
+aaa
+aaa
 aht
-evR
-evR
-aeI
-bNs
-bXM
-bNs
-bUC
-bOw
-bOw
-bOw
-bOw
-bUC
-cfM
-cfm
-cgO
-chu
-chN
-cfm
-ciq
-chu
-ciZ
-cfm
-pIy
-iJb
-iYT
-oya
-fnq
-ewV
-ewV
-ewV
-ewV
-tqW
-woX
+aaa
+aht
+aaa
+aaa
+aaa
+aaa
 whJ
-cfN
-cfN
-aaa
-aaa
+niN
+tNT
+crh
+ouv
+cwa
+ckj
+pnF
+cky
+cjm
+wWO
+crO
+wWO
+wWO
 aht
+aht
+aht
+aht
+bHI
 aaa
 aaa
-aht
-cfN
-cfN
-cyM
-cfN
-aht
 aaa
-aht
-cfN
-cfN
-cfN
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -70348,26 +70399,26 @@ aaa
 btK
 aaa
 aaa
-aaa
-qpT
+aht
+bAI
 bSl
 bSl
 bSl
 bSl
 eZM
 eZM
-lrI
-blE
-bTc
+chf
+cry
+cdo
 bNQ
-rMV
+cwx
 bDf
 bCa
-nMV
+cgO
 eZM
-gKZ
+lsq
 gXg
-wWO
+crz
 aht
 bva
 bva
@@ -70378,60 +70429,60 @@ bHQ
 bNF
 bHQ
 bva
-oTJ
-aaa
+bva
 aht
-bGI
-bNs
-bXN
-bNs
-bNs
-bNs
-bNs
-bNs
-bNs
-bNs
-bNs
-cfm
-cfm
-cfm
-cfm
-cfm
-cfm
-cfm
-cfm
-cfm
-niN
-njB
-qtD
+aht
+aht
+aht
+aht
+aht
+aht
+aht
 whJ
-fGm
-nQb
-nQb
-vek
-tNT
-fAe
-jOw
+ckU
+wIX
 whJ
-cfN
-cfN
-aaa
-aaa
+whJ
+cwa
+bNv
+cjm
+cjm
+cjm
+aht
+aht
+gYo
+gYo
+gYo
+bHI
+gYo
 aht
 aaa
-cfN
-cyM
-cfN
-cfN
-cfN
-cfN
-cyM
-cfN
-cyM
-cfN
-cfN
-cfN
-cfN
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -70605,24 +70656,24 @@ bsl
 btL
 aZx
 aaa
-aaa
-qpT
+aht
+bAI
 bSl
 bSi
 bEj
 bFF
 eZM
-fNX
-bFI
-fwg
+cZF
+wJl
+rie
 bCa
-wha
+cAi
 eZM
 eZM
 bNQ
 eZM
 eZM
-ouv
+uyZ
 eZM
 eZM
 bva
@@ -70639,56 +70690,56 @@ bva
 aaa
 aht
 aaa
-bSZ
-ahi
-bSZ
-crO
-crO
-crO
-crO
-crO
-crO
-crO
-cfN
-cfN
-whJ
-gtl
-tBb
-lto
-hwY
-njB
-icy
-vvY
-kzj
-gMG
-whJ
-ebp
-wJL
-mFu
-wJL
-iYT
-whJ
-whJ
-whJ
-cfN
+aht
 aaa
 aaa
 aaa
-cyM
-cfN
-cfN
-cfN
-cfN
-cfN
-cfN
-cfN
-cfN
-cfN
-cfN
-cfN
-cfN
-cfN
-cfN
+bGI
+bNs
+bQg
+bVC
+bgc
+bOw
+bOw
+cgk
+bNs
+sut
+aaa
+aht
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -70869,19 +70920,19 @@ bSi
 bEk
 eZM
 eZM
-bNB
-bCa
-eZM
-dAG
-eZM
-eZM
-und
-bCa
-gum
 rMV
-iEQ
+bCa
+eZM
+cwz
+eZM
+eZM
+ckg
+bCa
+bJj
+cwx
+clm
 bNQ
-bVs
+bNt
 bva
 bGK
 bHQ
@@ -70897,55 +70948,55 @@ aaa
 aht
 aaa
 aht
-cdm
+aaa
+aaa
+aaa
+bGI
+bNs
+bQg
+bOw
+bOw
+bOw
+bOw
+bIW
+bNs
+rWE
 aht
-aaa
-bva
-bva
-bIZ
-bIZ
-bIZ
+gYo
 aaa
 aaa
-cfN
-whJ
-wCj
-tKm
-tNT
-tNT
-roy
-whJ
-whJ
-whJ
-whJ
-whJ
-umO
-whJ
-whJ
-whJ
-whJ
-whJ
-cfN
-cfN
-cfN
 aaa
 aaa
-cfN
-cfN
-cfN
-cfN
-cfN
-cfN
-cfN
-cfN
-cfN
-cfN
-cfN
-cfN
-cfN
-cfN
-cfN
-cfN
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -71125,8 +71176,8 @@ bSl
 bDh
 bEl
 eZM
-bVv
-qdj
+crB
+nPm
 uPG
 uMY
 uyy
@@ -71154,55 +71205,55 @@ aaa
 aht
 aaa
 aht
-cdm
-aht
-aaa
-bIZ
-caZ
-cbS
-ccN
-bIZ
-aaa
-aaa
-cfN
-whJ
-wBO
-fdN
-qtD
-qtD
-kEk
-whJ
-reR
-tFt
-dCh
-dCh
-tJH
-sBW
-whJ
-cfN
-cfN
-cfN
-cfN
-cfN
 aaa
 aaa
 aaa
-cfN
-cfN
-cfN
-cfN
-cfN
-cfN
-cfN
+bGI
+bNs
+bQg
+bQe
+bNs
+bNs
+bNs
+cAr
+bNs
+sut
+aaa
+gYo
 aaa
 aaa
-cfN
-cfN
-cfN
-cfN
-cfN
-cfN
-cfN
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -71395,7 +71446,7 @@ bSl
 bSl
 bSl
 eZM
-iJI
+csh
 bva
 bGM
 bHQ
@@ -71408,35 +71459,24 @@ bOz
 bHQ
 bIZ
 aaa
-aht
-aht
-abI
-ahi
-abI
-aaa
+bva
+bva
 bIZ
-cba
-cbT
-bDi
 bIZ
+bIZ
+aht
+aYE
+bNs
+bQg
+bOw
+bNs
+kZU
+crO
+pds
+wWO
 aaa
 aaa
-cfN
-whJ
-nVN
-gkQ
-gkQ
-gkQ
-xkB
-whJ
-uIv
-kVM
-nWF
-xMQ
-nKQ
-gXh
-whJ
-cfN
+gYo
 aaa
 aaa
 aaa
@@ -71446,19 +71486,30 @@ aaa
 aaa
 aaa
 aaa
-cfN
-cfN
-cfN
 aaa
 aaa
 aaa
 aaa
 aaa
 aaa
-cfN
-cfN
-cfN
-cfN
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -71637,14 +71688,14 @@ bzB
 bAL
 bSl
 eUe
-oKD
+csB
 bCa
 uyy
 bSl
-bOG
+aRJ
 doo
 nCe
-tml
+ckz
 bKn
 bLz
 bMF
@@ -71664,35 +71715,35 @@ bNJ
 bOz
 bHQ
 bIZ
-aht
-aht
-crz
-bva
-bQS
-bva
 aaa
 bIZ
-cbb
-bDi
-ccO
+caZ
+cbS
+ccN
 bIZ
 aaa
+bGI
+bNs
+bQg
+bUC
+bNs
+sut
+aaa
+aht
+aht
+aht
+aht
+gYo
 aaa
 aaa
-whJ
-whJ
-wIX
-wIX
-wIX
-wIX
-whJ
-whJ
-whJ
-whJ
-whJ
-whJ
-whJ
-whJ
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -71883,7 +71934,7 @@ eZM
 bmc
 bnt
 bnt
-sXi
+cyz
 bSl
 bSl
 btO
@@ -71893,9 +71944,9 @@ bSl
 bSl
 bSl
 bSl
-jVS
-oKD
-wVV
+cdB
+csB
+vOw
 uPG
 bSl
 erQ
@@ -71910,7 +71961,7 @@ bOD
 aht
 bIZ
 bmf
-bNX
+bXU
 bva
 bHQ
 bJg
@@ -71921,21 +71972,21 @@ bJb
 bJb
 bPq
 bva
+uIv
+bIZ
+cba
+cbT
+bDi
+bIZ
+aaa
+bGI
+bIZ
+cxh
+bIZ
+bIZ
+sut
+aaa
 aht
-bIZ
-crA
-bIZ
-bVr
-bIZ
-aaa
-bva
-bva
-bNK
-bva
-bva
-aaa
-cFB
-aaa
 aaa
 aaa
 aaa
@@ -72153,9 +72204,9 @@ bBY
 tNl
 btQ
 ajJ
-uLp
+cuY
 bSl
-bTW
+ciJ
 qIl
 iMd
 bJm
@@ -72166,8 +72217,8 @@ bKn
 bEr
 aht
 bva
-aSr
-bsu
+pFM
+apS
 bva
 bmd
 bJh
@@ -72178,21 +72229,21 @@ bKm
 bOA
 bPr
 bva
-aht
-bIZ
-crB
+czV
 bva
-bTa
+cbb
+bDi
+ccO
 bva
 aaa
 aaa
-bIZ
-csy
-bQl
+ctS
+bNX
+xNx
 ctS
 aaa
 aaa
-aaa
+aht
 aaa
 aaa
 aaa
@@ -72393,7 +72444,7 @@ bhH
 biL
 eZM
 bRu
-rMV
+cwx
 uPG
 jMD
 uPG
@@ -72435,22 +72486,22 @@ bva
 bva
 bva
 bva
+cuX
 bva
 bva
-crC
-bva
-pEv
+bNK
 bva
 bva
 bva
 bva
-bSq
+bIZ
+cxh
 bva
 bva
 aaa
 aaa
-aaa
-aaa
+aht
+cFB
 aaa
 aaa
 aaa
@@ -72642,7 +72693,7 @@ baS
 bbV
 bdZ
 bdZ
-bTb
+cAM
 bjK
 bgW
 bhK
@@ -72674,13 +72725,13 @@ wLl
 iMd
 bGW
 bKn
-umV
-iHi
+cxM
+cAS
 lkK
 bOD
 aht
 bIZ
-bJi
+mTp
 bTl
 qEx
 dXa
@@ -72689,24 +72740,24 @@ bva
 bsn
 bME
 bva
-bJj
+sKe
 hZZ
-wdx
-bXU
-bVC
+vGg
+nPg
+crA
 bZr
 caa
 caa
 bXa
-xNS
+ccJ
 bXa
 bRD
-lLQ
-cdE
-bIZ
-aaa
+cAH
+rnE
+bQl
+mMc
 bBW
-bBW
+abI
 aaa
 aaa
 aaa
@@ -72938,16 +72989,16 @@ bEr
 aht
 bva
 bmf
-hRH
+nQb
 bva
-aej
+bIX
 bDi
 bDi
 bWZ
 bDi
 bWZ
-rXJ
-cre
+nWF
+ckm
 bDi
 bva
 bva
@@ -72961,7 +73012,7 @@ bva
 ukn
 bva
 bva
-bHI
+ciN
 aht
 aht
 aht
@@ -73194,15 +73245,15 @@ bQj
 bSp
 bTd
 mSr
-kaf
-rJg
+cjf
+ewV
 bXa
 bRD
-tZa
+cve
 sUP
 bTf
-wdx
-wdx
+vGg
+vGg
 bVu
 mzU
 bOB
@@ -73213,9 +73264,9 @@ oFI
 bva
 rse
 uIn
-pnF
+giI
 oAW
-hBY
+cxC
 bva
 bBX
 bBX
@@ -73441,9 +73492,9 @@ bEr
 jnG
 bEr
 bEr
-vGg
-cqy
-pQQ
+gVY
+cld
+jVS
 ozc
 vbv
 bFJ
@@ -73451,24 +73502,24 @@ iQW
 bFL
 bPy
 bQl
-rzp
+txB
 bva
 bva
 bva
-cSf
+crD
 bva
 bva
 bva
 jYh
 bDi
 bDi
-lor
+kzj
 bva
 kRq
 kRq
 kRq
 bva
-lNy
+rXJ
 bDi
 bmf
 bmf
@@ -73708,11 +73759,11 @@ bEr
 bEr
 aht
 oTJ
-bLy
+tYF
 bFZ
-iGp
-atx
-gZg
+crC
+cee
+cvI
 bDi
 bTh
 bva
@@ -73960,22 +74011,22 @@ pDZ
 qhW
 vmo
 sHH
-urP
+ciZ
 hdk
 rXT
 aht
 bva
-rhT
-stQ
+fAe
+fnq
 xXe
-bTX
-hko
-tTl
-bTg
-fov
-bUE
+bVr
+dbI
+cwE
+cbN
+cxn
+clg
 bXV
-rtA
+bLp
 bZt
 bva
 oAW
@@ -74217,22 +74268,22 @@ feS
 agl
 vsn
 pOt
-nPg
+ctt
 rHh
 bSs
 aht
 bIZ
 aLw
 bFZ
-bry
+bSq
 bWH
-bKq
+ckb
 bva
 bva
 bva
 bva
 tvP
-nAp
+bZo
 bZt
 bZs
 kRq
@@ -74472,7 +74523,7 @@ bNj
 sOB
 cLu
 qxU
-bss
+cSf
 piR
 lba
 sea
@@ -74729,10 +74780,10 @@ clK
 sOB
 vgg
 nbt
-bss
-fMm
+cSf
+jsD
 gsP
-rnE
+kVM
 bOI
 aht
 bva
@@ -74986,7 +75037,7 @@ auB
 sOB
 bpz
 bOE
-bss
+cSf
 wGM
 pTy
 kYt
@@ -75502,12 +75553,12 @@ tqC
 tqC
 tqC
 bva
-pds
+ctb
 snZ
 bva
 bva
 bva
-bUa
+cwU
 bva
 nGx
 eBb
@@ -75516,7 +75567,7 @@ bva
 ccN
 bDi
 wIv
-nbP
+mIa
 bDi
 bva
 bva
@@ -75770,7 +75821,7 @@ bSx
 bTk
 bUd
 bva
-qCG
+kdF
 bva
 bva
 ygZ
@@ -76030,13 +76081,13 @@ bva
 qOH
 fpT
 fpT
-gdJ
+cli
 wNq
 bva
 gMO
 kCc
 bBX
-bUF
+cAU
 aaa
 aaa
 aaa
@@ -76282,7 +76333,7 @@ sZP
 bDi
 bDg
 lla
-dES
+tKm
 bDi
 oez
 bBX
@@ -76535,7 +76586,7 @@ bva
 bva
 amZ
 bzO
-xNx
+pWe
 fpT
 jTw
 wem
@@ -76551,8 +76602,8 @@ oYj
 uMo
 bXk
 mci
-cry
 vKD
+cse
 pAb
 ceq
 ceq
@@ -77323,7 +77374,7 @@ ous
 bXk
 tuL
 ccR
-vKD
+cse
 lhu
 cbV
 ccQ
@@ -78121,7 +78172,7 @@ mVM
 mVM
 mVM
 mVM
-mVM
+tue
 clw
 clw
 clw
@@ -78311,7 +78362,7 @@ boF
 bwC
 xte
 bGT
-xan
+xja
 boB
 tWt
 pPN
@@ -78378,7 +78429,7 @@ aaa
 aaa
 aaa
 aaa
-mVM
+tue
 clA
 clD
 clJ
@@ -78825,7 +78876,7 @@ bTL
 diT
 qqQ
 bGT
-xan
+xja
 bsA
 xQr
 bpH
@@ -79155,7 +79206,7 @@ xnm
 clM
 clU
 cmb
-mxy
+bsu
 clw
 cmk
 cmr
@@ -79410,7 +79461,7 @@ abI
 clw
 clN
 qxq
-clV
+mxy
 cmc
 mDW
 clw
@@ -86018,7 +86069,7 @@ bEa
 bmL
 boX
 bvQ
-bKH
+bUa
 bqg
 brw
 bku
@@ -86275,7 +86326,7 @@ blF
 bmM
 bmM
 bqh
-mIa
+qpT
 brx
 bsX
 buv
@@ -86526,13 +86577,13 @@ bgC
 bgC
 bhQ
 bip
-kdF
+cqI
 bku
 blG
 bmN
 bnP
 bSh
-wMn
+bss
 bmM
 bsY
 bku
@@ -86789,7 +86840,7 @@ blH
 bmO
 bvU
 bqi
-viB
+cjC
 bSQ
 bsZ
 bkt
@@ -87046,7 +87097,7 @@ blI
 bmO
 bvU
 boY
-mKz
+oya
 bmM
 bta
 bkt
@@ -87305,7 +87356,7 @@ bnR
 ldQ
 bqj
 bmM
-crm
+xSX
 bkt
 bvJ
 bxw
@@ -89612,7 +89663,7 @@ aEj
 asG
 iSi
 bkz
-gkS
+bXL
 bmW
 bnW
 bpe
@@ -90126,7 +90177,7 @@ aEj
 asG
 iSi
 bky
-xeI
+jOw
 bky
 bnY
 bpg
@@ -92468,7 +92519,7 @@ bRr
 bWQ
 bCV
 bCV
-apS
+cpA
 bFc
 aaa
 aaa
@@ -93475,7 +93526,7 @@ iSi
 brT
 bxF
 wkZ
-aeq
+bLq
 spz
 any
 ahp
@@ -93989,10 +94040,10 @@ iSi
 bkF
 ume
 bkF
-cPT
+hfZ
 iLl
 wTZ
-bFE
+byg
 xgt
 iUX
 bPl
@@ -94246,11 +94297,11 @@ bqC
 tMs
 vMx
 xzp
-cPT
+hfZ
 aUj
-qvx
+blE
 urk
-eNy
+iJb
 iUX
 bLf
 bLf
@@ -94503,10 +94554,10 @@ bzg
 brX
 csu
 ofN
-cPT
+hfZ
 pXg
 uAx
-bUD
+cel
 aiL
 skj
 skj
@@ -94760,13 +94811,13 @@ bqE
 brW
 btu
 xpr
-cPT
-cPT
+hfZ
+hfZ
 mzp
 kPi
 azn
 azn
-fWL
+ctQ
 bFx
 gOV
 pgk
@@ -95017,13 +95068,13 @@ bqF
 brW
 qtf
 axj
+bSn
 hfZ
-cPT
-sKe
+cvV
 pNf
 kkQ
 rKL
-byg
+qvx
 bFy
 bGB
 pgk
@@ -95274,10 +95325,10 @@ ost
 nOY
 dgz
 jxl
-lQX
-cPT
+bTa
+hfZ
 aeV
-bSt
+bQS
 izP
 aUj
 dfm
@@ -99133,7 +99184,7 @@ bwn
 vRi
 dKs
 dKs
-rgn
+sBW
 jRG
 rgn
 pgk


### PR DESCRIPTION
## What is changing?

Redesigned Pubby monastery and adjacent station maintenance for more movement paths and interesting rooms to do stuff.

### Changes

* Pubby monastery is closer and more connected to the station
* second monastery shuttle dock on aft side
* slightly less confusing layout?
* consolidated some rooms while leaving the amount of stuff
* shrink viro and psych rooms slightly
* more interesting maintenance labyrinth
* fix transit tube stations being flipped wrong

### Wiki

station picture, updated automatically

## Why these changes?

Pubby's "new" monastery asteroid was pushed further from the station, making it more isolated and reducing how often it gets visited. Bringing it in allows people to access it by foot for good or bad purposes. Makes the port-aft station maintenance feel more cohesive and not just rooms jutting out into space.