### PR TITLE
Map checkgrep fixes

### DIFF
--- a/RussStation.dme
+++ b/RussStation.dme
@@ -4419,6 +4419,7 @@
 #include "russstation\code\datums\ruins\icemoon.dm"
 #include "russstation\code\datums\ruins\lavaland.dm"
 #include "russstation\code\datums\station_traits\negative_traits.dm"
+#include "russstation\code\game\area\space_station_13_areas.dm"
 #include "russstation\code\game\area\areas\mining.dm"
 #include "russstation\code\game\area\areas\ruins\lavaland.dm"
 #include "russstation\code\game\machinery\compost.dm"

--- a/_maps/map_files/CubeStation/Cube.dmm
+++ b/_maps/map_files/CubeStation/Cube.dmm
@@ -12968,14 +12968,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
-"gLQ" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/structure/cable,
-/turf/open/floor/engine,
-/area/engineering/main)
 "gMk" = (
 /turf/open/floor/iron,
 /area/commons/storage/tools)
@@ -28443,11 +28435,6 @@
 	},
 /turf/open/floor/grass,
 /area/security/prison)
-"oMw" = (
-/obj/structure/cable,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/port/fore)
 "oMM" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -47298,7 +47285,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 5
 	},
@@ -47854,7 +47840,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/structure/cable,
 /obj/effect/spawner/random/trash/garbage,
 /turf/open/floor/plating,
 /area/maintenance/fore/lesser)
@@ -69939,7 +69924,7 @@ ndJ
 hak
 aZS
 bfn
-oMw
+beZ
 lVt
 rAI
 gdH
@@ -77059,7 +77044,7 @@ kXr
 kXr
 ihn
 noU
-gLQ
+wLs
 kVW
 kKL
 eBW

