### PR TITLE
Scrub co2 from cryocell pipes

### DIFF
--- a/_maps/map_files/CubeStation/Cube.dmm
+++ b/_maps/map_files/CubeStation/Cube.dmm
@@ -16256,7 +16256,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue,
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden,
 /obj/structure/table,
 /turf/open/floor/iron/white,
 /area/medical/exam_room)
@@ -16504,9 +16503,7 @@
 	},
 /obj/effect/turf_decal/tile/blue,
 /obj/machinery/airalarm/directional/east,
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden{
-	dir = 10
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden,
 /turf/open/floor/iron/white,
 /area/medical/exam_room)
 "iEJ" = (
@@ -23824,8 +23821,8 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue,
-/obj/machinery/atmospherics/pipe/smart/manifold/cyan/hidden{
-	dir = 1
+/obj/machinery/atmospherics/components/trinary/filter/atmos/flipped/co2{
+	dir = 8
 	},
 /turf/open/floor/iron/white,
 /area/medical/exam_room)
@@ -24428,6 +24425,9 @@
 /area/medical/surgery/aft)
 "mNS" = (
 /obj/structure/table,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/medical/medbay/central)
 "mOF" = (
@@ -27449,6 +27449,7 @@
 	dir = 1
 	},
 /obj/structure/closet/secure_closet/medical1,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
 /turf/open/floor/iron/dark,
 /area/medical/exam_room)
 "olq" = (
@@ -35287,6 +35288,7 @@
 /obj/structure/bed,
 /obj/item/bedsheet/medical,
 /obj/effect/landmark/start/hangover,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden,
 /turf/open/floor/iron/white,
 /area/medical/exam_room)
 "rPL" = (
@@ -36505,6 +36507,7 @@
 /obj/effect/turf_decal/tile/blue,
 /obj/structure/bed,
 /obj/item/bedsheet/medical,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden,
 /turf/open/floor/iron/white,
 /area/medical/exam_room)
 "szk" = (
@@ -36577,13 +36580,6 @@
 	},
 /turf/open/floor/plating,
 /area/command/gateway)
