### PR TITLE
fixes Diona being dumb

### DIFF
--- a/russstation/code/modules/mob/living/carbon/human/species_types/diona.dm
+++ b/russstation/code/modules/mob/living/carbon/human/species_types/diona.dm
@@ -6,6 +6,8 @@
 	sexes = FALSE
 	species_traits = list(NOBLOOD, NOEYESPRITES, NO_UNDERWEAR)
 	inherent_traits = list(
+		TRAIT_ADVANCEDTOOLUSER,// honk -- imagine not having this
+		TRAIT_CAN_STRIP,
 		TRAIT_NOBREATH,
 		TRAIT_RESISTCOLD,
 		TRAIT_RESISTLOWPRESSURE,


### PR DESCRIPTION
<!-- Fill out each section with text below the header. 
 You can view https://github.com/RussStation/RussStation/wiki/Contributing for a detailed description of the pull request process. -->

## What is changing?

Adds 2 traits allowing Diona to use hands betterer and to strip people so that they can take people's clothes off and peform ~~ERP~~ surgery and steal people's stuff
### Changes


 * Added TRAIT_ADVANCEDTOOLUSER to Dionas allowing them to not have dumb insect hands fixing the dexterity issue
 * Added TRAIT_CAN_STRIP to Dionas so that they can strip people of their valuables

## Why these changes?

I made the fatal mistake of looking at the Diona code and seeing that I could fix this in 1 minute, so I did.