--- a/_maps/map_files/CubeStation/Cube.dmm
+++ b/_maps/map_files/CubeStation/Cube.dmm
@@ -5643,8 +5643,7 @@
 "dam" = (
 /obj/machinery/power/apc/auto_name/directional/south{
 	areastring = "/area/cargo/office";
-	name = "Cargo Office APC";
-	pixel_x = 1
+	name = "Cargo Office APC"
 	},
 /obj/structure/table,
 /obj/item/paper_bin,
@@ -10912,8 +10911,7 @@
 "fMQ" = (
 /obj/machinery/power/apc/auto_name/directional/west{
 	areastring = "/area/command/gateway";
-	name = "Gateway APC";
-	pixel_y = -1
+	name = "Gateway APC"
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -18354,8 +18352,7 @@
 "jCW" = (
 /obj/machinery/power/apc/auto_name/directional/south{
 	areastring = "/area/cargo/storage";
-	name = "Cargo Bay APC";
-	pixel_x = 1
+	name = "Cargo Bay APC"
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -24023,8 +24020,7 @@
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/north{
 	areastring = "/area/maintenance/port/fore";
-	name = "Port Bow Maintenance APC";
-	pixel_x = -1
+	name = "Port Bow Maintenance APC"
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
@@ -32888,8 +32884,7 @@
 	},
 /obj/machinery/power/apc/auto_name/directional/south{
 	areastring = "/area/security/checkpoint/auxiliary";
-	name = "Security Checkpoint APC";
-	pixel_x = 1
+	name = "Security Checkpoint APC"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -35149,8 +35144,7 @@
 "rNr" = (
 /obj/machinery/power/apc/auto_name/directional/west{
 	areastring = "/area/maintenance/solars/starboard/aft";
-	name = "Starboard Quarter Solar APC";
-	pixel_y = 3
+	name = "Starboard Quarter Solar APC"
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -36418,8 +36412,7 @@
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/west{
 	areastring = "/area/maintenance/solars/starboard/fore";
-	name = "Starboard Bow Solar APC";
-	pixel_y = 3
+	name = "Starboard Bow Solar APC"
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/fore)
@@ -39567,8 +39560,7 @@
 "udB" = (
 /obj/machinery/power/apc/auto_name/directional/west{
 	areastring = "/area/hallway/primary/aft";
-	name = "Aft Hall APC";
-	pixel_y = 1
+	name = "Aft Hall APC"
 	},
 /obj/structure/cable,
 /turf/open/floor/iron,
@@ -40184,8 +40176,7 @@
 "usg" = (
 /obj/machinery/power/apc/auto_name/directional/west{
 	areastring = "/area/maintenance/solars/port/fore";
-	name = "Port Bow Solar APC";
-	pixel_y = 3
+	name = "Port Bow Solar APC"
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -41986,8 +41977,7 @@
 "vlj" = (
 /obj/machinery/power/apc/auto_name/directional/west{
 	areastring = "/area/engineering/gravity_generator";
-	name = "Gravity Generator APC";
-	pixel_y = 1
+	name = "Gravity Generator APC"
 	},
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/line{
@@ -44241,8 +44231,7 @@
 "wnK" = (
 /obj/machinery/power/apc/auto_name/directional/south{
 	areastring = "/area/commons/storage/primary";
-	name = "Primary Tool Storage APC";
-	pixel_x = 1
+	name = "Primary Tool Storage APC"
 	},
 /obj/structure/cable,
 /turf/open/floor/iron,

--- a/_maps/map_files/CubeStation/Cube.dmm
+++ b/_maps/map_files/CubeStation/Cube.dmm
@@ -18930,11 +18930,6 @@
 	},
 /turf/open/floor/iron/sepia,
 /area/service/chapel)
-"jTm" = (
-/turf/open/floor/iron/white,
-/area/medical/medbay/central{
-	dir = 4
-	})
 "jTu" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -78561,7 +78556,7 @@ juF
 jNK
 orO
 juF
-jTm
+juF
 bnw
 xft
 juF

--- a/_maps/map_files/EchoStation/EchoStation.dmm
+++ b/_maps/map_files/EchoStation/EchoStation.dmm
@@ -3516,7 +3516,6 @@
 	dir = 8
 	},
 /obj/structure/cable,
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/main)
 "bQy" = (
@@ -3962,7 +3961,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable,
 /obj/structure/cable,
 /turf/open/floor/wood,
 /area/command/heads_quarters/captain)
@@ -5348,7 +5346,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 6
 	},
-/obj/structure/cable,
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/security/execution/transfer)
@@ -8002,7 +7999,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable,
 /obj/structure/cable,
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
@@ -31612,12 +31608,6 @@
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/medical/pharmacy)
-"qvT" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/tcommsat/computer)
 "qvZ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/camera/directional/east{
@@ -37852,7 +37842,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 9
 	},
-/obj/structure/cable,
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/ai_monitored/security/armory)
@@ -46736,14 +46725,6 @@
 /obj/effect/spawner/random/trash/grille_or_waste,
 /turf/open/floor/plating,
 /area/maintenance/fore)
-"xDk" = (
-/obj/structure/cable,
-/obj/structure/cable,
-/obj/machinery/door/airlock/grunge{
-	name = "Maintenance"
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
 "xDm" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 9
@@ -46950,7 +46931,6 @@
 	charge = 5e+006
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
 /obj/structure/cable,
 /turf/open/floor/circuit,
 /area/tcommsat/server)
@@ -76364,7 +76344,7 @@ vuC
 gbd
 lTA
 lTA
-xDk
+lVP
 lTA
 lTA
 lTA
@@ -79698,7 +79678,7 @@ rIu
 rLn
 rLn
 rLn
-qvT
+rLn
 cha
 yek
 yih

--- a/_maps/map_files/EchoStation/EchoStation.dmm
+++ b/_maps/map_files/EchoStation/EchoStation.dmm
@@ -51,7 +51,7 @@
 /obj/machinery/power/apc/auto_name/directional/north{
 	areastring = "/area/maintenance/starboard/lesser";
 	name = "Starboard Bow  Maintenance 2 APC";
-	pixel_x = 24
+	pixel_x = 25
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -6360,8 +6360,7 @@
 	},
 /obj/machinery/power/apc/auto_name/directional/south{
 	areastring = "/area/security/checkpoint/auxiliary";
-	name = "Security Checkpoint APC";
-	pixel_x = 1
+	name = "Security Checkpoint APC"
 	},
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
@@ -6421,8 +6420,7 @@
 	},
 /obj/machinery/power/apc/auto_name/directional/north{
 	areastring = "/area/maintenance/port/fore";
-	name = "Port Bow Maintenance APC";
-	pixel_x = -1
+	name = "Port Bow Maintenance APC"
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -16893,8 +16891,7 @@
 "iTH" = (
 /obj/machinery/power/apc/auto_name/directional/south{
 	areastring = "/area/cargo/sorting";
-	name = "Delivery Office APC";
-	pixel_x = 1
+	name = "Delivery Office APC"
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -33905,8 +33902,7 @@
 "rAw" = (
 /obj/machinery/power/apc/auto_name/directional/west{
 	areastring = "/area/command/gateway";
-	name = "Gateway APC";
-	pixel_y = -1
+	name = "Gateway APC"
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -35253,8 +35249,7 @@
 "slW" = (
 /obj/machinery/power/apc/auto_name/directional/north{
 	areastring = "/area/cargo/storage";
-	name = "Cargo Bay APC";
-	pixel_x = 1
+	name = "Cargo Bay APC"
 	},
 /obj/structure/cable,
 /obj/structure/closet/crate,
@@ -46132,8 +46127,7 @@
 	},
 /obj/machinery/power/apc/auto_name/directional/west{
 	areastring = "/area/maintenance/port/aft";
-	name = "Port Quarter Maintenance APC";
-	pixel_y = 1
+	name = "Port Quarter Maintenance APC"
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,

--- a/_maps/map_files/EchoStation/EchoStation.dmm
+++ b/_maps/map_files/EchoStation/EchoStation.dmm
@@ -126,12 +126,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/security/processing)
-"aef" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/hallway/primary/central)
 "aeD" = (
 /obj/structure/disposalpipe/sorting/mail/flip{
 	dir = 4;
@@ -6034,7 +6028,6 @@
 	req_access_txt = "2"
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/processing)
 "djk" = (
@@ -10200,12 +10193,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/hallway/primary/aft)
-"fpB" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/grimy,
-/area/commons/vacant_room/office)
 "fqe" = (
 /obj/machinery/door/airlock/atmos{
 	name = "Atmospherics";
@@ -14944,7 +14931,6 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood{
 	icon_state = "wood-broken7"
@@ -33751,7 +33737,6 @@
 "rvr" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/camera/autoname/directional/east{
 	pixel_y = -8
 	},
@@ -37157,12 +37142,6 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen)
-"toS" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/maintenance/starboard/central)
 "tpb" = (
 /obj/structure/cable,
 /obj/effect/spawner/random/trash/garbage,
@@ -85832,7 +85811,7 @@ pcw
 qzz
 qYh
 rvr
-aef
+uQB
 hAz
 uQB
 gEU
@@ -86372,7 +86351,7 @@ tnC
 xbQ
 hUg
 qyu
-fpB
+jTB
 jTB
 jTB
 okP
@@ -93789,7 +93768,7 @@ pAQ
 qfZ
 rpa
 rtS
-toS
+rUQ
 uUP
 rUQ
 rUQ

--- a/_maps/map_files/IceCubeStation/IceCube.dmm
+++ b/_maps/map_files/IceCubeStation/IceCube.dmm
@@ -17092,11 +17092,9 @@
 /obj/structure/chair{
 	dir = 4
 	},
-/obj/machinery/power/apc/auto_name/directional/west{
-	pixel_y = 7
-	},
+/obj/machinery/power/apc/auto_name/directional/west,
 /obj/item/radio/intercom/directional/west{
-	pixel_y = -9
+	pixel_y = 9
 	},
 /obj/effect/turf_decal/siding/blue{
 	dir = 1
@@ -24166,8 +24164,7 @@
 "kqw" = (
 /obj/machinery/power/apc/auto_name/directional/west{
 	areastring = "/area/command/gateway";
-	name = "Gateway APC";
-	pixel_y = -1
+	name = "Gateway APC"
 	},
 /obj/structure/cable,
 /obj/effect/spawner/random/trash/grime,
@@ -31660,8 +31657,7 @@
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/west{
 	areastring = "/area/hallway/primary/aft";
-	name = "Aft Hall APC";
-	pixel_y = 1
+	name = "Aft Hall APC"
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)

--- a/_maps/map_files/IceCubeStation/IceCube.dmm
+++ b/_maps/map_files/IceCubeStation/IceCube.dmm
@@ -53792,10 +53792,7 @@
 	},
 /obj/effect/spawner/random/exotic/tool,
 /turf/open/floor/iron,
-/area/hallway/secondary/construction{
-	pixel_x = -32;
-	pixel_y = 32
-	})
+/area/hallway/secondary/construction)
 "wPR" = (
 /obj/machinery/camera/directional/south{
 	c_tag = "Public Mining Exterior North"

--- a/_maps/map_files/LimaStation/Lima.dmm
+++ b/_maps/map_files/LimaStation/Lima.dmm
@@ -40928,9 +40928,7 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/multilayer{
-	cable_layer = 3
-	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/maintenance/disposal/incinerator)
 "uzD" = (
@@ -41910,7 +41908,7 @@
 /obj/machinery/portable_atmospherics/canister,
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/layer1,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/maintenance/disposal/incinerator)
 "vfc" = (
@@ -43123,7 +43121,7 @@
 	pixel_x = 29
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/layer1,
+/obj/structure/cable,
 /obj/machinery/light_switch{
 	pixel_x = 22;
 	pixel_y = 11
@@ -43826,7 +43824,7 @@
 /area/hallway/primary/starboard)
 "woY" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/layer1,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/maintenance/disposal/incinerator)
 "wpu" = (
@@ -43845,7 +43843,7 @@
 	pixel_y = -24
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/layer1,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/maintenance/disposal/incinerator)
 "wpG" = (
@@ -44095,7 +44093,7 @@
 	pixel_y = -24
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/layer1,
+/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
@@ -44136,7 +44134,7 @@
 	pixel_y = -32
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/layer1,
+/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/pink/visible,
 /turf/open/floor/iron,
 /area/maintenance/disposal/incinerator)
@@ -44550,7 +44548,7 @@
 	pixel_x = 38;
 	pixel_y = 6
 	},
-/obj/structure/cable/layer1,
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/maintenance/disposal/incinerator)
 "wMv" = (
@@ -45211,7 +45209,7 @@
 /obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume/incinerator_atmos{
 	dir = 8
 	},
-/obj/structure/cable/layer1,
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/maintenance/disposal/incinerator)
 "xds" = (
@@ -45837,7 +45835,7 @@
 "xsx" = (
 /obj/effect/mapping_helpers/airlock/locked,
 /obj/machinery/door/airlock/public/glass/incinerator/atmos_exterior,
-/obj/structure/cable/layer1,
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/maintenance/disposal/incinerator)
 "xsI" = (
@@ -46395,7 +46393,7 @@
 	pixel_y = -32
 	},
 /obj/machinery/igniter/incinerator_atmos,
-/obj/structure/cable/layer1,
+/obj/structure/cable,
 /turf/open/floor/engine/vacuum,
 /area/maintenance/disposal/incinerator)
 "xGv" = (
@@ -46522,9 +46520,7 @@
 	c_tag = "Turbine Chamber";
 	network = list("turbine")
 	},
-/obj/structure/cable/multilayer{
-	cable_layer = 3
-	},
+/obj/structure/cable,
 /turf/open/floor/engine/vacuum,
 /area/maintenance/disposal/incinerator)
 "xKY" = (
@@ -47091,9 +47087,7 @@
 /obj/machinery/power/turbine{
 	luminosity = 2
 	},
-/obj/structure/cable/multilayer{
-	cable_layer = 3
-	},
+/obj/structure/cable,
 /turf/open/floor/engine/vacuum,
 /area/maintenance/disposal/incinerator)
 "yau" = (

--- a/_maps/map_files/LimaStation/Lima.dmm
+++ b/_maps/map_files/LimaStation/Lima.dmm
@@ -3854,7 +3854,6 @@
 	charge = 5e+006
 	},
 /obj/structure/cable,
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/gravity_generator)
 "aSk" = (

--- a/_maps/map_files/LimaStation/Lima.dmm
+++ b/_maps/map_files/LimaStation/Lima.dmm
@@ -22194,9 +22194,7 @@
 /obj/structure/table,
 /obj/item/storage/fancy/donut_box,
 /obj/machinery/airalarm/directional/east,
-/obj/machinery/power/apc/auto_name/directional/north{
-	pixel_x = 3
-	},
+/obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 5

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -1815,11 +1815,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/ai_upload)
-"agB" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/purple/visible,
-/turf/closed/wall/r_wall,
-/area/maintenance/disposal/incinerator)
 "agD" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -36793,7 +36788,6 @@
 /area/service/chapel)
 "eNF" = (
 /obj/structure/grille,
-/obj/structure/lattice,
 /turf/closed/wall,
 /area/space/nearstation)
 "eOe" = (
@@ -43441,10 +43435,6 @@
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/department/security/brig)
-"oTJ" = (
-/obj/structure/lattice,
-/turf/closed/wall,
-/area/maintenance/department/engine)
 "oUa" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -47845,10 +47835,6 @@
 /obj/effect/turf_decal/tile/yellow/half/contrasted,
 /turf/open/floor/iron,
 /area/engineering/main)
-"vkd" = (
-/obj/structure/lattice,
-/turf/closed/wall,
-/area/maintenance/department/science/xenobiology)
 "vlF" = (
 /obj/item/coin/silver,
 /obj/effect/decal/cleanable/oil{
@@ -73817,7 +73803,7 @@ bEr
 bEr
 bEr
 aht
-oTJ
+bva
 tYF
 bFZ
 crC
@@ -89762,7 +89748,7 @@ caQ
 bnc
 caQ
 sCf
-agB
+qXu
 qXu
 bZi
 bZR
@@ -99756,7 +99742,7 @@ xKc
 aiw
 krC
 pgk
-vkd
+pgk
 pgk
 vtl
 pgk

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -38247,7 +38247,6 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/checkpoint/science)
 "gRv" = (

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -12444,9 +12444,7 @@
 /area/security/checkpoint/supply)
 "aOS" = (
 /obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/south{
-	pixel_x = 3
-	},
+/obj/machinery/power/apc/auto_name/directional/south,
 /obj/machinery/light_switch/directional/south{
 	pixel_x = -9
 	},
@@ -16100,8 +16098,7 @@
 /area/security/checkpoint/customs)
 "baU" = (
 /obj/machinery/power/apc/auto_name/directional/south{
-	name = "Security Checkpoint APC";
-	pixel_x = 1
+	name = "Security Checkpoint APC"
 	},
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/red/anticorner/contrasted,
@@ -24314,7 +24311,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/power/apc/auto_name/directional/north{
-	pixel_x = -26;
+	pixel_x = -25;
 	name = "Science Security APC"
 	},
 /obj/structure/cable,
@@ -27246,8 +27243,7 @@
 /area/engineering/storage/tech)
 "bQB" = (
 /obj/machinery/power/apc/auto_name/directional/west{
-	name = "Aft Hall APC";
-	pixel_y = 1
+	name = "Aft Hall APC"
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -28144,8 +28140,7 @@
 /area/engineering/gravity_generator)
 "bTr" = (
 /obj/machinery/power/apc/auto_name/directional/west{
-	name = "Gravity Generator APC";
-	pixel_y = 1
+	name = "Gravity Generator APC"
 	},
 /obj/structure/table,
 /obj/item/paper/guides/jobs/engi/gravity_gen,
@@ -29873,8 +29868,7 @@
 "bYt" = (
 /obj/machinery/power/apc/auto_name/directional/north{
 	areastring = "/area/medical/exam_room";
-	name = "Treatment Centre APC";
-	pixel_x = -3
+	name = "Treatment Centre APC"
 	},
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/blue/fourcorners,
@@ -33273,8 +33267,7 @@
 	},
 /obj/machinery/power/apc/auto_name/directional/east{
 	areastring = "/area/medical/medbay/lobby";
-	name = "Medbay Lobby APC";
-	pixel_y = 6
+	name = "Medbay Lobby APC"
 	},
 /obj/structure/cable,
 /turf/open/floor/iron/white,
@@ -48812,8 +48805,7 @@
 /obj/machinery/power/apc/highcap/five_k{
 	dir = 8;
 	name = "Engineering Maintenance APC";
-	pixel_x = -25;
-	pixel_y = 1
+	pixel_x = -25
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,

--- a/_maps/map_files/ShitStation/ShitStation.dmm
+++ b/_maps/map_files/ShitStation/ShitStation.dmm
@@ -203,9 +203,7 @@
 /obj/machinery/power/turbine{
 	dir = 1
 	},
-/obj/structure/cable/multilayer{
-	cable_layer = 1
-	},
+/obj/structure/cable/multilayer/connected,
 /obj/structure/cable,
 /turf/open/floor/engine/vacuum,
 /area/maintenance/disposal/incinerator)
@@ -281,9 +279,7 @@
 /obj/machinery/power/compressor{
 	comp_id = "incineratorturbine"
 	},
-/obj/structure/cable/multilayer{
-	cable_layer = 1
-	},
+/obj/structure/cable/multilayer/connected,
 /obj/structure/cable,
 /turf/open/floor/engine/vacuum,
 /area/maintenance/disposal/incinerator)

--- a/_maps/map_files/ShitStation/ShitStation.dmm
+++ b/_maps/map_files/ShitStation/ShitStation.dmm
@@ -9124,10 +9124,6 @@
 /obj/structure/closet/secure_closet/research_director,
 /turf/open/floor/wood,
 /area/command/heads_quarters/rd)
-"aBx" = (
-/obj/structure/lattice/catwalk,
-/turf/closed/wall/r_wall,
-/area/tcommsat/server)
 "aBy" = (
 /obj/machinery/computer/security{
 	dir = 1
@@ -11260,10 +11256,6 @@
 /obj/item/radio/intercom/directional/west,
 /turf/open/floor/iron/dark/airless,
 /area/tcommsat/server)
-"aIg" = (
-/obj/structure/lattice,
-/turf/closed/wall,
-/area/maintenance/department/cargo)
 "aIp" = (
 /turf/closed/wall/rust,
 /area/space/nearstation)
@@ -20229,11 +20221,6 @@
 /obj/structure/bookcase/random,
 /turf/open/floor/wood,
 /area/service/library)
-"hus" = (
-/obj/structure/grille,
-/obj/structure/lattice,
-/turf/closed/wall/r_wall,
-/area/space/nearstation)
 "huB" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -27
@@ -84186,7 +84173,7 @@ aqr
 oZN
 aDs
 oZN
-aIg
+oZN
 oZN
 oZN
 aqr
@@ -87835,7 +87822,7 @@ aaa
 aaa
 aaa
 hET
-hus
+hET
 hET
 aaa
 aaa
@@ -88092,7 +88079,7 @@ aaa
 aaa
 aaa
 hET
-hus
+hET
 hET
 aaa
 aaa
@@ -88349,7 +88336,7 @@ aeQ
 aaa
 aaa
 hET
-hus
+hET
 hET
 aaa
 aaa
@@ -89376,9 +89363,9 @@ aeR
 akE
 azl
 azl
-hus
-hus
-hus
+hET
+hET
+hET
 aaa
 aaa
 aaa
@@ -90142,7 +90129,7 @@ mFv
 mFv
 mFv
 hvL
-aBx
+rqR
 qxc
 akE
 aeR
@@ -90918,9 +90905,9 @@ aBK
 aeQ
 aeQ
 aaa
-hus
-hus
-hus
+hET
+hET
+hET
 aaa
 aaa
 aaa
@@ -91931,24 +91918,24 @@ aaa
 aaa
 aaa
 hET
-hus
 hET
 hET
-hus
+hET
+hET
 hET
 hET
 gvy
 hET
 hET
-hus
+hET
 gvy
 hET
 hET
-hus
 hET
-hus
-hus
-hus
+hET
+hET
+hET
+hET
 aaa
 aaa
 aaa
@@ -92188,20 +92175,20 @@ aaa
 aaa
 aaa
 hET
-hus
 hET
 hET
-hus
+hET
+hET
 hET
 hET
 gvy
 hET
 hET
-hus
+hET
 gvy
 hET
 hET
-hus
+hET
 hET
 hET
 hET
@@ -92445,20 +92432,20 @@ aaa
 aaa
 aaa
 hET
-hus
 hET
 hET
-hus
+hET
+hET
 hET
 hET
 gvy
 hET
 hET
-hus
+hET
 gvy
 hET
 hET
-hus
+hET
 hET
 hET
 hET
@@ -154138,7 +154125,7 @@ azk
 azk
 aaa
 aaa
-hus
+hET
 hET
 aaa
 aaa
@@ -154395,7 +154382,7 @@ aaa
 aaa
 aaa
 aaa
-hus
+hET
 hET
 aaa
 aaa
@@ -154652,7 +154639,7 @@ aaa
 aaa
 aaa
 aaa
-hus
+hET
 hET
 aaa
 aaa
@@ -154909,7 +154896,7 @@ aMa
 aaa
 aaa
 aaa
-hus
+hET
 hET
 aaa
 aaa
@@ -155166,7 +155153,7 @@ aMa
 azk
 aaa
 azk
-hus
+hET
 hET
 aaa
 aaa
@@ -155423,7 +155410,7 @@ aMa
 azk
 azk
 azk
-hus
+hET
 hET
 aaa
 aaa
@@ -155680,7 +155667,7 @@ aMa
 aaa
 aaa
 azk
-hus
+hET
 hET
 aaa
 aaa
@@ -155937,7 +155924,7 @@ aMa
 aaa
 aaa
 aaa
-hus
+hET
 hET
 aaa
 aaa
@@ -156194,7 +156181,7 @@ aaa
 aaa
 aaa
 aaa
-hus
+hET
 hET
 aaa
 aaa
@@ -156451,7 +156438,7 @@ aaa
 azk
 azk
 aaa
-hus
+hET
 hET
 aaa
 aaa
@@ -156708,7 +156695,7 @@ aaa
 aaa
 aaa
 aaa
-hus
+hET
 hET
 aaa
 aaa
@@ -156954,18 +156941,18 @@ aaa
 aaa
 aaa
 aaa
-hus
 hET
 hET
 hET
 hET
-hus
 hET
 hET
-hus
 hET
 hET
-hus
+hET
+hET
+hET
+hET
 hET
 aaa
 aaa
@@ -157211,18 +157198,18 @@ aaa
 aaa
 aaa
 aaa
-hus
 hET
 hET
 hET
 hET
-hus
 hET
 hET
-hus
 hET
 hET
-hus
+hET
+hET
+hET
+hET
 hET
 aaa
 aaa

--- a/_maps/map_files/ShitStation/ShitStation.dmm
+++ b/_maps/map_files/ShitStation/ShitStation.dmm
@@ -26751,7 +26751,7 @@
 /obj/effect/spawner/random/contraband/armory,
 /obj/effect/landmark/start/warden,
 /obj/item/paper/fluff{
-	info = "You have been in cryostasis for [REDACTED] years. New crew should be arriving this month. We left you in this closet to thaw. Glory to NanoTrasen.";
+	info = "You have been in cryostasis for \[REDACTED] years. New crew should be arriving this month. We left you in this closet to thaw. Glory to NanoTrasen.";
 	name = "CentCom Notice"
 	},
 /turf/open/floor/plating,
@@ -35868,7 +35868,7 @@
 /obj/effect/landmark/start/paramedic,
 /obj/effect/spawner/random/medical/surgery_tool_alien,
 /obj/item/paper/fluff{
-	info = "You have been in cryostasis for [REDACTED] years. New crew should be arriving this month. We left you in this closet to thaw. Glory to NanoTrasen.";
+	info = "You have been in cryostasis for \[REDACTED] years. New crew should be arriving this month. We left you in this closet to thaw. Glory to NanoTrasen.";
 	name = "CentCom Notice"
 	},
 /turf/open/floor/plating{
@@ -39978,7 +39978,7 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/landmark/start/atmospheric_technician,
 /obj/item/paper/fluff{
-	info = "You have been in cryostasis for [REDACTED] years. New crew should be arriving this month. We left you in this closet to thaw. Glory to NanoTrasen.";
+	info = "You have been in cryostasis for \[REDACTED] years. New crew should be arriving this month. We left you in this closet to thaw. Glory to NanoTrasen.";
 	name = "CentCom Notice"
 	},
 /turf/open/floor/plating,

--- a/_maps/map_files/ShitStation/ShitStation.dmm
+++ b/_maps/map_files/ShitStation/ShitStation.dmm
@@ -3884,7 +3884,6 @@
 /obj/structure/cable,
 /obj/structure/bed,
 /obj/item/bedsheet/ce,
-/obj/structure/cable,
 /turf/open/floor/wood,
 /area/command/heads_quarters/hos)
 "anz" = (

--- a/_maps/map_files/ShitStation/ShitStation.dmm
+++ b/_maps/map_files/ShitStation/ShitStation.dmm
@@ -266,9 +266,7 @@
 /area/maintenance/central)
 "abc" = (
 /turf/closed/wall,
-/area/medical/chemistry{
-	name = "Meth Lab"
-	})
+/area/medical/chemistry/lab)
 "abd" = (
 /obj/effect/turf_decal/arrows/red{
 	dir = 4
@@ -913,9 +911,7 @@
 /area/ai_monitored/security/armory)
 "adr" = (
 /turf/open/floor/mineral/bananium,
-/area/command/bridge{
-	name = "Bridgenana"
-	})
+/area/command/bridge/bridgenana)
 "ads" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/bananium/glass{
@@ -927,9 +923,7 @@
 	cycle_id = "bridge-left"
 	},
 /turf/open/floor/iron/dark,
-/area/command/bridge{
-	name = "Bridgenana"
-	})
+/area/command/bridge/bridgenana)
 "adt" = (
 /obj/structure/sign/departments/science{
 	pixel_x = 32
@@ -962,9 +956,7 @@
 "adw" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
-/area/command/bridge{
-	name = "Bridgenana"
-	})
+/area/command/bridge/bridgenana)
 "adx" = (
 /turf/open/floor/iron/dark,
 /area/hallway/secondary/command)
@@ -1010,9 +1002,7 @@
 "adD" = (
 /obj/structure/filingcabinet/employment,
 /turf/open/floor/wood,
-/area/command/heads_quarters/hop{
-	name = "Ian's Quarters"
-	})
+/area/command/heads_quarters/hop/ians_quarters)
 "adE" = (
 /obj/structure/rack,
 /obj/item/camera,
@@ -1089,9 +1079,7 @@
 /area/maintenance/department/engine/atmos)
 "adP" = (
 /turf/closed/wall/r_wall,
-/area/command/bridge{
-	name = "Bridgenana"
-	})
+/area/command/bridge/bridgenana)
 "adQ" = (
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
@@ -1445,9 +1433,7 @@
 /area/science/mixing)
 "afv" = (
 /turf/closed/wall/r_wall,
-/area/command/heads_quarters/hop{
-	name = "Ian's Quarters"
-	})
+/area/command/heads_quarters/hop/ians_quarters)
 "afw" = (
 /obj/effect/turf_decal/tile/blue/anticorner{
 	dir = 1
@@ -1566,9 +1552,7 @@
 	dir = 4
 	},
 /turf/closed/wall/r_wall,
-/area/command/heads_quarters/hop{
-	name = "Ian's Quarters"
-	})
+/area/command/heads_quarters/hop/ians_quarters)
 "afQ" = (
 /obj/machinery/airalarm/directional/north,
 /obj/machinery/button/door{
@@ -1703,9 +1687,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/white,
-/area/medical/chemistry{
-	name = "Meth Lab"
-	})
+/area/medical/chemistry/lab)
 "agi" = (
 /turf/open/floor/plating,
 /area/service/chapel)