-"sBE" = (
-/obj/effect/turf_decal/tile/blue,
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden{
-	dir = 5
-	},
-/turf/open/floor/iron/white,
-/area/medical/exam_room)
 "sBM" = (
 /obj/machinery/holopad,
 /obj/structure/disposalpipe/segment{
@@ -36962,6 +36958,7 @@
 /obj/structure/mirror{
 	pixel_x = 28
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /turf/open/floor/iron/dark,
 /area/medical/exam_room)
 "sNf" = (
@@ -37840,9 +37837,7 @@
 /area/security/brig)
 "tkA" = (
 /obj/effect/turf_decal/tile/blue,
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden{
-	dir = 6
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden,
 /turf/open/floor/iron/white,
 /area/medical/exam_room)
 "tkM" = (
@@ -44265,9 +44260,7 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden{
-	dir = 9
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden,
 /obj/structure/sign/poster/official/cleanliness{
 	pixel_x = 32
 	},
@@ -46442,7 +46435,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue,
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden,
 /obj/structure/table,
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/white,
@@ -47252,6 +47244,7 @@
 /obj/structure/mirror{
 	pixel_x = 28
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden,
 /turf/open/floor/iron/dark,
 /area/medical/exam_room)
 "xFZ" = (
@@ -81301,7 +81294,7 @@ fRq
 lot
 xJE
 tpX
-sBE
+tkA
 szd
 rPJ
 tkA
@@ -81526,7 +81519,7 @@ mNQ
 eee
 fRq
 mNS
-xJE
+lYg
 olc
 mye
 xnw

--- a/_maps/map_files/CubeStation/Cube.dmm
+++ b/_maps/map_files/CubeStation/Cube.dmm
@@ -36958,7 +36958,7 @@
 /obj/structure/mirror{
 	pixel_x = 28
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden,
 /turf/open/floor/iron/dark,
 /area/medical/exam_room)
 "sNf" = (

--- a/_maps/map_files/EchoStation/EchoStation.dmm
+++ b/_maps/map_files/EchoStation/EchoStation.dmm
@@ -11961,10 +11961,6 @@
 	},
 /turf/open/floor/engine,
 /area/engineering/main)
-"grc" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden,
-/turf/open/floor/iron/white,
-/area/medical/cryo)
 "grf" = (
 /obj/machinery/navbeacon{
 	codes_txt = "delivery;dir=4";
@@ -27801,9 +27797,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/landmark/start/medical_doctor,
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden{
-	dir = 5
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden,
 /turf/open/floor/iron/white,
 /area/medical/cryo)
 "ozV" = (
@@ -28694,7 +28688,6 @@
 /obj/item/reagent_containers/glass/beaker/cryoxadone{
 	pixel_x = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden,
 /turf/open/floor/iron/white,
 /area/medical/cryo)
 "oUO" = (
@@ -32327,9 +32320,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold/cyan/hidden{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden,
 /turf/open/floor/iron/white,
 /area/medical/cryo)
 "qKF" = (
@@ -43482,15 +43473,12 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold/cyan/hidden{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden,
 /turf/open/floor/iron/white,
 /area/medical/cryo)
 "wif" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden,
 /turf/open/floor/iron/white,
 /area/medical/cryo)
 "wim" = (
@@ -45252,7 +45240,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden,
 /turf/open/floor/iron/white,
 /area/medical/cryo)
 "wXK" = (
@@ -45261,7 +45249,9 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "wXS" = (
-/obj/machinery/atmospherics/components/unary/cryo_cell,
+/obj/machinery/atmospherics/components/unary/cryo_cell{
+	dir = 8
+	},
 /turf/open/floor/iron/white,
 /area/medical/cryo)
 "wYP" = (
@@ -74813,7 +74803,7 @@ ufv
 vwR
 prp
 wXS
-grc
+prp
 oUo
 ihH
 cgK

--- a/_maps/map_files/EchoStation/EchoStation.dmm
+++ b/_maps/map_files/EchoStation/EchoStation.dmm
@@ -4788,6 +4788,9 @@
 /area/medical/medbay/central)
 "cDd" = (
 /obj/effect/decal/cleanable/blood/splatter,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/iron/showroomfloor,
 /area/medical/cryo)
 "cDp" = (
@@ -11958,6 +11961,10 @@
 	},
 /turf/open/floor/engine,
 /area/engineering/main)
+"grc" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden,
+/turf/open/floor/iron/white,
+/area/medical/cryo)
 "grf" = (
 /obj/machinery/navbeacon{
 	codes_txt = "delivery;dir=4";
@@ -13163,6 +13170,10 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/medical/virology)
+"hdd" = (
+/obj/machinery/atmospherics/components/trinary/filter/atmos/flipped/co2,
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "hde" = (
 /obj/effect/landmark/event_spawn,
 /obj/effect/landmark/blobstart,
@@ -19931,6 +19942,14 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
 /turf/open/floor/engine,
 /area/engineering/main)
+"kAd" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/medical/cryo)
 "kAG" = (
 /obj/structure/window{
 	dir = 8
@@ -22469,6 +22488,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/obj/machinery/atmospherics/components/trinary/filter/atmos/flipped/co2,
 /turf/open/floor/iron/white,
 /area/medical/cryo)
 "lRt" = (
@@ -27784,8 +27804,10 @@
 /obj/effect/decal/cleanable/blood,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden,
 /obj/effect/landmark/start/medical_doctor,
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden{
+	dir = 5
+	},
 /turf/open/floor/iron/white,
 /area/medical/cryo)
 "ozV" = (
@@ -28676,6 +28698,7 @@
 /obj/item/reagent_containers/glass/beaker/cryoxadone{
 	pixel_x = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden,
 /turf/open/floor/iron/white,
 /area/medical/cryo)
 "oUO" = (
@@ -29360,10 +29383,16 @@
 "pqM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/start/medical_doctor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/iron/showroomfloor,
 /area/medical/cryo)
 "pqO" = (
 /obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/hidden{
 	dir = 4
 	},
 /turf/open/floor/iron/showroomfloor,
@@ -29378,6 +29407,7 @@
 	dir = 8
 	},
 /obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
 /turf/open/floor/iron/showroomfloor,
 /area/medical/cryo)
 "prp" = (
@@ -32301,7 +32331,9 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden,
+/obj/machinery/atmospherics/pipe/smart/manifold/cyan/hidden{
+	dir = 1
+	},
 /turf/open/floor/iron/white,
 /area/medical/cryo)
 "qKF" = (
@@ -32508,6 +32540,7 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden,
 /turf/open/floor/iron/white,
 /area/medical/cryo)
 "qSL" = (
@@ -43450,20 +43483,18 @@
 /area/engineering/engine_smes)
 "whT" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold/cyan/hidden{
+	dir = 4
 	},
 /turf/open/floor/iron/white,
 /area/medical/cryo)
 "wif" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold/cyan/hidden{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden,
 /turf/open/floor/iron/white,
 /area/medical/cryo)
 "wim" = (
@@ -43510,12 +43541,6 @@
 /obj/machinery/navbeacon/wayfinding/tcomms,
 /turf/open/floor/iron/showroomfloor,
 /area/tcommsat/computer)
-"wiY" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden{
-	dir = 10
-	},
-/turf/open/floor/iron/white,
-/area/medical/cryo)
 "wjb" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 10
@@ -45231,9 +45256,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold/cyan/hidden{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden,
 /turf/open/floor/iron/white,
 /area/medical/cryo)
 "wXK" = (
@@ -45242,9 +45265,7 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "wXS" = (
-/obj/machinery/atmospherics/components/unary/cryo_cell{
-	dir = 1
-	},
+/obj/machinery/atmospherics/components/unary/cryo_cell,
 /turf/open/floor/iron/white,
 /area/medical/cryo)
 "wYP" = (
@@ -74280,7 +74301,7 @@ nzM
 szT
 tOz
 vvG
-whT
+kAd
 whT
 lRr
 qSK
@@ -74794,9 +74815,9 @@ xMG
 wjD
 ufv
 vwR
-wiY
-wXS
 prp
+wXS
+grc
 oUo
 ihH
 cgK
@@ -75566,7 +75587,7 @@ lax
 tUe
 xQA
 paf
-xQA
+hdd
 leC
 pLs
 adV

--- a/_maps/map_files/EchoStation/EchoStation.dmm
+++ b/_maps/map_files/EchoStation/EchoStation.dmm
@@ -13170,10 +13170,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/medical/virology)
-"hdd" = (
-/obj/machinery/atmospherics/components/trinary/filter/atmos/flipped/co2,
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
 "hde" = (
 /obj/effect/landmark/event_spawn,
 /obj/effect/landmark/blobstart,
@@ -75587,7 +75583,7 @@ lax
 tUe
 xQA
 paf
-hdd
+xQA
 leC
 pLs
 adV

--- a/_maps/map_files/IceCubeStation/IceCube.dmm
+++ b/_maps/map_files/IceCubeStation/IceCube.dmm
@@ -3269,6 +3269,7 @@
 /obj/machinery/shower{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /turf/open/floor/iron/dark,
 /area/medical/exam_room)
 "bgN" = (
@@ -3688,6 +3689,12 @@
 /obj/machinery/holopad/secure,
 /turf/open/floor/carpet/red,
 /area/command/heads_quarters/hos)
+"bot" = (
+/obj/machinery/atmospherics/components/trinary/filter/atmos/flipped/co2{
+	dir = 8
+	},
+/turf/open/floor/iron/white/textured,
+/area/medical/exam_room)
 "boL" = (
 /obj/structure/closet/firecloset,
 /obj/effect/landmark/start/hangover/closet,
@@ -32352,6 +32359,7 @@
 "nMb" = (
 /obj/structure/table/glass,
 /obj/effect/landmark/start/hangover,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /turf/open/floor/iron/white/textured,
 /area/medical/exam_room)
 "nMc" = (
@@ -40386,6 +40394,7 @@
 	pixel_y = 10
 	},
 /obj/item/reagent_containers/glass/beaker/cryoxadone,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /turf/open/floor/iron/white/textured,
 /area/medical/exam_room)
 "rim" = (
@@ -41404,6 +41413,7 @@
 /obj/structure/mirror{
 	pixel_x = 28
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /turf/open/floor/iron/dark,
 /area/medical/exam_room)
 "rCY" = (
@@ -47133,6 +47143,7 @@
 /obj/structure/mirror{
 	pixel_x = 28
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /turf/open/floor/iron/dark,
 /area/medical/exam_room)
 "ubJ" = (
@@ -50359,6 +50370,7 @@
 "vsc" = (
 /obj/structure/table/glass,
 /obj/item/wrench/medical,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /turf/open/floor/iron/white/textured,
 /area/medical/exam_room)
 "vsi" = (
@@ -55704,6 +55716,7 @@
 	},
 /obj/structure/closet/secure_closet/medical1,
 /obj/machinery/light/directional/north,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
 /turf/open/floor/iron/dark,
 /area/medical/exam_room)
 "xHk" = (
@@ -99125,12 +99138,12 @@ jgR
 tRf
 tRf
 boM
-kGE
+wsX
 xHe
-gEx
-gEx
-gEx
-gEx
+bot
+oBs
+oBs
+oBs
 gEx
 blt
 wsX

--- a/_maps/map_files/LimaStation/Lima.dmm
+++ b/_maps/map_files/LimaStation/Lima.dmm
@@ -6024,19 +6024,6 @@
 /obj/machinery/duct,
 /turf/open/floor/plating,
 /area/maintenance/central/lesser)
-"bzr" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/medical/exam_room)
 "bzu" = (
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/stripes/line{
@@ -7423,17 +7410,6 @@
 /obj/effect/turf_decal/trimline/purple/filled/line,
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
-"cjw" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
-/turf/open/floor/iron/white,
-/area/medical/exam_room)
 "cjO" = (
 /obj/structure/table/reinforced,
 /obj/effect/spawner/random/food_or_drink/donkpockets,
@@ -29381,6 +29357,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /turf/open/floor/iron/white,
 /area/medical/exam_room)
 "nSK" = (
@@ -31337,19 +31314,6 @@
 "pcC" = (
 /turf/open/floor/carpet/purple,
 /area/hallway/primary/starboard)
-"pcS" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/medical/exam_room)
 "pdi" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/light/directional/south,
@@ -83885,7 +83849,7 @@ kPg
 gJh
 nfz
 jOx
-cjw
+gaZ
 pJH
 qpc
 kSG
@@ -84142,7 +84106,7 @@ gJh
 gJh
 nfQ
 jdy
-bzr
+gaZ
 vNy
 gXT
 oon
@@ -84399,7 +84363,7 @@ kSi
 pjH
 pjH
 jkp
-bzr
+gaZ
 nqc
 nMn
 ooE
@@ -84656,7 +84620,7 @@ kSy
 lBo
 nhE
 uTh
-pcS
+oMx
 rLO
 lkL
 rLO
@@ -84913,7 +84877,7 @@ kSy
 lBJ
 cPc
 nSs
-jOx
+rcF
 rcF
 mwx
 rcF
@@ -85170,7 +85134,7 @@ kWh
 lBX
 fbL
 jvR
-fbL
+rqm
 nqn
 nNi
 opj

--- a/_maps/map_files/LimaStation/Lima.dmm
+++ b/_maps/map_files/LimaStation/Lima.dmm
@@ -6024,6 +6024,19 @@
 /obj/machinery/duct,
 /turf/open/floor/plating,
 /area/maintenance/central/lesser)
+"bzr" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/medical/exam_room)
 "bzu" = (
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/stripes/line{
@@ -31332,7 +31345,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/medical/exam_room)
 "pdi" = (
@@ -84127,7 +84142,7 @@ gJh
 gJh
 nfQ
 jdy
-cjw
+bzr
 vNy
 gXT
 oon
@@ -84384,7 +84399,7 @@ kSi
 pjH
 pjH
 jkp
-cjw
+bzr
 nqc
 nMn
 ooE

--- a/_maps/map_files/LimaStation/Lima.dmm
+++ b/_maps/map_files/LimaStation/Lima.dmm
@@ -7410,6 +7410,17 @@
 /obj/effect/turf_decal/trimline/purple/filled/line,
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
+"cjw" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/turf/open/floor/iron/white,
+/area/medical/exam_room)
 "cjO" = (
 /obj/structure/table/reinforced,
 /obj/effect/spawner/random/food_or_drink/donkpockets,
@@ -8587,6 +8598,10 @@
 "cOR" = (
 /turf/closed/wall,
 /area/maintenance/aft)
+"cPc" = (
+/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/hidden,
+/turf/open/floor/iron/white,
+/area/medical/exam_room)
 "cPn" = (
 /obj/docking_port/stationary{
 	dir = 8;
@@ -13537,6 +13552,14 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"fbL" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/turf/open/floor/iron/white,
+/area/medical/exam_room)
 "fcd" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -21419,6 +21442,18 @@
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/fore)
+"jvR" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/turf/open/floor/iron/white,
+/area/medical/exam_room)
 "jwm" = (
 /obj/effect/landmark/event_spawn,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -22220,6 +22255,10 @@
 /obj/effect/landmark/start/assistant,
 /turf/open/floor/iron/showroomfloor,
 /area/commons/toilet)
+"jOx" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/turf/open/floor/iron/white,
+/area/medical/exam_room)
 "jOG" = (
 /turf/open/floor/engine/n2o,
 /area/engineering/atmos)
@@ -24203,6 +24242,7 @@
 "kWh" = (
 /obj/machinery/light/directional/east,
 /obj/effect/turf_decal/siding/blue,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /turf/open/floor/iron/dark,
 /area/medical/exam_room)
 "kWj" = (
@@ -25346,6 +25386,7 @@
 	},
 /obj/structure/table,
 /obj/item/wrench/medical,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /turf/open/floor/iron/white,
 /area/medical/exam_room)
 "lBJ" = (
@@ -25355,7 +25396,7 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
 /turf/open/floor/iron/white,
 /area/medical/exam_room)
 "lBW" = (
@@ -25378,6 +25419,7 @@
 	},
 /obj/effect/turf_decal/tile/blue,
 /obj/machinery/airalarm/directional/east,
+/obj/machinery/atmospherics/components/trinary/filter/atmos/flipped/co2,
 /turf/open/floor/iron/white,
 /area/medical/exam_room)
 "lBY" = (
@@ -28204,6 +28246,7 @@
 	pixel_x = 7;
 	pixel_y = 1
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /turf/open/floor/iron/white,
 /area/medical/exam_room)
 "nhO" = (
@@ -29325,7 +29368,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /turf/open/floor/iron/white,
 /area/medical/exam_room)
 "nSK" = (
@@ -31282,6 +31324,17 @@
 "pcC" = (
 /turf/open/floor/carpet/purple,
 /area/hallway/primary/starboard)
+"pcS" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/turf/open/floor/iron/white,
+/area/medical/exam_room)
 "pdi" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/light/directional/south,
@@ -37985,10 +38038,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/commons/toilet)
-"sXv" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
-/turf/open/floor/iron/white,
-/area/medical/exam_room)
 "sXw" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -83820,8 +83869,8 @@ jOj
 kPg
 gJh
 nfz
-sXv
-gaZ
+jOx
+cjw
 pJH
 qpc
 kSG
@@ -84078,7 +84127,7 @@ gJh
 gJh
 nfQ
 jdy
-gaZ
+cjw
 vNy
 gXT
 oon
@@ -84335,7 +84384,7 @@ kSi
 pjH
 pjH
 jkp
-gaZ
+cjw
 nqc
 nMn
 ooE
@@ -84592,7 +84641,7 @@ kSy
 lBo
 nhE
 uTh
-oMx
+pcS
 rLO
 lkL
 rLO
@@ -84847,9 +84896,9 @@ pjH
 ktY
 kSy
 lBJ
-sXv
+cPc
 nSs
-rcF
+jOx
 rcF
 mwx
 rcF
@@ -85104,9 +85153,9 @@ mIq
 qqi
 kWh
 lBX
-rqm
-vdD
-rqm
+fbL
+jvR
+fbL
 nqn
 nNi
 opj

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -2068,7 +2068,6 @@
 /obj/effect/turf_decal/tile/blue/fourcorners,
 /obj/item/radio/intercom/directional/west,
 /obj/machinery/medical_kiosk,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /turf/open/floor/iron/white,
 /area/medical/exam_room)
 "ahv" = (
@@ -41614,9 +41613,7 @@
 /area/engineering/main)
 "mqT" = (
 /obj/effect/turf_decal/tile/blue/fourcorners,
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 10
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /turf/open/floor/iron/white,
 /area/medical/exam_room)
 "mrh" = (

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -2068,6 +2068,7 @@
 /obj/effect/turf_decal/tile/blue/fourcorners,
 /obj/item/radio/intercom/directional/west,
 /obj/machinery/medical_kiosk,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /turf/open/floor/iron/white,
 /area/medical/exam_room)
 "ahv" = (
@@ -36756,6 +36757,7 @@
 /obj/structure/table/glass,
 /obj/item/clothing/neck/stethoscope,
 /obj/item/clothing/mask/surgical,
+/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/hidden,
 /turf/open/floor/iron/white,
 /area/medical/exam_room)
 "eFu" = (
@@ -40429,6 +40431,7 @@
 	pixel_x = 5;
 	pixel_y = 5
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
 /turf/open/floor/iron/white,
 /area/medical/exam_room)
 "krC" = (
@@ -41542,6 +41545,14 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark,
 /area/engineering/main)
+"mmV" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/blue/fourcorners,
+/obj/machinery/atmospherics/components/trinary/filter/atmos/flipped/co2{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/medical/exam_room)
 "mnw" = (
 /obj/machinery/power/terminal{
 	dir = 4
@@ -41601,6 +41612,13 @@
 /obj/machinery/meter,
 /turf/open/floor/engine,
 /area/engineering/main)
+"mqT" = (
+/obj/effect/turf_decal/tile/blue/fourcorners,
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+	dir = 10
+	},
+/turf/open/floor/iron/white,
+/area/medical/exam_room)
 "mrh" = (
 /obj/structure/rack,
 /obj/item/clothing/mask/gas,
@@ -45423,6 +45441,7 @@
 "rHG" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/blue/fourcorners,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /turf/open/floor/iron/white,
 /area/medical/exam_room)
 "rJg" = (
@@ -76892,7 +76911,7 @@ cqm
 bsA
 byp
 eER
-eER
+mqT
 eER
 ioj
 cec
@@ -77149,7 +77168,7 @@ cqm
 bsA
 bYt
 rHG
-rHG
+mmV
 rHG
 bEE
 adq


### PR DESCRIPTION
Changes cryocell pipes to loops on all maps but shitstation.
Added CO2 Filter to the new loop and filter CO2 to scrubber pipes.

Check map diffs here: https://github.com/unv-annihilator/RussStation/pull/10/checks?check_run_id=6136793611

Attempted to base setup off of MetaStation's setup: 
![image](https://user-images.githubusercontent.com/665570/164801345-e39dbab1-cd8b-416a-9d64-616633a6ec1e.png)
