### PR TITLE
Dev container

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,59 @@
+# See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.231.3/containers/ubuntu/.devcontainer/base.Dockerfile
+
+# [Choice] Ubuntu version (use hirsuite or bionic on local arm64/Apple Silicon): hirsute, focal, bionic
+ARG VARIANT="hirsute"
+# Base image from Microsoft vscode devcontainers (ubuntu)
+FROM mcr.microsoft.com/vscode/devcontainers/base:0-${VARIANT}
+
+# Capture our arguments for BYOND Major and Minor versions required (passed in from devcontainer.json)
+ARG BYOND_MAJOR
+ARG BYOND_MINOR
+# Rust G Version to download/compile
+ARG RUST_G_VERSION
+
+# Add i386 arch (32 bit), update, upgrade, and install ca-certificates if not already
+RUN dpkg --add-architecture i386 \
+    && apt-get update \
+    && apt-get upgrade -y \
+    && apt-get dist-upgrade -y \
+    && apt-get install -y --no-install-recommends \
+    ca-certificates
+
+# Dependencies for building byond for linux
+RUN apt-get install -y --no-install-recommends \
+    curl \
+    unzip \
+    make \
+    libstdc++6:i386
+
+# Set work directory
+WORKDIR /tmp
+# Download byond linux zip, unzip file, execute `make`, update resulting file permissions, remove dependencies used for compilation
+RUN curl "https://www.byond.com/download/build/${BYOND_MAJOR}/${BYOND_MAJOR}.${BYOND_MINOR}_byond_linux.zip" -o byond.zip \
+    && unzip byond.zip \
+    && rm byond.zip \
+    && cd byond \
+    && sed -i 's|install:|&\n\tmkdir -p $(MAN_DIR)/man6|' Makefile \
+    && make install \
+    && chmod 644 /usr/local/byond/man/man6/* \
+    && apt-get purge -y --auto-remove curl unzip make
+
+# Install dependencies required to use our previously compiled rust_g
+RUN apt-get install -y --no-install-recommends \
+    libssl-dev:i386 \
+    zlib1g-dev:i386
+
+# Space Merge Requirements
+RUN apt-get install -y --no-install-recommends \
+    python \
+    pip
+
+# Space Merge Requirements cont.
+RUN pip install GitPython
+
+# Set work directory
+WORKDIR /opt/rust_g
+# Download the required `librust_g.so` from github releases
+RUN wget -nv -O ./librust_g.so "https://github.com/tgstation/rust-g/releases/download/$RUST_G_VERSION/librust_g.so"
+# Allow execution of the file
+RUN chmod +x ./librust_g.so

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,60 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.231.3/containers/ubuntu
+{
+	"name": "RussStation 13 - DevContainer",
+	"build": {
+		"dockerfile": "Dockerfile",
+		"args": {
+			// Update 'VARIANT' to pick an Ubuntu version: hirsute, focal, bionic
+			// Use hirsute or bionic on local arm64/Apple Silicon.
+			"VARIANT": "focal",
+			// TODO: Update/Set these from dependencies.sh
+			"BYOND_MAJOR": "514",
+			"BYOND_MINOR": "1560",
+			"RUST_G_VERSION": "0.5.0",
+		}
+	},
+	// Set *default* container specific settings.json values on container create.
+	"settings": {
+		// Lets you preview .dmi files in the editor
+		"workbench.editorAssociations": {
+			"*.dmi": "imagePreview.previewEditor"
+		},
+		// Set byond path for container
+		"dreammaker.byondPath": [
+			"/usr/local/byond",
+		],
+		"tgstationTestExplorer.apps.dreamdaemon": "/usr/local/byond/bin/DreamDaemon",
+		"tgstationTestExplorer.apps.dreammaker": "/usr/local/byond/bin/DreamMaker",
+		// Set TG Station Test Explorer DME filename
+		"tgstationTestExplorer.project.DMEName": "RussStation.dme",
+		// Set Result Type to JSON
+		"tgstationTestExplorer.project.resultsType": "json"
+	},
+	// Add the IDs of extensions you want installed when the container is created.
+	"extensions": [
+		// Good remote container extension for displaying container stats (CPU, Ram, etc.)
+		"mutantdino.resourcemonitor",
+		// Install TG's recommended extensions
+		"gbasood.byond-dm-language-support",
+		"platymuus.dm-langclient",
+		"EditorConfig.EditorConfig",
+		"arcanis.vscode-zipfs",
+		"dbaeumer.vscode-eslint",
+		"stylemistake.auto-comment-blocks",
+		// Commented out because it doesn't seem to work correctly in remote containers
+		// "Donkie.vscode-tgstation-test-adapter",
+	],
+	// Use 'forwardPorts' to make a list of ports inside the container available locally. (Should forward automatically)
+	"forwardPorts": [],
+	// Use 'postCreateCommand' to run commands after the container is created.
+	// Moves downloaded `librust_g.so` file to our end container workspace folder and chowns
+	"postCreateCommand": "sudo mv /opt/rust_g/librust_g.so ${containerWorkspaceFolder} && sudo chown vscode:vscode ${containerWorkspaceFolder}/librust_g.so",
+	// Comment out to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
+	"remoteUser": "vscode",
+	// Features to add to the dev container.
+	"features": {
+		// TODO: Update/Set this from dependencies.sh
+		"node": "14"
+	}
+}

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 A codebase built from the /tg/station codebase
 https://github.com/tgstation/tgstation
 
+[![Open in Remote - Containers](https://img.shields.io/static/v1?label=Remote%20-%20Containers&message=Open&color=blue&logo=visualstudiocode)](https://vscode.dev/redirect?url=vscode://ms-vscode-remote.remote-containers/cloneInVolume?url=https://github.com/RussStation/RussStation)
+
 ![Coverage](https://img.shields.io/badge/coverage---2%25-red.svg)  
 [![forthebadge](https://forthebadge.com/images/badges/built-with-resentment.svg)](https://forthebadge.com) [![forthebadge](https://forthebadge.com/images/badges/contains-technical-debt.svg)](https://user-images.githubusercontent.com/8171642/50290880-ffef5500-043a-11e9-8270-a2e5b697c86c.png) [![forinfinityandbyond](https://user-images.githubusercontent.com/5211576/29499758-4efff304-85e6-11e7-8267-62919c3688a9.gif)](https://www.reddit.com/r/SS13/comments/5oplxp/what_is_the_main_problem_with_byond_as_an_engine/dclbu1a)
 


### PR DESCRIPTION
vscode remote container (devcontainer) setup

- Added devcontainer.json (container settings) and Dockerfile (used to build the container)
- Added 'Open in Remote - Container' badge to readme
- When clicked will prompt to open the repository in a vscode remote dev container (based off files in the repository)

Container is setup to allow building of code, testing code (test extension not working correctly in remote container), running a server from the container and accessible from host computer for testing. Also comes installed with python and required items for spacemerge usage (YMMV)