@@ -1835,9 +1817,7 @@
 	dir = 4
 	},
 /turf/open/floor/mineral/bananium,
-/area/command/bridge{
-	name = "Bridgenana"
-	})
+/area/command/bridge/bridgenana)
 "agG" = (
 /obj/machinery/airalarm/directional/south,
 /obj/effect/decal/cleanable/dirt,
@@ -1876,15 +1856,11 @@
 /obj/machinery/camera/autoname/directional/west,
 /obj/structure/cable,
 /turf/open/floor/wood,
-/area/command/heads_quarters/hop{
-	name = "Ian's Quarters"
-	})
+/area/command/heads_quarters/hop/ians_quarters)
 "agN" = (
 /obj/structure/cable,
 /turf/closed/wall/r_wall,
-/area/command/bridge{
-	name = "Bridgenana"
-	})
+/area/command/bridge/bridgenana)
 "agO" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
 /obj/machinery/newscaster{
@@ -1933,9 +1909,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /turf/open/floor/mineral/bananium,
-/area/command/bridge{
-	name = "Bridgenana"
-	})
+/area/command/bridge/bridgenana)
 "agW" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/purple/visible,
@@ -1950,9 +1924,7 @@
 	dir = 4
 	},
 /turf/open/floor/mineral/bananium,
