### PR TITLE
Fix Lima Atmos Scrubber Pipe

### DIFF
--- a/_maps/map_files/LimaStation/Lima.dmm
+++ b/_maps/map_files/LimaStation/Lima.dmm
@@ -10484,7 +10484,6 @@
 /obj/machinery/camera/directional/west{
 	c_tag = "Atmospherics North West"
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "dJV" = (
@@ -14634,7 +14633,6 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/bridge_pipe/dark/visible,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
 "fIE" = (
@@ -15253,6 +15251,7 @@
 	dir = 4;
 	name = "Pure to Ports"
 	},
+/obj/machinery/atmospherics/pipe/bridge_pipe/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "gaV" = (
@@ -17054,7 +17053,6 @@
 "gYJ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible,
 /obj/machinery/light/directional/west,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
 "gYL" = (
@@ -20811,7 +20809,6 @@
 	dir = 4;
 	name = "Waste Release"
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
 "jcW" = (
@@ -20976,6 +20973,7 @@
 /obj/machinery/atmospherics/pipe/layer_manifold/orange/visible{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/bridge_pipe/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "jjC" = (
@@ -22297,7 +22295,6 @@
 "jTp" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/yellow/visible/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
 "jTE" = (
@@ -24520,7 +24517,6 @@
 "lgw" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible/layer4,
 /obj/machinery/light/directional/west,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
 "lgP" = (
@@ -25719,10 +25715,6 @@
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/station/service/hydroponics)
-"lPk" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
-/area/station/engineering/atmos)
 "lPM" = (
 /obj/structure/window{
 	dir = 8
@@ -27884,7 +27876,6 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "ncy" = (
@@ -27956,7 +27947,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "nfg" = (
@@ -28579,11 +28569,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/port)
-"nAG" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
-/area/station/engineering/atmos)
 "nBc" = (
 /obj/machinery/light/directional/west,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/violet/visible,
@@ -33538,6 +33523,12 @@
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/aft)
+"qtj" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "qto" = (
 /obj/structure/chair/office/light{
 	dir = 8
@@ -34090,17 +34081,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/engineering/break_room)
-"qJv" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/purple/visible,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/station/engineering/atmos)
 "qJJ" = (
 /turf/open/floor/iron/freezer,
 /area/station/security/prison/safe)
@@ -36541,7 +36521,6 @@
 	c_tag = "Atmospherics South West";
 	network = list("ss13","engine")
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
 "sfD" = (
@@ -37886,6 +37865,16 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/station/commons/toilet)
+"sVS" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/purple/visible,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/station/engineering/atmos)
 "sWj" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron,
@@ -37955,11 +37944,6 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/station/science/ordnance)
-"sYZ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
-/area/station/engineering/atmos)
 "sZc" = (
 /obj/structure/window{
 	dir = 8
@@ -38824,6 +38808,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/pink,
 /turf/closed/wall/r_wall,
 /area/station/science/ordnance/burnchamber)
+"ttF" = (
+/obj/machinery/atmospherics/pipe/bridge_pipe/yellow/visible/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible/layer4,
+/obj/machinery/atmospherics/pipe/bridge_pipe/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "tuj" = (
 /turf/closed/wall,
 /area/station/cargo/warehouse)
@@ -62575,21 +62567,21 @@ eNN
 mCh
 eNN
 dJL
-nAG
-nAG
+eNN
+eNN
 fIv
 gYJ
-nAG
+eNN
 jcG
 jTp
 lgw
-sYZ
-lPk
+lJC
+jsP
 jTp
 lgw
-sYZ
-lPk
-lPk
+lJC
+jsP
+jsP
 sft
 qLt
 rVV
@@ -62848,7 +62840,7 @@ oCe
 jfY
 jfY
 pNA
-qJv
+pvo
 rVV
 rVV
 rVV
@@ -63105,7 +63097,7 @@ mIz
 mIz
 mIz
 pQk
-qJv
+pvo
 smR
 fsz
 fsz
@@ -63346,23 +63338,23 @@ mpW
 yjw
 yjw
 njl
-ycG
-ycG
+kOv
+kOv
 gaS
 gaS
-ycG
+kOv
 jji
-ycG
-ycG
-ycG
-ycG
-ycG
-ycG
-ycG
-ycG
-mIz
-pQk
-qOi
+kOv
+kOv
+kOv
+kOv
+kOv
+kOv
+kOv
+kOv
+ttF
+qtj
+sVS
 smR
 fsz
 qUA


### PR DESCRIPTION
## What is changing?

Fixes Lima's scrubber pipe getting connected to the CO2 and N2O manifolds. Thanks to Redbert for reporting the issue and providing the screenshot below!

Picture of the problem (scrubber is connected but hidden under yellow layer 2 pipe): 
![unknown](https://user-images.githubusercontent.com/665570/189378607-795c46dc-7a48-42f6-8503-ec85f1a0db62.png)

### Changes

Moved scrubber pipe away from the omni manifolds to prevent them connecting to each other

## Why these changes?

Lima map fix. 