-/area/command/bridge{
-	name = "Bridgenana"
-	})
+/area/command/bridge/bridgenana)
 "aha" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
@@ -2062,9 +2034,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /turf/open/floor/mineral/bananium,
-/area/command/bridge{
-	name = "Bridgenana"
-	})
+/area/command/bridge/bridgenana)
 "ahw" = (
 /obj/machinery/light,
 /obj/structure/chair{
@@ -2265,9 +2235,7 @@
 	cycle_id = "bridge-left"
 	},
 /turf/open/floor/iron/dark,
-/area/command/bridge{
-	name = "Bridgenana"
-	})
+/area/command/bridge/bridgenana)
 "ahZ" = (
 /obj/structure/bed,
 /obj/effect/landmark/start/prisoner,
@@ -2522,18 +2490,14 @@
 	dir = 1
 	},
 /turf/open/floor/iron/white,
-/area/medical/chemistry{
-	name = "Meth Lab"
-	})
+/area/medical/chemistry/lab)
 "aiN" = (
 /obj/machinery/chem_master,
 /obj/effect/turf_decal/tile/blue/half{
 	dir = 1
 	},
 /turf/open/floor/iron/white,
-/area/medical/chemistry{
-	name = "Meth Lab"
-	})
+/area/medical/chemistry/lab)
 "aiO" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -2549,18 +2513,14 @@
 	dir = 1
 	},
 /turf/open/floor/iron/white,
-/area/medical/chemistry{
-	name = "Meth Lab"
-	})
+/area/medical/chemistry/lab)
 "aiQ" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/blue/half{
 	dir = 1
 	},
 /turf/open/floor/iron/white,
-/area/medical/chemistry{
-	name = "Meth Lab"
-	})
+/area/medical/chemistry/lab)
 "aiR" = (
 /obj/machinery/door/airlock/medical/glass{
 	name = "Chemistry Lab";
@@ -2571,9 +2531,7 @@
 	location = "Chemistry"
 	},
 /turf/open/floor/iron/white,
-/area/medical/chemistry{
-	name = "Meth Lab"
-	})
+/area/medical/chemistry/lab)
 "aiT" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
@@ -2583,9 +2541,7 @@
 "aiU" = (
 /obj/machinery/chem_heater,
 /turf/open/floor/iron/white,
-/area/medical/chemistry{
-	name = "Meth Lab"
-	})
+/area/medical/chemistry/lab)
 "aiV" = (
 /obj/item/book/manual/wiki/chemistry{
 	pixel_x = 4;
@@ -2594,9 +2550,7 @@
 /obj/item/book/manual/wiki/plumbing,
 /obj/structure/table/glass,
 /turf/open/floor/iron/white,
-/area/medical/chemistry{
-	name = "Meth Lab"
-	})
+/area/medical/chemistry/lab)
 "aiY" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -2604,9 +2558,7 @@
 	},
 /obj/effect/turf_decal/stripes/box,
 /turf/open/floor/iron/white,
-/area/medical/chemistry{
-	name = "Meth Lab"
-	})
+/area/medical/chemistry/lab)
 "aiZ" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass,
@@ -2621,9 +2573,7 @@
 	},
 /obj/structure/table/glass,
 /turf/open/floor/iron/white,
-/area/medical/chemistry{
-	name = "Meth Lab"
-	})
+/area/medical/chemistry/lab)
 "ajb" = (
 /obj/structure/cable,
 /turf/open/floor/iron,
@@ -2634,9 +2584,7 @@
 	},
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron/white,
-/area/medical/chemistry{
-	name = "Meth Lab"
-	})
+/area/medical/chemistry/lab)
 "ajd" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -2721,9 +2669,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/white,
-/area/medical/chemistry{
-	name = "Meth Lab"
-	})
+/area/medical/chemistry/lab)
 "ajq" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
 /obj/structure/stairs/north,
@@ -3689,9 +3635,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/wood,
-/area/command/heads_quarters/hop{
-	name = "Ian's Quarters"
-	})
+/area/command/heads_quarters/hop/ians_quarters)
 "amL" = (
 /obj/structure/disposalpipe/junction/yjunction{
 	dir = 4
@@ -4062,9 +4006,7 @@
 	dir = 4
 	},
 /turf/open/floor/mineral/bananium,
-/area/command/bridge{
-	name = "Bridgenana"
-	})
+/area/command/bridge/bridgenana)
 "aom" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/dark,
@@ -4074,18 +4016,14 @@
 	dir = 5
 	},
 /turf/open/floor/mineral/bananium,
-/area/command/bridge{
-	name = "Bridgenana"
-	})
+/area/command/bridge/bridgenana)
 "aoo" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
 /turf/open/floor/mineral/bananium,
-/area/command/bridge{
-	name = "Bridgenana"
-	})
+/area/command/bridge/bridgenana)
 "aop" = (
 /obj/structure/disposalpipe/segment,
 /turf/closed/wall/r_wall,
@@ -4169,9 +4107,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /turf/open/floor/wood,
-/area/command/heads_quarters/hop{
-	name = "Ian's Quarters"
-	})
+/area/command/heads_quarters/hop/ians_quarters)
 "aoA" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -4182,9 +4118,7 @@
 /obj/structure/table/wood,
 /obj/item/storage/box/pdas,
 /turf/open/floor/wood,
-/area/command/heads_quarters/hop{
-	name = "Ian's Quarters"
-	})
+/area/command/heads_quarters/hop/ians_quarters)
 "aoB" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/left/directional/west{
@@ -4200,9 +4134,7 @@
 	},
 /obj/effect/spawner/random/entertainment/wallet_storage,
 /turf/open/floor/wood,
-/area/command/heads_quarters/hop{
-	name = "Ian's Quarters"
-	})
+/area/command/heads_quarters/hop/ians_quarters)
 "aoC" = (
 /obj/machinery/firealarm{
 	dir = 8;
@@ -4228,9 +4160,7 @@
 "aoH" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/wood,
-/area/command/heads_quarters/hop{
-	name = "Ian's Quarters"
-	})
+/area/command/heads_quarters/hop/ians_quarters)
 "aoI" = (
 /obj/machinery/power/apc/auto_cell/west{
 	dir = 2;
@@ -4366,9 +4296,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/wood,
-/area/command/heads_quarters/hop{
-	name = "Ian's Quarters"
-	})
+/area/command/heads_quarters/hop/ians_quarters)
 "apb" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -4890,9 +4818,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/white,
-/area/medical/chemistry{
-	name = "Meth Lab"
-	})
+/area/medical/chemistry/lab)
 "aqG" = (
 /obj/item/statuebust/hippocratic,
 /obj/machinery/navbeacon/wayfinding/med,
@@ -5932,9 +5858,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/white,
-/area/medical/chemistry{
-	name = "Meth Lab"
-	})
+/area/medical/chemistry/lab)
 "atI" = (
 /obj/machinery/door/window/left/directional/west{
 	dir = 4;
@@ -6183,9 +6107,7 @@
 /obj/machinery/door/firedoor,
 /obj/item/stock_parts/cell/lead,
 /turf/open/floor/iron/white,
-/area/medical/chemistry{
-	name = "Meth Lab"
-	})
+/area/medical/chemistry/lab)
 "aun" = (
 /obj/structure/chair/office,
 /obj/effect/turf_decal/tile/purple/half{
@@ -6595,9 +6517,7 @@
 	dir = 8
 	},
 /turf/open/floor/mineral/bananium,
-/area/command/bridge{
-	name = "Bridgenana"
-	})
+/area/command/bridge/bridgenana)
 "avo" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -6606,9 +6526,7 @@
 	dir = 8
 	},
 /turf/open/floor/mineral/bananium,
-/area/command/bridge{
-	name = "Bridgenana"
-	})
+/area/command/bridge/bridgenana)
 "avp" = (
 /obj/structure/closet/secure_closet/chief_medical,
 /obj/structure/cable,
@@ -6624,9 +6542,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/wood,
-/area/command/heads_quarters/hop{
-	name = "Ian's Quarters"
-	})
+/area/command/heads_quarters/hop/ians_quarters)
 "avr" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -6839,9 +6755,7 @@
 /obj/effect/landmark/event_spawn,
 /obj/structure/chair/office,
 /turf/open/floor/iron/white,
-/area/medical/chemistry{
-	name = "Meth Lab"
-	})
+/area/medical/chemistry/lab)
 "avV" = (
 /obj/machinery/light{
 	dir = 1
@@ -6901,9 +6815,7 @@
 	dir = 6
 	},
 /turf/open/floor/mineral/bananium,
-/area/command/bridge{
-	name = "Bridgenana"
-	})
+/area/command/bridge/bridgenana)
 "awf" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -6971,9 +6883,7 @@
 	dir = 4
 	},
 /turf/open/floor/wood,
-/area/command/heads_quarters/hop{
-	name = "Ian's Quarters"
-	})
+/area/command/heads_quarters/hop/ians_quarters)
 "awl" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -6984,9 +6894,7 @@
 	pixel_x = 32
 	},
 /turf/open/floor/mineral/bananium,
-/area/command/bridge{
-	name = "Bridgenana"
-	})
+/area/command/bridge/bridgenana)
 "awm" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -7022,17 +6930,13 @@
 	pixel_x = 16
 	},
 /turf/open/floor/mineral/bananium,
-/area/command/bridge{
-	name = "Bridgenana"
-	})
+/area/command/bridge/bridgenana)
 "awq" = (
 /obj/machinery/firealarm{
 	pixel_y = 28
 	},
 /turf/open/floor/mineral/bananium,
-/area/command/bridge{
-	name = "Bridgenana"
-	})
+/area/command/bridge/bridgenana)
 "aws" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -7049,18 +6953,14 @@
 	pixel_y = -30
 	},
 /turf/open/floor/wood,
-/area/command/heads_quarters/hop{
-	name = "Ian's Quarters"
-	})
+/area/command/heads_quarters/hop/ians_quarters)
 "awt" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
 /turf/open/floor/mineral/bananium,
-/area/command/bridge{
-	name = "Bridgenana"
-	})
+/area/command/bridge/bridgenana)
 "awu" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Bridge Maintenance";
@@ -7077,9 +6977,7 @@
 	dir = 8
 	},
 /turf/open/floor/mineral/bananium,
-/area/command/bridge{
-	name = "Bridgenana"
-	})
+/area/command/bridge/bridgenana)
 "awx" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -7121,16 +7019,12 @@
 /obj/machinery/photocopier,
 /obj/structure/cable,
 /turf/open/floor/wood,
-/area/command/heads_quarters/hop{
-	name = "Ian's Quarters"
-	})
+/area/command/heads_quarters/hop/ians_quarters)
 "awD" = (
 /obj/machinery/pdapainter,
 /obj/structure/cable,
 /turf/open/floor/wood,
-/area/command/heads_quarters/hop{
-	name = "Ian's Quarters"
-	})
+/area/command/heads_quarters/hop/ians_quarters)
 "awE" = (
 /obj/structure/disposalpipe/junction{
 	dir = 4
@@ -7172,9 +7066,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/white,
-/area/medical/chemistry{
-	name = "Meth Lab"
-	})
+/area/medical/chemistry/lab)
 "awH" = (
 /obj/item/reagent_containers/glass/bottle/chlorine{
 	pixel_x = -6;
@@ -7203,9 +7095,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/white,
-/area/medical/chemistry{
-	name = "Meth Lab"
-	})
+/area/medical/chemistry/lab)
 "awI" = (
 /obj/item/reagent_containers/glass/bottle/fluorine{
 	pixel_x = -6;
@@ -7235,9 +7125,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/white,
-/area/medical/chemistry{
-	name = "Meth Lab"
-	})
+/area/medical/chemistry/lab)
 "awJ" = (
 /obj/item/reagent_containers/glass/bottle/lithium{
 	pixel_x = -6;
@@ -7266,9 +7154,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/white,
-/area/medical/chemistry{
-	name = "Meth Lab"
-	})
+/area/medical/chemistry/lab)
 "awK" = (
 /obj/machinery/power/apc/auto_cell/west{
 	dir = 2;
@@ -7307,9 +7193,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/white,
-/area/medical/chemistry{
-	name = "Meth Lab"
-	})
+/area/medical/chemistry/lab)
 "awL" = (
 /obj/item/reagent_containers/glass/bottle/potassium{
 	pixel_x = -6;
@@ -7339,9 +7223,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/white,
-/area/medical/chemistry{
-	name = "Meth Lab"
-	})
+/area/medical/chemistry/lab)
 "awM" = (
 /obj/item/reagent_containers/glass/bottle/sulfur{
 	pixel_x = -6;
@@ -7371,9 +7253,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/white,
-/area/medical/chemistry{
-	name = "Meth Lab"
-	})
+/area/medical/chemistry/lab)
 "awN" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
@@ -7382,9 +7262,7 @@
 	dir = 8
 	},
 /turf/open/floor/mineral/bananium,
-/area/command/bridge{
-	name = "Bridgenana"
-	})
+/area/command/bridge/bridgenana)
 "awO" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
 /obj/structure/cable,
@@ -7395,9 +7273,7 @@
 	pixel_x = 28
 	},
 /turf/open/floor/mineral/bananium,
-/area/command/bridge{
-	name = "Bridgenana"
-	})
+/area/command/bridge/bridgenana)
 "awP" = (
 /obj/structure/disposalpipe/junction/flip{
 	dir = 4
@@ -7415,9 +7291,7 @@
 /obj/item/beacon,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /turf/open/floor/mineral/bananium,
-/area/command/bridge{
-	name = "Bridgenana"
-	})
+/area/command/bridge/bridgenana)
 "awR" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -7426,24 +7300,18 @@
 	dir = 8
 	},
 /turf/open/floor/mineral/bananium,
-/area/command/bridge{
-	name = "Bridgenana"
-	})
+/area/command/bridge/bridgenana)
 "awS" = (
 /obj/machinery/status_display/evac{
 	pixel_x = 32
 	},
 /obj/structure/stairs/east,
 /turf/open/floor/mineral/bananium,
-/area/command/bridge{
-	name = "Bridgenana"
-	})
+/area/command/bridge/bridgenana)
 "awT" = (
 /obj/structure/stairs/east,
 /turf/open/floor/mineral/bananium,
-/area/command/bridge{
-	name = "Bridgenana"
-	})
+/area/command/bridge/bridgenana)
 "awU" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -7458,9 +7326,7 @@
 	dir = 4
 	},
 /turf/open/floor/mineral/bananium,
-/area/command/bridge{
-	name = "Bridgenana"
-	})
+/area/command/bridge/bridgenana)
 "awV" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -7469,9 +7335,7 @@
 	dir = 4
 	},
 /turf/open/floor/mineral/bananium,
-/area/command/bridge{
-	name = "Bridgenana"
-	})
+/area/command/bridge/bridgenana)
 "awW" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -7574,9 +7438,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/command/heads_quarters/hop{
-	name = "Ian's Quarters"
-	})
+/area/command/heads_quarters/hop/ians_quarters)
 "axj" = (
 /obj/machinery/door/airlock/command/glass{
 	name = "Ian's Quarters";
@@ -7585,18 +7447,14 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
 /turf/open/floor/wood,
-/area/command/heads_quarters/hop{
-	name = "Ian's Quarters"
-	})
+/area/command/heads_quarters/hop/ians_quarters)
 "axk" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "captainprivacy"
 	},
 /turf/open/floor/plating,
-/area/command/bridge{
-	name = "Bridgenana"
-	})
+/area/command/bridge/bridgenana)
 "axl" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -7611,9 +7469,7 @@
 	name = "bridge power monitoring console"
 	},
 /turf/open/floor/mineral/bananium,
-/area/command/bridge{
-	name = "Bridgenana"
-	})
+/area/command/bridge/bridgenana)
 "axn" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -7645,9 +7501,7 @@
 	req_access = null
 	},
 /turf/open/floor/mineral/bananium,
-/area/command/bridge{
-	name = "Bridgenana"
-	})
+/area/command/bridge/bridgenana)
 "axs" = (
 /obj/machinery/door/airlock/research/glass{
 	name = "Robotics Lab";
@@ -8219,9 +8073,7 @@
 	dir = 8
 	},
 /turf/open/floor/mineral/bananium,
-/area/command/bridge{
-	name = "Bridgenana"
-	})
+/area/command/bridge/bridgenana)
 "ayI" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -8241,9 +8093,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/white,
-/area/medical/chemistry{
-	name = "Meth Lab"
-	})
+/area/medical/chemistry/lab)
 "ayK" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
@@ -8278,9 +8128,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/white,
-/area/medical/chemistry{
-	name = "Meth Lab"
-	})
+/area/medical/chemistry/lab)
 "ayQ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /obj/effect/turf_decal/tile/blue/half,
@@ -8301,16 +8149,12 @@
 	dir = 8
 	},
 /turf/open/floor/iron/white,
-/area/medical/chemistry{
-	name = "Meth Lab"
-	})
+/area/medical/chemistry/lab)
 "ayS" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/blue/half,
 /turf/open/floor/iron/white,
-/area/medical/chemistry{
-	name = "Meth Lab"
-	})
+/area/medical/chemistry/lab)
 "ayT" = (
 /obj/structure/window/fulltile,
 /obj/effect/turf_decal/tile/blue,
@@ -8989,9 +8833,7 @@
 	dir = 4
 	},
 /turf/open/floor/mineral/bananium,
-/area/command/bridge{
-	name = "Bridgenana"
-	})
+/area/command/bridge/bridgenana)
 "aBj" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -9006,9 +8848,7 @@
 	pixel_y = -25
 	},
 /turf/open/floor/mineral/bananium,
-/area/command/bridge{
-	name = "Bridgenana"
-	})
+/area/command/bridge/bridgenana)
 "aBk" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -9022,9 +8862,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /turf/open/floor/mineral/bananium,
-/area/command/bridge{
-	name = "Bridgenana"
-	})
+/area/command/bridge/bridgenana)
 "aBl" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -10500,9 +10338,7 @@
 /mob/living/simple_animal/pet/dog/corgi/ian,
 /obj/structure/cable,
 /turf/open/floor/wood,
-/area/command/heads_quarters/hop{
-	name = "Ian's Quarters"
-	})
+/area/command/heads_quarters/hop/ians_quarters)
 "aFt" = (
 /obj/structure/bed/dogbed/renault,
 /mob/living/simple_animal/pet/fox/renault,
@@ -10605,9 +10441,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
 /obj/effect/turf_decal/tile/blue/anticorner,
 /turf/open/floor/iron/white,
-/area/medical/chemistry{
-	name = "Meth Lab"
-	})
+/area/medical/chemistry/lab)
 "aFI" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -11236,9 +11070,7 @@
 	dir = 4
 	},
 /turf/open/floor/mineral/bananium,
-/area/command/bridge{
-	name = "Bridgenana"
-	})
+/area/command/bridge/bridgenana)
 "aHx" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /turf/open/floor/iron,
@@ -11360,9 +11192,7 @@
 "aNK" = (
 /obj/effect/landmark/xeno_spawn,
 /turf/open/floor/iron/white,
-/area/medical/chemistry{
-	name = "Meth Lab"
-	})
+/area/medical/chemistry/lab)
 "aOk" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/landmark/event_spawn,
@@ -11834,9 +11664,7 @@
 "bid" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white,
-/area/medical/chemistry{
-	name = "Meth Lab"
-	})
+/area/medical/chemistry/lab)
 "bit" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -11850,9 +11678,7 @@
 	},
 /obj/effect/turf_decal/tile/blue/half,
 /turf/open/floor/iron/white,
-/area/medical/chemistry{
-	name = "Meth Lab"
-	})
+/area/medical/chemistry/lab)
 "biR" = (
 /obj/structure/disposalpipe/segment,
 /turf/closed/wall,
@@ -12360,9 +12186,7 @@
 /obj/structure/railing,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /turf/open/floor/mineral/bananium,
-/area/command/bridge{
-	name = "Bridgenana"
-	})
+/area/command/bridge/bridgenana)
 "bzf" = (
 /obj/effect/spawner/atmos_canister/air,
 /turf/open/floor/plating{
@@ -12691,9 +12515,7 @@
 	dir = 6
 	},
 /turf/open/floor/iron/white,
-/area/medical/chemistry{
-	name = "Meth Lab"
-	})
+/area/medical/chemistry/lab)
 "bOO" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Exam Maintenance";
@@ -12865,9 +12687,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/effect/mapping_helpers/ianbirthday,
 /turf/open/floor/wood,
-/area/command/heads_quarters/hop{
-	name = "Ian's Quarters"
-	})
+/area/command/heads_quarters/hop/ians_quarters)
 "bVC" = (
 /obj/structure/cable,
 /obj/structure/grille,
@@ -13278,9 +13098,7 @@
 	cycle_id = "bridge-left"
 	},
 /turf/open/floor/iron/dark,
-/area/command/bridge{
-	name = "Bridgenana"
-	})
+/area/command/bridge/bridgenana)
 "cmy" = (
 /obj/machinery/door/airlock/engineering{
 	name = "Telecommunications";
@@ -13569,9 +13387,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
 /obj/structure/cable,
 /turf/open/floor/mineral/bananium,
-/area/command/bridge{
-	name = "Bridgenana"
-	})
+/area/command/bridge/bridgenana)
 "cxN" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -13688,9 +13504,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/white,
-/area/medical/chemistry{
-	name = "Meth Lab"
-	})
+/area/medical/chemistry/lab)
 "cCA" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/decal/cleanable/dirt,
@@ -13774,9 +13588,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/white,
-/area/medical/chemistry{
-	name = "Meth Lab"
-	})
+/area/medical/chemistry/lab)
 "cFu" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
 /obj/structure/cable,
@@ -14730,9 +14542,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/white,
-/area/medical/chemistry{
-	name = "Meth Lab"
-	})
+/area/medical/chemistry/lab)
 "drW" = (
 /obj/structure/chair{
 	dir = 1
@@ -14776,9 +14586,7 @@
 /obj/structure/cable,
 /obj/effect/mapping_helpers/iannewyear,
 /turf/open/floor/wood,
-/area/command/heads_quarters/hop{
-	name = "Ian's Quarters"
-	})
+/area/command/heads_quarters/hop/ians_quarters)
 "dtt" = (
 /obj/structure/window/reinforced/tinted{
 	dir = 1
@@ -15280,9 +15088,7 @@
 /obj/item/kirbyplants/random,
 /obj/structure/cable,
 /turf/open/floor/wood,
-/area/command/heads_quarters/hop{
-	name = "Ian's Quarters"
-	})
+/area/command/heads_quarters/hop/ians_quarters)
 "dSU" = (
 /obj/item/kirbyplants/random,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
@@ -15532,9 +15338,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/white,
-/area/medical/chemistry{
-	name = "Meth Lab"
-	})
+/area/medical/chemistry/lab)
 "ebT" = (
 /obj/item/radio/intercom{
 	pixel_x = -30
@@ -16074,9 +15878,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /turf/open/floor/iron/white,
-/area/medical/chemistry{
-	name = "Meth Lab"
-	})
+/area/medical/chemistry/lab)
 "evi" = (
 /obj/machinery/light{
 	dir = 4
@@ -16196,9 +15998,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /turf/open/floor/wood,
-/area/command/heads_quarters/hop{
-	name = "Ian's Quarters"
-	})
+/area/command/heads_quarters/hop/ians_quarters)
 "eyQ" = (
 /obj/effect/spawner/random/structure/crate,
 /turf/open/floor/plating,
@@ -16905,9 +16705,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/white,
-/area/medical/chemistry{
-	name = "Meth Lab"
-	})
+/area/medical/chemistry/lab)
 "fcp" = (
 /obj/effect/decal/remains/human{
 	desc = "Looks like human remains. I guess they didn't get to upload their fun laws..."
@@ -17267,9 +17065,7 @@
 	pixel_y = -32
 	},
 /turf/open/floor/mineral/bananium,
-/area/command/bridge{
-	name = "Bridgenana"
-	})
+/area/command/bridge/bridgenana)
 "frv" = (
 /obj/machinery/atmospherics/pipe/smart/simple/green/hidden{
 	dir = 4
@@ -17593,9 +17389,7 @@
 "fDn" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/open/floor/iron/white,
-/area/medical/chemistry{
-	name = "Meth Lab"
-	})
+/area/medical/chemistry/lab)
 "fDz" = (
 /turf/closed/wall/r_wall,
 /area/maintenance/aft/upper)
@@ -17861,9 +17655,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/white,
-/area/medical/chemistry{
-	name = "Meth Lab"
-	})
+/area/medical/chemistry/lab)
 "fNw" = (
 /obj/machinery/door/airlock/grunge{
 	name = "Morgue";
@@ -18693,9 +18485,7 @@
 "gqq" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
 /turf/closed/wall,
-/area/medical/chemistry{
-	name = "Meth Lab"
-	})
+/area/medical/chemistry/lab)
 "gqB" = (
 /obj/structure/cable,
 /obj/structure/table,
@@ -18794,9 +18584,7 @@
 "guV" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /turf/open/floor/iron/white,
-/area/medical/chemistry{
-	name = "Meth Lab"
-	})
+/area/medical/chemistry/lab)
 "gvh" = (
 /obj/effect/turf_decal/tile/yellow/anticorner{
 	dir = 8
@@ -19181,9 +18969,7 @@
 	},
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/wood,
-/area/command/heads_quarters/hop{
-	name = "Ian's Quarters"
-	})
+/area/command/heads_quarters/hop/ians_quarters)
 "gJh" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -19285,9 +19071,7 @@
 	dir = 8
 	},
 /turf/open/floor/mineral/bananium,
-/area/command/bridge{
-	name = "Bridgenana"
-	})
+/area/command/bridge/bridgenana)
 "gNs" = (
 /obj/effect/spawner/random/structure/crate,
 /turf/open/floor/plating{
@@ -19602,9 +19386,7 @@
 "gWX" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/white,
-/area/medical/chemistry{
-	name = "Meth Lab"
-	})
+/area/medical/chemistry/lab)
 "gXk" = (
 /obj/structure/sign/poster/contraband/borg_fancy_2{
 	pixel_y = -32
@@ -19616,9 +19398,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /turf/open/floor/wood,
-/area/command/heads_quarters/hop{
-	name = "Ian's Quarters"
-	})
+/area/command/heads_quarters/hop/ians_quarters)
 "gXw" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
@@ -19759,9 +19539,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/white,
-/area/medical/chemistry{
-	name = "Meth Lab"
-	})
+/area/medical/chemistry/lab)
 "hco" = (
 /obj/machinery/atmospherics/pipe/smart/simple/green/hidden{
 	dir = 4
@@ -20446,9 +20224,7 @@
 /obj/item/plunger,
 /obj/effect/turf_decal/tile/blue/half,
 /turf/open/floor/iron/white,
-/area/medical/chemistry{
-	name = "Meth Lab"
-	})
+/area/medical/chemistry/lab)
 "hGm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/relic,
@@ -20833,9 +20609,7 @@
 "hPE" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
 /turf/open/floor/mineral/bananium,
-/area/command/bridge{
-	name = "Bridgenana"
-	})
+/area/command/bridge/bridgenana)
 "hPK" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -20922,9 +20696,7 @@
 "hSo" = (
 /obj/item/stock_parts/capacitor,
 /turf/open/floor/iron/white,
-/area/medical/chemistry{
-	name = "Meth Lab"
-	})
+/area/medical/chemistry/lab)
 "hSB" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/stripes/line{
@@ -20966,9 +20738,7 @@
 "hUR" = (
 /obj/structure/window/reinforced/fulltile,
 /turf/open/floor/iron/white,
-/area/medical/chemistry{
-	name = "Meth Lab"
-	})
+/area/medical/chemistry/lab)
 "hVn" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/stripes/line,
@@ -20989,9 +20759,7 @@
 /obj/item/storage/lockbox/medal/service,
 /obj/structure/table/wood,
 /turf/open/floor/wood,
-/area/command/heads_quarters/hop{
-	name = "Ian's Quarters"
-	})
+/area/command/heads_quarters/hop/ians_quarters)
 "hWd" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -21031,9 +20799,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /turf/closed/wall,
-/area/medical/chemistry{
-	name = "Meth Lab"
-	})
+/area/medical/chemistry/lab)
 "hYo" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -21284,9 +21050,7 @@
 	dir = 4
 	},
 /turf/closed/wall/r_wall,
-/area/command/bridge{
-	name = "Bridgenana"
-	})
+/area/command/bridge/bridgenana)
 "ijV" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
 /obj/structure/disposalpipe/segment,
@@ -21473,9 +21237,7 @@
 "isN" = (
 /obj/structure/cable,
 /turf/closed/wall,
-/area/medical/chemistry{
-	name = "Meth Lab"
-	})
+/area/medical/chemistry/lab)
 "isR" = (
 /obj/structure/girder,
 /turf/open/floor/plating,
@@ -21762,9 +21524,7 @@
 "iEd" = (
 /obj/item/clothing/glasses/science,
 /turf/open/floor/iron/white,
-/area/medical/chemistry{
-	name = "Meth Lab"
-	})
+/area/medical/chemistry/lab)
 "iEf" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /turf/closed/wall,
@@ -21889,9 +21649,7 @@
 	dir = 8
 	},
 /turf/open/floor/mineral/bananium,
-/area/command/bridge{
-	name = "Bridgenana"
-	})
+/area/command/bridge/bridgenana)
 "iJz" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
 /turf/closed/wall/r_wall,
@@ -21908,9 +21666,7 @@
 /obj/item/stack/sheet/mineral/plasma,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/white,
-/area/medical/chemistry{
-	name = "Meth Lab"
-	})
+/area/medical/chemistry/lab)
 "iKi" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden{
 	dir = 4
@@ -21925,9 +21681,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
 /obj/structure/closet/secure_closet/medical1,
 /turf/open/floor/iron/white,
-/area/medical/chemistry{
-	name = "Meth Lab"
-	})
+/area/medical/chemistry/lab)
 "iKK" = (
 /obj/structure/cable,
 /turf/open/floor/plating/rust,
@@ -22500,9 +22254,7 @@
 	},
 /obj/item/pen,
 /turf/open/floor/wood,
-/area/command/heads_quarters/hop{
-	name = "Ian's Quarters"
-	})
+/area/command/heads_quarters/hop/ians_quarters)
 "jgV" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /obj/effect/decal/cleanable/dirt,
@@ -22977,9 +22729,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/medical/chemistry{
-	name = "Meth Lab"
-	})
+/area/medical/chemistry/lab)
 "jxG" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/sign/warning/vacuum/external{
@@ -23030,9 +22780,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/white,
-/area/medical/chemistry{
-	name = "Meth Lab"
-	})
+/area/medical/chemistry/lab)
 "jxW" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
@@ -23092,9 +22840,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/white,
-/area/medical/chemistry{
-	name = "Meth Lab"
-	})
+/area/medical/chemistry/lab)
 "jBO" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/dirt,
@@ -23309,9 +23055,7 @@
 	},
 /obj/effect/turf_decal/tile/blue/half,
 /turf/open/floor/iron/white,
-/area/medical/chemistry{
-	name = "Meth Lab"
-	})
+/area/medical/chemistry/lab)
 "jIB" = (
 /obj/structure/disposalpipe/trunk/multiz/down,
 /turf/open/floor/plating,
@@ -23401,9 +23145,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/white,
-/area/medical/chemistry{
-	name = "Meth Lab"
-	})
+/area/medical/chemistry/lab)
 "jLK" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /obj/effect/turf_decal/tile/red/half{
@@ -23472,9 +23214,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/white,
-/area/medical/chemistry{
-	name = "Meth Lab"
-	})
+/area/medical/chemistry/lab)
 "jOj" = (
 /obj/machinery/status_display/evac{
 	pixel_x = -32
@@ -23730,9 +23470,7 @@
 "jZu" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/open/floor/mineral/bananium,
-/area/command/bridge{
-	name = "Bridgenana"
-	})
+/area/command/bridge/bridgenana)
 "jZx" = (
 /obj/structure/sign/directions/command{
 	dir = 8
@@ -24704,9 +24442,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /obj/item/circuitboard/machine/chem_dispenser,
 /turf/open/floor/iron/white,
-/area/medical/chemistry{
-	name = "Meth Lab"
-	})
+/area/medical/chemistry/lab)
 "kLl" = (
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/carpet/purple,
@@ -25849,9 +25585,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /turf/open/floor/iron/white,
-/area/medical/chemistry{
-	name = "Meth Lab"
-	})
+/area/medical/chemistry/lab)
 "lFn" = (
 /turf/closed/wall,
 /area/maintenance/disposal/incinerator)
@@ -25886,9 +25620,7 @@
 	dir = 4
 	},
 /turf/open/floor/mineral/bananium,
-/area/command/bridge{
-	name = "Bridgenana"
-	})
+/area/command/bridge/bridgenana)
 "lFO" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Upper Fore Maintenance"
@@ -26706,9 +26438,7 @@
 	pixel_y = -30
 	},
 /turf/open/floor/mineral/bananium,
-/area/command/bridge{
-	name = "Bridgenana"
-	})
+/area/command/bridge/bridgenana)
 "mls" = (
 /obj/structure/cable,
 /obj/effect/landmark/event_spawn,
@@ -26944,9 +26674,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
 /obj/item/grown/bananapeel,
 /turf/open/floor/mineral/bananium,
-/area/command/bridge{
-	name = "Bridgenana"
-	})
+/area/command/bridge/bridgenana)
 "msn" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /obj/structure/disposalpipe/segment,
@@ -27125,9 +26853,7 @@
 /obj/item/grown/bananapeel,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /turf/open/floor/mineral/bananium,
-/area/command/bridge{
-	name = "Bridgenana"
-	})
+/area/command/bridge/bridgenana)
 "myv" = (
 /obj/machinery/door/airlock/atmos{
 	name = "Custodial";
@@ -27180,9 +26906,7 @@
 "mAT" = (
 /obj/effect/turf_decal/tile/blue/half,
 /turf/open/floor/iron/white,
-/area/medical/chemistry{
-	name = "Meth Lab"
-	})
+/area/medical/chemistry/lab)
 "mAY" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/line{
@@ -27213,9 +26937,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /turf/open/floor/mineral/bananium,
-/area/command/bridge{
-	name = "Bridgenana"
-	})
+/area/command/bridge/bridgenana)
 "mCc" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
 /turf/open/floor/iron,
@@ -27279,9 +27001,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
 /turf/open/floor/mineral/bananium,
-/area/command/bridge{
-	name = "Bridgenana"
-	})
+/area/command/bridge/bridgenana)
 "mFv" = (
 /turf/open/floor/iron/dark/airless,
 /area/tcommsat/server)
@@ -27476,9 +27196,7 @@
 "mNb" = (
 /obj/item/grown/bananapeel,
 /turf/open/floor/mineral/bananium,
-/area/command/bridge{
-	name = "Bridgenana"
-	})
+/area/command/bridge/bridgenana)
 "mNi" = (
 /obj/structure/window/reinforced/fulltile,
 /turf/open/floor/plating,
@@ -27521,9 +27239,7 @@
 /obj/effect/landmark/event_spawn,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /turf/open/floor/iron/white,
-/area/medical/chemistry{
-	name = "Meth Lab"
-	})
+/area/medical/chemistry/lab)
 "mPf" = (
 /obj/machinery/atmospherics/pipe/bridge_pipe/green/hidden{
 	dir = 4
@@ -27610,9 +27326,7 @@
 /obj/machinery/holopad,
 /obj/effect/turf_decal/box,
 /turf/open/floor/iron/white,
-/area/medical/chemistry{
-	name = "Meth Lab"
-	})
+/area/medical/chemistry/lab)
 "mTD" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
@@ -27705,9 +27419,7 @@
 "mYK" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /turf/open/floor/mineral/bananium,
-/area/command/bridge{
-	name = "Bridgenana"
-	})
+/area/command/bridge/bridgenana)
 "mYX" = (
 /obj/structure/disposalpipe/junction{
 	dir = 4
@@ -28721,9 +28433,7 @@
 /obj/item/stack/sheet/iron/ten,
 /obj/item/stack/sheet/glass,
 /turf/open/floor/iron/white,
-/area/medical/chemistry{
-	name = "Meth Lab"
-	})
+/area/medical/chemistry/lab)
 "nOF" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -29937,17 +29647,13 @@
 "oHC" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/mineral/bananium,
-/area/command/bridge{
-	name = "Bridgenana"
-	})
+/area/command/bridge/bridgenana)
 "oHH" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
 /turf/open/floor/iron/white,
-/area/medical/chemistry{
-	name = "Meth Lab"
-	})
+/area/medical/chemistry/lab)
 "oHT" = (
 /obj/machinery/navbeacon/wayfinding/tcomms,
 /turf/open/floor/iron/dark/airless,
@@ -30248,9 +29954,7 @@
 /obj/effect/turf_decal/box,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /turf/open/floor/mineral/bananium,
-/area/command/bridge{
-	name = "Bridgenana"
-	})
+/area/command/bridge/bridgenana)
 "oXU" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -30433,9 +30137,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
 /turf/closed/wall,
-/area/medical/chemistry{
-	name = "Meth Lab"
-	})
+/area/medical/chemistry/lab)
 "pfb" = (
 /obj/item/trash/cheesie{
 	pixel_x = 5;
@@ -31003,9 +30705,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /turf/open/floor/iron/white,
-/area/medical/chemistry{
-	name = "Meth Lab"
-	})
+/area/medical/chemistry/lab)
 "pAz" = (
 /obj/structure/disposalpipe/trunk/multiz/down{
 	dir = 1
@@ -31209,9 +30909,7 @@
 	pixel_x = 32
 	},
 /turf/open/floor/wood,
-/area/command/heads_quarters/hop{
-	name = "Ian's Quarters"
-	})
+/area/command/heads_quarters/hop/ians_quarters)
 "pHy" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/circuit/airless,
@@ -31243,9 +30941,7 @@
 	dir = 4
 	},
 /turf/open/floor/wood,
-/area/command/heads_quarters/hop{
-	name = "Ian's Quarters"
-	})
+/area/command/heads_quarters/hop/ians_quarters)
 "pIN" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
 /obj/structure/disposalpipe/segment{
@@ -31387,9 +31083,7 @@
 "pLx" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /turf/closed/wall,
-/area/medical/chemistry{
-	name = "Meth Lab"
-	})
+/area/medical/chemistry/lab)
 "pLD" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/spawner/random/trash/garbage,
@@ -31402,9 +31096,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/wood,
-/area/command/heads_quarters/hop{
-	name = "Ian's Quarters"
-	})
+/area/command/heads_quarters/hop/ians_quarters)
 "pMd" = (
 /obj/machinery/atmospherics/pipe/bridge_pipe/supply/hidden{
 	dir = 4
@@ -32365,9 +32057,7 @@
 /obj/effect/turf_decal/stripes/box,
 /obj/structure/cable,
 /turf/open/floor/wood,
-/area/command/heads_quarters/hop{
-	name = "Ian's Quarters"
-	})
+/area/command/heads_quarters/hop/ians_quarters)
 "qto" = (
 /obj/structure/cable,
 /obj/machinery/light/small{
@@ -32472,9 +32162,7 @@
 "qvN" = (
 /obj/machinery/chem_mass_spec,
 /turf/open/floor/iron/white,
-/area/medical/chemistry{
-	name = "Meth Lab"
-	})
+/area/medical/chemistry/lab)
 "qvV" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -32669,9 +32357,7 @@
 /obj/item/pen,
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/white,
-/area/medical/chemistry{
-	name = "Meth Lab"
-	})
+/area/medical/chemistry/lab)
 "qBb" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
@@ -33446,9 +33132,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /turf/open/floor/wood,
-/area/command/heads_quarters/hop{
-	name = "Ian's Quarters"
-	})
+/area/command/heads_quarters/hop/ians_quarters)
 "rbN" = (
 /obj/structure/cable,
 /obj/structure/reagent_dispensers/watertank,
@@ -33595,9 +33279,7 @@
 "riE" = (
 /obj/effect/spawner/random/trash/food_packaging,
 /turf/open/floor/mineral/bananium,
-/area/command/bridge{
-	name = "Bridgenana"
-	})
+/area/command/bridge/bridgenana)
 "riJ" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/dirt,
@@ -33641,9 +33323,7 @@
 	dir = 4
 	},
 /turf/open/floor/mineral/bananium,
-/area/command/bridge{
-	name = "Bridgenana"
-	})
+/area/command/bridge/bridgenana)
 "rkk" = (
 /obj/machinery/door/airlock/external{
 	name = "Escape Airlock"
@@ -33878,9 +33558,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
 /turf/open/floor/mineral/bananium,
-/area/command/bridge{
-	name = "Bridgenana"
-	})
+/area/command/bridge/bridgenana)
 "rsg" = (
 /obj/structure/girder,
 /turf/open/floor/plating{
@@ -34297,9 +33975,7 @@
 "rED" = (
 /obj/item/storage/box/lights/mixed,
 /turf/open/floor/mineral/bananium,
-/area/command/bridge{
-	name = "Bridgenana"
-	})
+/area/command/bridge/bridgenana)
 "rEZ" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/stripes/line,
@@ -35020,9 +34696,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /turf/open/floor/iron/white,
-/area/medical/chemistry{
-	name = "Meth Lab"
-	})
+/area/medical/chemistry/lab)
 "sbH" = (
 /obj/machinery/atmospherics/pipe/bridge_pipe/yellow/visible{
 	dir = 4
@@ -35564,9 +35238,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/white,
-/area/medical/chemistry{
-	name = "Meth Lab"
-	})
+/area/medical/chemistry/lab)
 "stS" = (
 /obj/structure/railing{
 	dir = 4
@@ -35656,9 +35328,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/white,
-/area/medical/chemistry{
-	name = "Meth Lab"
-	})
+/area/medical/chemistry/lab)
 "syG" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
@@ -36162,9 +35832,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /turf/open/floor/mineral/bananium,
-/area/command/bridge{
-	name = "Bridgenana"
-	})
+/area/command/bridge/bridgenana)
 "sPL" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
 /obj/effect/decal/cleanable/dirt,
@@ -36372,9 +36040,7 @@
 /obj/item/stack/cable_coil,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /turf/open/floor/iron/white,
-/area/medical/chemistry{
-	name = "Meth Lab"
-	})
+/area/medical/chemistry/lab)
 "sYu" = (
 /obj/structure/girder,
 /turf/open/floor/carpet/red,
@@ -37009,9 +36675,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white,
-/area/medical/chemistry{
-	name = "Meth Lab"
-	})
+/area/medical/chemistry/lab)
 "twJ" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/circuit,
@@ -38228,9 +37892,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/white,
-/area/medical/chemistry{
-	name = "Meth Lab"
-	})
+/area/medical/chemistry/lab)
 "usd" = (
 /obj/structure/lattice,
 /turf/open/floor/plating/airless,
@@ -38262,9 +37924,7 @@
 	cycle_id = "bridge-left"
 	},
 /turf/open/floor/iron/dark,
-/area/command/bridge{
-	name = "Bridgenana"
-	})
+/area/command/bridge/bridgenana)
 "utB" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -38409,9 +38069,7 @@
 /obj/machinery/holopad,
 /obj/effect/turf_decal/box,
 /turf/open/floor/wood,
-/area/command/heads_quarters/hop{
-	name = "Ian's Quarters"
-	})
+/area/command/heads_quarters/hop/ians_quarters)
 "uzl" = (
 /obj/effect/spawner/docking_port{
 	dir = 4;
@@ -38715,9 +38373,7 @@
 	},
 /obj/machinery/washing_machine,
 /turf/open/floor/wood,
-/area/command/heads_quarters/hop{
-	name = "Ian's Quarters"
-	})
+/area/command/heads_quarters/hop/ians_quarters)
 "uKo" = (
 /obj/structure/window,
 /turf/open/floor/grass,
@@ -39111,9 +38767,7 @@
 "uXL" = (
 /obj/item/stock_parts/matter_bin,
 /turf/open/floor/iron/white,
-/area/medical/chemistry{
-	name = "Meth Lab"
-	})
+/area/medical/chemistry/lab)
 "uXO" = (
 /obj/machinery/light,
 /obj/machinery/requests_console{
@@ -39325,9 +38979,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /obj/effect/turf_decal/tile/blue/half,
 /turf/open/floor/iron/white,
-/area/medical/chemistry{
-	name = "Meth Lab"
-	})
+/area/medical/chemistry/lab)
 "vdQ" = (
 /obj/effect/turf_decal/stripes/red/line{
 	dir = 1
@@ -39368,9 +39020,7 @@
 	},
 /obj/machinery/atmospherics/pipe/bridge_pipe/scrubbers/hidden,
 /turf/open/floor/mineral/bananium,
-/area/command/bridge{
-	name = "Bridgenana"
-	})
+/area/command/bridge/bridgenana)
 "veB" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
 /obj/machinery/holopad,
@@ -40313,9 +39963,7 @@
 	dir = 4
 	},
 /turf/open/floor/mineral/bananium,
-/area/command/bridge{
-	name = "Bridgenana"
-	})
+/area/command/bridge/bridgenana)
 "vNQ" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -42281,9 +41929,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/white,
-/area/medical/chemistry{
-	name = "Meth Lab"
-	})
+/area/medical/chemistry/lab)
 "xql" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
@@ -42475,9 +42121,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /turf/open/floor/mineral/bananium,
-/area/command/bridge{
-	name = "Bridgenana"
-	})
+/area/command/bridge/bridgenana)
 "xAb" = (
 /obj/structure/bed,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
@@ -42620,9 +42264,7 @@
 /obj/machinery/smartfridge/chemistry,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white,
-/area/medical/chemistry{
-	name = "Meth Lab"
-	})
+/area/medical/chemistry/lab)
 "xEF" = (
 /obj/structure/sign/poster/contraband/random{
 	pixel_x = -32
@@ -42732,9 +42374,7 @@
 	dir = 4
 	},
 /turf/open/floor/wood,
-/area/command/heads_quarters/hop{
-	name = "Ian's Quarters"
-	})
+/area/command/heads_quarters/hop/ians_quarters)
 "xJa" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /obj/effect/turf_decal/tile/brown/anticorner,
@@ -42874,9 +42514,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /turf/open/floor/mineral/bananium,
-/area/command/bridge{
-	name = "Bridgenana"
-	})
+/area/command/bridge/bridgenana)
 "xPA" = (
 /obj/machinery/atmospherics/components/binary/thermomachine/freezer{
 	dir = 4
@@ -43051,9 +42689,7 @@
 "xYc" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
 /turf/open/floor/iron/white,
-/area/medical/chemistry{
-	name = "Meth Lab"
-	})
+/area/medical/chemistry/lab)
 "xYh" = (
 /obj/item/relic,
 /turf/open/floor/plating,
@@ -43104,9 +42740,7 @@
 /area/hallway/primary/starboard)
 "xYZ" = (
 /turf/open/floor/iron/white,
-/area/medical/chemistry{
-	name = "Meth Lab"
-	})
+/area/medical/chemistry/lab)
 "xZr" = (
 /obj/item/skub,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
@@ -43142,9 +42776,7 @@
 "yaS" = (
 /obj/structure/cable,
 /turf/open/floor/wood,
-/area/command/heads_quarters/hop{
-	name = "Ian's Quarters"
-	})
+/area/command/heads_quarters/hop/ians_quarters)
 "yaU" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
 /obj/structure/chair/office,

--- a/_maps/map_files/ShitStation/ShitStation.dmm
+++ b/_maps/map_files/ShitStation/ShitStation.dmm
@@ -26752,7 +26752,7 @@
 /obj/effect/landmark/start/warden,
 /obj/item/paper/fluff{
 	info = "You have been in cryostasis for [REDACTED] years. New crew should be arriving this month. We left you in this closet to thaw. Glory to NanoTrasen.";
-	name = "CentComm Notice"
+	name = "CentCom Notice"
 	},
 /turf/open/floor/plating,
 /area/security/lockers)
@@ -35869,7 +35869,7 @@
 /obj/effect/spawner/random/medical/surgery_tool_alien,
 /obj/item/paper/fluff{
 	info = "You have been in cryostasis for [REDACTED] years. New crew should be arriving this month. We left you in this closet to thaw. Glory to NanoTrasen.";
-	name = "CentComm Notice"
+	name = "CentCom Notice"
 	},
 /turf/open/floor/plating{
 	icon_state = "platingdmg1"
@@ -39979,7 +39979,7 @@
 /obj/effect/landmark/start/atmospheric_technician,
 /obj/item/paper/fluff{
 	info = "You have been in cryostasis for [REDACTED] years. New crew should be arriving this month. We left you in this closet to thaw. Glory to NanoTrasen.";
-	name = "CentComm Notice"
+	name = "CentCom Notice"
 	},
 /turf/open/floor/plating,
 /area/security/office)

--- a/russstation/code/game/area/space_station_13_areas.dm
+++ b/russstation/code/game/area/space_station_13_areas.dm
@@ -1,0 +1,10 @@
+// Custom RussStation areas; expands off `code\game\area\space_station_13_areas.dm`
+// ShitStation (Sugma Station) Area Renames
+/area/medical/chemistry/lab
+	name = "Meth Lab"
+
+/area/command/bridge/bridgenana
+	name = "Bridgenana"
+
+/area/command/heads_quarters/hop/ians_quarters
+	name = "Ian's Quarters"


### PR DESCRIPTION
Resolving errors thrown by `tools/ci/check_grep.sh`:
- Removed var edited cables (replaced where needed)
- Removed multiple cables in same tile
- Removed identical pipes on the same tile
- Moved all APCs to 0 or +/- 25 pixel offset 
- [IceCube] - Moved intercom to accommodate the moved apc
- Removed lattice stacked with a wall
- Removed varedits from /area paths
- [ShitStation] Replaced varedited areas with custom areas
- [ShitStation] CentCom misspelling fixed (unsure if intentional)
- Escaped `[` in ShitStation map file to avoid breaking MapDiffBot