### PR TITLE
APC Cleanup

### DIFF
--- a/_maps/map_files/CubeStation/Cube.dmm
+++ b/_maps/map_files/CubeStation/Cube.dmm
@@ -45,15 +45,6 @@
 /obj/machinery/rnd/production/circuit_imprinter/department/science,
 /turf/open/floor/iron/dark,
 /area/station/science/lab)
-"aaH" = (
-/obj/machinery/power/apc/auto_name/directional/east{
-	areastring = "/area/station/tcommsat/computer";
-	name = "Telecomms Monitoring APC"
-	},
-/obj/structure/cable,
-/obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/plating,
-/area/station/maintenance/port/aft)
 "aaJ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -1307,8 +1298,7 @@
 /area/station/engineering/main)
 "aGU" = (
 /obj/machinery/power/apc/auto_name/directional/west{
-	areastring = "/area/station/cargo/miningdock";
-	name = "Mining Dock APC"
+	areastring = "/area/station/cargo/miningdock"
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -1719,10 +1709,7 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "aTB" = (
-/obj/machinery/power/apc/auto_name/directional/north{
-	areastring = "/area/station/engineering/storage/tech";
-	name = "Tech Storage APC"
-	},
+/obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
 /turf/open/floor/iron/checker,
 /area/station/engineering/storage/tech)
@@ -2264,10 +2251,7 @@
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
 "bjO" = (
-/obj/machinery/power/apc/auto_name/directional/north{
-	areastring = "/area/station/maintenance/starboard/central";
-	name = "Starboard Central Maintenance APC"
-	},
+/obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
 /obj/effect/spawner/random/trash/garbage,
 /turf/open/floor/plating,
@@ -3762,8 +3746,7 @@
 /area/station/ai_monitored/turret_protected/ai_upload)
 "bXc" = (
 /obj/machinery/power/apc/auto_name/directional/north{
-	areastring = "/area/station/science/robotics/mechbay";
-	name = "Mech Bay APC"
+	areastring = "/area/station/science/robotics/mechbay"
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -4114,8 +4097,7 @@
 /area/station/medical/surgery)
 "ciC" = (
 /obj/machinery/power/apc/auto_name/directional/north{
-	areastring = "/area/station/commons/storage/tools";
-	name = "Auxiliary Tool Storage APC"
+	areastring = "/area/station/commons/storage/tools"
 	},
 /obj/structure/cable,
 /obj/effect/spawner/random/trash/garbage,
@@ -5533,10 +5515,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/machinery/power/apc/auto_name/directional/north{
-	areastring = "/area/station/security/brig";
-	name = "Brig APC"
-	},
+/obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/brig)
@@ -5578,11 +5557,7 @@
 /turf/open/floor/circuit,
 /area/station/ai_monitored/command/nuke_storage)
 "dam" = (
-/obj/machinery/power/apc/auto_name/directional/south{
-	areastring = "/area/station/cargo/office";
-	name = "Cargo Office APC";
-	pixel_x = 1
-	},
+/obj/machinery/power/apc/auto_name/directional/south,
 /obj/structure/table,
 /obj/item/paper_bin,
 /obj/item/pen/red,
@@ -5917,10 +5892,7 @@
 /turf/open/floor/iron,
 /area/station/security/checkpoint/auxiliary)
 "dkj" = (
-/obj/machinery/power/apc/auto_name/directional/west{
-	areastring = "/area/station/commons/vacant_room/office";
-	name = "Vacant Office APC"
-	},
+/obj/machinery/power/apc/auto_name/directional/west,
 /obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/commons/vacant_room/office)
@@ -6049,8 +6021,7 @@
 /area/station/science/lab)
 "dnw" = (
 /obj/machinery/power/apc/auto_name/directional/east{
-	areastring = "/area/station/service/chapel";
-	name = "Chapel APC"
+	areastring = "/area/station/service/chapel"
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -6443,10 +6414,7 @@
 /turf/open/floor/iron,
 /area/station/command/bridge)
 "dzf" = (
-/obj/machinery/power/apc/auto_name/directional/north{
-	areastring = "/area/station/science/lab";
-	name = "Research Lab APC"
-	},
+/obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
 /turf/open/floor/iron/showroomfloor,
 /area/station/science/lab)
@@ -7832,8 +7800,7 @@
 /area/station/engineering/gravity_generator)
 "ehm" = (
 /obj/machinery/power/apc/auto_name/directional/east{
-	areastring = "/area/station/cargo/warehouse";
-	name = "Cargo Warehouse APC"
+	areastring = "/area/station/cargo/warehouse"
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -7892,6 +7859,7 @@
 	pixel_x = 27
 	},
 /obj/structure/cable,
+/obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/iron,
 /area/station/tcommsat/computer)
 "eik" = (
@@ -8175,10 +8143,7 @@
 /area/station/cargo/storage)
 "epp" = (
 /obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/south{
-	areastring = "/area/station/hallway/primary/starboard";
-	name = "Starboard Primary Hallway APC"
-	},
+/obj/machinery/power/apc/auto_name/directional/south,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "epw" = (
@@ -8848,10 +8813,7 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "eIG" = (
-/obj/machinery/power/apc/auto_name/directional/west{
-	areastring = "/area/station/engineering/break_room";
-	name = "Engineering Foyer APC"
-	},
+/obj/machinery/power/apc/auto_name/directional/west,
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -9639,10 +9601,7 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
-/obj/machinery/power/apc/auto_name/directional/north{
-	areastring = "/area/station/medical/medbay/aft";
-	name = "Paramedic APC"
-	},
+/obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/aft)
@@ -9681,10 +9640,7 @@
 /turf/open/floor/iron/dark,
 /area/station/science/genetics)
 "feH" = (
-/obj/machinery/power/apc/auto_name/directional/east{
-	areastring = "/area/station/security";
-	name = "Security Office APC"
-	},
+/obj/machinery/power/apc/auto_name/directional/east,
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security)
@@ -10622,10 +10578,7 @@
 /turf/open/floor/iron/showroomfloor,
 /area/station/science/xenobiology)
 "fHb" = (
-/obj/machinery/power/apc/auto_name/directional/west{
-	areastring = "/area/station/command/heads_quarters/hos";
-	name = "Head of Security's Office APC"
-	},
+/obj/machinery/power/apc/auto_name/directional/west,
 /obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hos)
@@ -10789,9 +10742,7 @@
 /area/station/tcommsat/server)
 "fMQ" = (
 /obj/machinery/power/apc/auto_name/directional/west{
-	areastring = "/area/station/command/gateway";
-	name = "Gateway APC";
-	pixel_y = -1
+	areastring = "/area/station/command/gateway"
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -10839,10 +10790,7 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "fNo" = (
-/obj/machinery/power/apc/auto_name/directional/east{
-	areastring = "/area/station/hallway/secondary/entry";
-	name = "Entry Hall APC"
-	},
+/obj/machinery/power/apc/auto_name/directional/east,
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
@@ -11238,8 +11186,7 @@
 /area/station/maintenance/port/aft)
 "fXg" = (
 /obj/machinery/power/apc/auto_name/directional/south{
-	areastring = "/area/station/service/chapel/office";
-	name = "Chapel Office APC"
+	areastring = "/area/station/service/chapel/office"
 	},
 /obj/structure/cable,
 /obj/effect/spawner/random/trash/garbage,
@@ -11397,8 +11344,7 @@
 /area/station/service/theater)
 "gbw" = (
 /obj/machinery/power/apc/auto_name/directional/north{
-	areastring = "/area/station/medical/pharmacy";
-	name = "Pharmacy APC"
+	areastring = "/area/station/medical/pharmacy"
 	},
 /obj/structure/cable,
 /obj/structure/table,
@@ -11504,8 +11450,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/power/apc/auto_name/directional/east{
-	areastring = "/area/station/security/detectives_office";
-	name = "Detective's Office APC"
+	areastring = "/area/station/security/detectives_office"
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -11958,10 +11903,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/aft)
 "gqS" = (
-/obj/machinery/power/apc/auto_name/directional/north{
-	areastring = "/area/station/maintenance/central";
-	name = "Central Maintenance APC"
-	},
+/obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/central)
@@ -12154,11 +12096,7 @@
 	dir = 6
 	},
 /obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/west{
-	areastring = "/area/station/maintenance/port";
-	name = "Port Maintenance APC";
-	pixel_y = 2
-	},
+/obj/machinery/power/apc/auto_name/directional/west,
 /turf/open/floor/plating,
 /area/station/maintenance/port)
 "guO" = (
@@ -13439,8 +13377,7 @@
 /area/station/command/bridge)
 "hdi" = (
 /obj/machinery/power/apc/auto_name/directional/north{
-	areastring = "/area/station/commons/dorms";
-	name = "Dormitory APC"
+	areastring = "/area/station/commons/dorms"
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -13756,11 +13693,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/solars/starboard/fore)
 "hnG" = (
-/obj/machinery/power/apc/auto_name/directional/east{
-	areastring = "/area/station/maintenance/solars/port/aft";
-	name = "Port Quarter Solar APC";
-	pixel_y = 2
-	},
+/obj/machinery/power/apc/auto_name/directional/east,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/solars/port/aft)
@@ -13886,10 +13819,7 @@
 /area/station/maintenance/port/aft)
 "hpM" = (
 /obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/north{
-	areastring = "/area/station/maintenance/starboard/fore";
-	name = "Starboard Bow Maintenance APC"
-	},
+/obj/machinery/power/apc/auto_name/directional/north,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "hqg" = (
@@ -14125,10 +14055,7 @@
 /turf/open/floor/iron/dark,
 /area/station/medical/pharmacy)
 "huC" = (
-/obj/machinery/power/apc/auto_name/directional/south{
-	areastring = "/area/station/maintenance/department/electrical";
-	name = "Electrical Maintenance APC"
-	},
+/obj/machinery/power/apc/auto_name/directional/south,
 /obj/structure/cable,
 /obj/machinery/recharge_station,
 /turf/open/floor/plating,
@@ -14348,10 +14275,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue,
-/obj/machinery/power/apc/auto_name/directional/south{
-	areastring = "/area/station/medical/exam_room";
-	name = "Treatment Center APC"
-	},
+/obj/machinery/power/apc/auto_name/directional/south,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
@@ -14667,8 +14591,7 @@
 "hHD" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/north{
-	areastring = "/area/station/commons/storage/emergency/port";
-	name = "Port Emergency Storage APC"
+	areastring = "/area/station/commons/storage/emergency/port"
 	},
 /obj/effect/spawner/random/trash/garbage,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
@@ -14751,8 +14674,7 @@
 /area/station/maintenance/starboard/fore)
 "hKp" = (
 /obj/machinery/power/apc/auto_name/directional/south{
-	areastring = "/area/station/maintenance/disposal/incinerator";
-	name = "Incinerator APC"
+	areastring = "/area/station/maintenance/disposal/incinerator"
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -15124,10 +15046,7 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/north{
-	areastring = "/area/station/maintenance/fore";
-	name = "Fore Maintenance APC"
-	},
+/obj/machinery/power/apc/auto_name/directional/north,
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
 "hVG" = (
@@ -17873,10 +17792,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/power/apc/auto_name/directional/north{
-	areastring = "/area/station/hallway/primary/port";
-	name = "Port Hall APC"
-	},
+/obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
@@ -18145,9 +18061,7 @@
 /area/station/security/checkpoint/auxiliary)
 "jCW" = (
 /obj/machinery/power/apc/auto_name/directional/south{
-	areastring = "/area/station/cargo/storage";
-	name = "Cargo Bay APC";
-	pixel_x = 1
+	areastring = "/area/station/cargo/storage"
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -18896,10 +18810,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue,
-/obj/machinery/power/apc/auto_name/directional/north{
-	areastring = "/area/station/command/heads_quarters/cmo";
-	name = "CMO Office APC"
-	},
+/obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
 /obj/machinery/computer/crew,
 /turf/open/floor/iron/showroomfloor,
@@ -19468,8 +19379,7 @@
 	dir = 4
 	},
 /obj/machinery/power/apc/auto_name/directional/south{
-	areastring = "/area/station/medical/chemistry";
-	name = "Chemistry APC"
+	areastring = "/area/station/medical/chemistry"
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -19516,8 +19426,7 @@
 /area/station/cargo/sorting)
 "kpU" = (
 /obj/machinery/power/apc/auto_name/directional/north{
-	areastring = "/area/station/command/heads_quarters/hop";
-	name = "Head of Personnel APC"
+	areastring = "/area/station/command/heads_quarters/hop"
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -20323,9 +20232,7 @@
 /area/station/hallway/primary/starboard)
 "kNB" = (
 /obj/machinery/power/apc/auto_name/directional/east{
-	areastring = "/area/station/commons/vacant_room/commissary";
-	name = "Vacant Commissary APC";
-	pixel_y = 2
+	areastring = "/area/station/commons/vacant_room/commissary"
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -20386,10 +20293,7 @@
 /area/station/hallway/primary/starboard)
 "kPD" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/power/apc/auto_name/directional/east{
-	areastring = "/area/station/science/xenobiology";
-	name = "Xenobiology APC"
-	},
+/obj/machinery/power/apc/auto_name/directional/east,
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/science/xenobiology)
@@ -21995,10 +21899,7 @@
 /turf/open/floor/iron/dark,
 /area/station/science/genetics)
 "lKG" = (
-/obj/machinery/power/apc/auto_name/directional/north{
-	areastring = "/area/station/command/heads_quarters/captain";
-	name = "Captain's Office APC"
-	},
+/obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/captain)
@@ -22062,8 +21963,7 @@
 "lLE" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/east{
-	areastring = "/area/station/service/theater";
-	name = "Theatre APC"
+	areastring = "/area/station/service/theater"
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/aft)
@@ -22492,10 +22392,7 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "lZc" = (
-/obj/machinery/power/apc/auto_name/directional/north{
-	areastring = "/area/station/ai_monitored/command/nuke_storage";
-	name = "Vault APC"
-	},
+/obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/command/nuke_storage)
@@ -23189,8 +23086,7 @@
 "moX" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/east{
-	areastring = "/area/station/science/genetics";
-	name = "Genetics Lab APC"
+	areastring = "/area/station/science/genetics"
 	},
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/plating,
@@ -23431,10 +23327,7 @@
 "muZ" = (
 /obj/structure/table,
 /obj/item/storage/toolbox/artistic,
-/obj/machinery/power/apc/auto_name/directional/north{
-	areastring = "/area/station/hallway/secondary/service";
-	name = "Service Hall APC"
-	},
+/obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/service)
@@ -23527,10 +23420,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 6
 	},
-/obj/machinery/power/apc/auto_name/directional/north{
-	areastring = "/area/station/medical/morgue";
-	name = "Morgue APC"
-	},
+/obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
@@ -23765,11 +23655,7 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/north{
-	areastring = "/area/station/maintenance/port/fore";
-	name = "Port Bow Maintenance APC";
-	pixel_x = -1
-	},
+/obj/machinery/power/apc/auto_name/directional/north,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "mCU" = (
@@ -24075,10 +23961,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "mMt" = (
-/obj/machinery/power/apc/auto_name/directional/west{
-	areastring = "/area/station/command/heads_quarters/rd";
-	name = "RD Office APC"
-	},
+/obj/machinery/power/apc/auto_name/directional/west,
 /obj/structure/cable,
 /obj/machinery/modular_computer/console/preset/research{
 	dir = 4
@@ -24180,8 +24063,7 @@
 /area/station/service/kitchen)
 "mOY" = (
 /obj/machinery/power/apc/auto_name/directional/north{
-	areastring = "/area/station/service/hydroponics";
-	name = "Hydroponics APC"
+	areastring = "/area/station/service/hydroponics"
 	},
 /obj/structure/cable,
 /obj/structure/closet/crate/freezer,
@@ -24299,10 +24181,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/west{
-	areastring = "/area/station/security/lockers";
-	name = "Brig Locker Room APC"
-	},
+/obj/machinery/power/apc/auto_name/directional/west,
 /turf/open/floor/iron/showroomfloor,
 /area/station/security/lockers)
 "mRM" = (
@@ -24412,10 +24291,7 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
-/obj/machinery/power/apc/auto_name/directional/south{
-	areastring = "/area/station/commons/fitness";
-	name = "Fitness Room APC"
-	},
+/obj/machinery/power/apc/auto_name/directional/south,
 /obj/structure/cable,
 /turf/open/floor/iron/cafeteria,
 /area/station/commons/fitness)
@@ -24499,8 +24375,7 @@
 "mVM" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/north{
-	areastring = "/area/station/science/explab";
-	name = "Experimentation APC"
+	areastring = "/area/station/science/explab"
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
@@ -25091,8 +24966,7 @@
 /area/station/maintenance/starboard/aft)
 "njG" = (
 /obj/machinery/power/apc/auto_name/directional/north{
-	areastring = "/area/station/command/heads_quarters/qm";
-	name = "Quartermaster APC"
+	areastring = "/area/station/command/heads_quarters/qm"
 	},
 /obj/structure/cable,
 /obj/effect/spawner/random/trash/garbage,
@@ -26667,10 +26541,7 @@
 	dir = 9
 	},
 /obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/south{
-	areastring = "/area/station/maintenance/aft";
-	name = "Aft Maintenance APC"
-	},
+/obj/machinery/power/apc/auto_name/directional/south,
 /turf/open/floor/plating,
 /area/station/maintenance/aft)
 "nZt" = (
@@ -27235,8 +27106,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/power/apc/auto_name/directional/west{
-	areastring = "/area/station/commons/toilet";
-	name = "Dormitory Bathrooms APC"
+	areastring = "/area/station/commons/toilet"
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -27552,8 +27422,7 @@
 /area/station/engineering/gravity_generator)
 "ovt" = (
 /obj/machinery/power/apc/auto_name/directional/south{
-	areastring = "/area/station/medical/psychology";
-	name = "Psychology APC"
+	areastring = "/area/station/medical/psychology"
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -27908,10 +27777,7 @@
 /turf/open/floor/iron/showroomfloor,
 /area/station/hallway/primary/starboard)
 "oGP" = (
-/obj/machinery/power/apc/auto_name/directional/south{
-	areastring = "/area/station/hallway/primary/central";
-	name = "Central Hall APC"
-	},
+/obj/machinery/power/apc/auto_name/directional/south,
 /obj/effect/turf_decal/caution{
 	dir = 8
 	},
@@ -28009,10 +27875,7 @@
 /area/station/service/bar)
 "oIu" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/power/apc/auto_name/directional/west{
-	areastring = "/area/station/science/ordnance/storage";
-	name = "Toxins Storage APC"
-	},
+/obj/machinery/power/apc/auto_name/directional/west,
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/science/ordnance/storage)
@@ -29086,10 +28949,7 @@
 /turf/open/floor/carpet/red,
 /area/station/service/chapel)
 "pjV" = (
-/obj/machinery/power/apc/auto_name/directional/west{
-	areastring = "/area/station/hallway/secondary/exit";
-	name = "Escape Hallway APC"
-	},
+/obj/machinery/power/apc/auto_name/directional/west,
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit)
@@ -29128,10 +28988,7 @@
 /turf/open/floor/plating/airless,
 /area/station/engineering/supermatter/room)
 "plu" = (
-/obj/machinery/power/apc/auto_name/directional/west{
-	areastring = "/area/station/maintenance/central/lesser";
-	name = "Central Maintenance APC"
-	},
+/obj/machinery/power/apc/auto_name/directional/west,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/central/lesser)
@@ -29791,10 +29648,7 @@
 /area/station/security/prison)
 "pBr" = (
 /obj/effect/spawner/random/trash/grille_or_waste,
-/obj/machinery/power/apc/auto_name/directional/south{
-	areastring = "/area/station/maintenance/starboard/aft";
-	name = "Starboard Quarter Maintenance APC"
-	},
+/obj/machinery/power/apc/auto_name/directional/south,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
@@ -30803,8 +30657,7 @@
 /area/station/maintenance/starboard/aft)
 "qbD" = (
 /obj/machinery/power/apc/auto_name/directional/west{
-	areastring = "/area/station/commons/storage/art";
-	name = "Art Storage"
+	areastring = "/area/station/commons/storage/art"
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -31490,8 +31343,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/south{
-	areastring = "/area/station/service/bar";
-	name = "Bar APC"
+	areastring = "/area/station/service/bar"
 	},
 /obj/effect/spawner/random/trash/garbage,
 /turf/open/floor/iron,
@@ -31598,10 +31450,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/power/apc/auto_name/directional/north{
-	areastring = "/area/station/science/robotics/lab";
-	name = "Robotics Lab APC"
-	},
+/obj/machinery/power/apc/auto_name/directional/north,
 /turf/open/floor/iron/showroomfloor,
 /area/station/science/robotics/lab)
 "qwA" = (
@@ -31627,8 +31476,7 @@
 /area/station/science/xenobiology)
 "qwG" = (
 /obj/machinery/power/apc/auto_name/directional/north{
-	areastring = "/area/station/maintenance/disposal";
-	name = "Disposal APC"
+	areastring = "/area/station/maintenance/disposal"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -32399,10 +32247,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
-/obj/machinery/power/apc/auto_name/directional/east{
-	areastring = "/area/station/science/server";
-	name = "Server Room APC"
-	},
+/obj/machinery/power/apc/auto_name/directional/east,
 /obj/structure/cable,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/plating,
@@ -32532,15 +32377,7 @@
 /turf/open/floor/plating,
 /area/station/engineering/atmos)
 "qPS" = (
-/obj/machinery/light_switch{
-	pixel_x = -8;
-	pixel_y = -23
-	},
-/obj/machinery/power/apc/auto_name/directional/south{
-	areastring = "/area/station/security/checkpoint/auxiliary";
-	name = "Security Checkpoint APC";
-	pixel_x = 1
-	},
+/obj/machinery/power/apc/auto_name/directional/south,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
@@ -32552,6 +32389,9 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/red,
+/obj/machinery/light_switch/directional/south{
+	pixel_x = -11
+	},
 /turf/open/floor/iron,
 /area/station/security/checkpoint/auxiliary)
 "qPU" = (
@@ -32980,8 +32820,7 @@
 /area/station/maintenance/aft)
 "qXt" = (
 /obj/machinery/power/apc/auto_name/directional/west{
-	areastring = "/area/station/security/courtroom";
-	name = "Courtroom APC"
+	areastring = "/area/station/security/courtroom"
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -33511,8 +33350,7 @@
 /area/station/cargo/miningdock)
 "rkb" = (
 /obj/machinery/power/apc/auto_name/directional/east{
-	areastring = "/area/station/service/kitchen";
-	name = "Kitchen APC"
+	areastring = "/area/station/service/kitchen"
 	},
 /obj/structure/cable,
 /obj/machinery/food_cart,
@@ -34062,8 +33900,7 @@
 /area/station/service/hydroponics)
 "rwK" = (
 /obj/machinery/power/apc/auto_name/directional/east{
-	areastring = "/area/station/service/janitor";
-	name = "Custodial Closet APC"
+	areastring = "/area/station/service/janitor"
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -34502,8 +34339,7 @@
 /area/station/cargo/warehouse)
 "rFR" = (
 /obj/machinery/power/apc/auto_name/directional/west{
-	areastring = "/area/station/construction/mining/aux_base";
-	name = "Auxillary Base Construction APC"
+	areastring = "/area/station/construction/mining/aux_base"
 	},
 /obj/structure/cable,
 /turf/open/floor/iron,
@@ -34652,10 +34488,7 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
-/obj/machinery/power/apc/auto_name/directional/south{
-	areastring = "/area/station/security/execution/transfer";
-	name = "Prisoner Transfer Centre"
-	},
+/obj/machinery/power/apc/auto_name/directional/south,
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/security/execution/transfer)
@@ -34751,11 +34584,7 @@
 /turf/open/floor/iron,
 /area/station/science/lab)
 "rNr" = (
-/obj/machinery/power/apc/auto_name/directional/west{
-	areastring = "/area/station/maintenance/solars/starboard/aft";
-	name = "Starboard Quarter Solar APC";
-	pixel_y = 3
-	},
+/obj/machinery/power/apc/auto_name/directional/west,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/solars/starboard/aft)
@@ -35821,10 +35650,7 @@
 /turf/open/floor/iron,
 /area/station/commons/fitness)
 "srk" = (
-/obj/machinery/power/apc/auto_name/directional/north{
-	areastring = "/area/station/maintenance/starboard/lesser";
-	name = "Starboard Bow  Maintenance 2 APC"
-	},
+/obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
@@ -35933,8 +35759,7 @@
 	},
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/north{
-	areastring = "/area/station/service/lawoffice";
-	name = "Law Office APC"
+	areastring = "/area/station/service/lawoffice"
 	},
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
@@ -36027,11 +35852,7 @@
 /area/station/security/brig)
 "swu" = (
 /obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/west{
-	areastring = "/area/station/maintenance/solars/starboard/fore";
-	name = "Starboard Bow Solar APC";
-	pixel_y = 3
-	},
+/obj/machinery/power/apc/auto_name/directional/west,
 /turf/open/floor/plating,
 /area/station/maintenance/solars/starboard/fore)
 "swO" = (
@@ -36726,10 +36547,7 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
-/obj/machinery/power/apc/auto_name/directional/north{
-	areastring = "/area/station/medical/storage";
-	name = "Medbay Storage APC"
-	},
+/obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/storage)
@@ -38377,10 +38195,7 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "tLc" = (
-/obj/machinery/power/apc/auto_name/directional/north{
-	areastring = "/area/station/ai_monitored/command/storage/eva";
-	name = "EVA Storage APC"
-	},
+/obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/ai_monitored/command/storage/eva)
@@ -39140,11 +38955,7 @@
 /turf/open/floor/engine,
 /area/station/science/xenobiology)
 "udB" = (
-/obj/machinery/power/apc/auto_name/directional/west{
-	areastring = "/area/station/hallway/primary/aft";
-	name = "Aft Hall APC";
-	pixel_y = 1
-	},
+/obj/machinery/power/apc/auto_name/directional/west,
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
@@ -39753,11 +39564,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
 "usg" = (
-/obj/machinery/power/apc/auto_name/directional/west{
-	areastring = "/area/station/maintenance/solars/port/fore";
-	name = "Port Bow Solar APC";
-	pixel_y = 3
-	},
+/obj/machinery/power/apc/auto_name/directional/west,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/solars/port/fore)
@@ -40548,8 +40355,7 @@
 /area/station/service/chapel/office)
 "uMV" = (
 /obj/machinery/power/apc/auto_name/directional/west{
-	areastring = "/area/station/cargo/sorting";
-	name = "Delivery Office APC"
+	areastring = "/area/station/cargo/sorting"
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -40897,10 +40703,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/power/apc/auto_name/directional/north{
-	areastring = "/area/station/science/research";
-	name = "Research Division APC"
-	},
+/obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
 /turf/open/floor/iron/showroomfloor,
 /area/station/science/research)
@@ -41067,10 +40870,7 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
-/obj/machinery/power/apc/auto_name/directional/west{
-	areastring = "/area/station/hallway/primary/fore";
-	name = "Fore Primary Hallway APC"
-	},
+/obj/machinery/power/apc/auto_name/directional/west,
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
@@ -41472,10 +41272,7 @@
 	pixel_x = 4;
 	pixel_y = 8
 	},
-/obj/machinery/power/apc/auto_name/directional/west{
-	areastring = "/area/station/security/checkpoint/medical";
-	name = "Medbay Security APC"
-	},
+/obj/machinery/power/apc/auto_name/directional/west,
 /obj/item/storage/fancy/donut_box,
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/red/filled/line{
@@ -41542,11 +41339,7 @@
 /turf/open/floor/iron,
 /area/station/commons/storage/primary)
 "vlj" = (
-/obj/machinery/power/apc/auto_name/directional/west{
-	areastring = "/area/station/engineering/gravity_generator";
-	name = "Gravity Generator APC";
-	pixel_y = 1
-	},
+/obj/machinery/power/apc/auto_name/directional/west,
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -41720,10 +41513,7 @@
 /area/station/engineering/atmos)
 "vro" = (
 /obj/structure/closet/crate,
-/obj/machinery/power/apc/auto_name/directional/west{
-	areastring = "/area/station/command/teleporter";
-	name = "Teleporter APC"
-	},
+/obj/machinery/power/apc/auto_name/directional/west,
 /obj/item/radio/intercom{
 	pixel_y = 20
 	},
@@ -42144,10 +41934,7 @@
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "vzF" = (
-/obj/machinery/power/apc/auto_name/directional/west{
-	areastring = "/area/station/security/processing";
-	name = "Labor Shuttle Dock APC"
-	},
+/obj/machinery/power/apc/auto_name/directional/west,
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/processing)
@@ -42275,9 +42062,7 @@
 	},
 /obj/structure/cable,
 /obj/machinery/camera/autoname/directional/east,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 27
-	},
+/obj/machinery/power/apc/auto_name/directional/east,
 /turf/open/floor/iron,
 /area/station/tcommsat/computer)
 "vCX" = (
@@ -43792,11 +43577,7 @@
 /turf/open/floor/iron,
 /area/station/command/bridge)
 "wnK" = (
-/obj/machinery/power/apc/auto_name/directional/south{
-	areastring = "/area/station/commons/storage/primary";
-	name = "Primary Tool Storage APC";
-	pixel_x = 1
-	},
+/obj/machinery/power/apc/auto_name/directional/south,
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/commons/storage/primary)
@@ -44173,9 +43954,7 @@
 "wwt" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/east{
-	areastring = "/area/station/service/hydroponics/garden";
-	name = "Garden APC";
-	pixel_y = 2
+	areastring = "/area/station/service/hydroponics/garden"
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
@@ -44254,10 +44033,7 @@
 /turf/open/floor/engine/o2,
 /area/station/engineering/atmos)
 "wys" = (
-/obj/machinery/power/apc/auto_name/directional/west{
-	areastring = "/area/station/security/warden";
-	name = "Brig Control APC"
-	},
+/obj/machinery/power/apc/auto_name/directional/west,
 /obj/structure/cable,
 /obj/machinery/computer/security{
 	dir = 4
@@ -46163,8 +45939,7 @@
 "xrY" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/power/apc/auto_name/directional/east{
-	areastring = "/area/station/service/library";
-	name = "Library APC"
+	areastring = "/area/station/service/library"
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -46252,10 +46027,7 @@
 /area/station/service/bar)
 "xuq" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/power/apc/auto_name/directional/east{
-	areastring = "/area/station/medical/medbay/central";
-	name = "Medbay Central APC"
-	},
+/obj/machinery/power/apc/auto_name/directional/east,
 /obj/structure/cable,
 /obj/machinery/iv_drip,
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -46287,10 +46059,7 @@
 /area/station/command/heads_quarters/hos)
 "xvB" = (
 /obj/machinery/modular_computer/console/preset/engineering,
-/obj/machinery/power/apc/auto_name/directional/north{
-	areastring = "/area/station/engineering/engine_smes";
-	name = "SMES room APC"
-	},
+/obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/engineering/engine_smes)
@@ -47923,10 +47692,7 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/north{
-	areastring = "/area/station/maintenance/fore/lesser";
-	name = "Fore Maintenance APC"
-	},
+/obj/machinery/power/apc/auto_name/directional/north,
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
 "yjq" = (
@@ -69946,7 +69712,7 @@ htU
 kNB
 uog
 myk
-aaH
+htU
 nPn
 qhp
 qhp

--- a/_maps/map_files/EchoStation/EchoStation.dmm
+++ b/_maps/map_files/EchoStation/EchoStation.dmm
@@ -48,11 +48,7 @@
 /area/station/hallway/secondary/exit)
 "abG" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/power/apc/auto_name/directional/north{
-	areastring = "/area/station/maintenance/starboard/lesser";
-	name = "Starboard Bow  Maintenance 2 APC";
-	pixel_x = 24
-	},
+/obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/lesser)
@@ -86,10 +82,7 @@
 /turf/open/floor/iron,
 /area/station/security/processing)
 "adp" = (
-/obj/machinery/power/apc/auto_name/directional/west{
-	areastring = "/area/station/engineering/break_room";
-	name = "Engineering Foyer APC"
-	},
+/obj/machinery/power/apc/auto_name/directional/west,
 /obj/machinery/computer/station_alert{
 	dir = 4
 	},
@@ -983,8 +976,7 @@
 	dir = 4
 	},
 /obj/machinery/power/apc/auto_name/directional/north{
-	areastring = "/area/station/security/processing";
-	name = "Labor Shuttle Dock APC"
+	areastring = "/area/station/security/processing"
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -1470,7 +1462,7 @@
 /obj/item/folder,
 /obj/item/paper/crumpled,
 /turf/open/floor/iron/dark,
-/area/station/science/explab)
+/area/station/science/circuits)
 "aNM" = (
 /obj/structure/toilet{
 	dir = 4
@@ -1798,8 +1790,7 @@
 /area/station/science/server)
 "aWv" = (
 /obj/machinery/power/apc/auto_name/directional/south{
-	areastring = "/area/station/service/chapel";
-	name = "Chapel APC"
+	areastring = "/area/station/service/chapel"
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
@@ -1835,7 +1826,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/showroomfloor,
-/area/station/science/lab)
+/area/station/science/explab)
 "aXg" = (
 /obj/machinery/camera/directional/north,
 /turf/open/floor/iron,
@@ -2016,10 +2007,7 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
-/obj/machinery/power/apc/auto_name/directional/east{
-	areastring = "/area/station/security/prison";
-	name = "Prison Wing APC"
-	},
+/obj/machinery/power/apc/auto_name/directional/east,
 /obj/structure/table,
 /obj/structure/cable,
 /turf/open/floor/iron,
@@ -3664,8 +3652,7 @@
 	},
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/north{
-	areastring = "/area/station/commons/vacant_room/commissary";
-	name = "Vacant Commissary APC"
+	areastring = "/area/station/commons/vacant_room/commissary"
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
@@ -4122,8 +4109,7 @@
 /area/space/nearstation)
 "ckB" = (
 /obj/machinery/power/apc/auto_name/directional/north{
-	areastring = "/area/station/service/bar";
-	name = "Bar APC"
+	areastring = "/area/station/service/bar"
 	},
 /obj/structure/cable,
 /obj/effect/spawner/random/trash/garbage,
@@ -4771,8 +4757,7 @@
 /area/station/hallway/secondary/exit)
 "cEr" = (
 /obj/machinery/power/apc/auto_name/directional/west{
-	areastring = "/area/station/commons/storage/art";
-	name = "Art Storage"
+	areastring = "/area/station/commons/storage/art"
 	},
 /obj/structure/cable,
 /obj/effect/spawner/random/structure/crate_abandoned,
@@ -5176,7 +5161,7 @@
 	},
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/showroomfloor,
-/area/station/science/lab)
+/area/station/science/explab)
 "cPl" = (
 /obj/structure/sign/logo{
 	icon_state = "nanotrasen_sign2";
@@ -5270,10 +5255,7 @@
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/auxiliary)
 "cRQ" = (
-/obj/machinery/power/apc/auto_name/directional/north{
-	areastring = "/area/station/security/execution/transfer";
-	name = "Prisoner Transfer Centre"
-	},
+/obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/closet/secure_closet/injection{
 	name = "Sleepytime Syringes"
 	},
@@ -5371,7 +5353,7 @@
 	dir = 5
 	},
 /turf/open/floor/iron/showroomfloor,
-/area/station/science/lab)
+/area/station/science/explab)
 "cWb" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -5625,7 +5607,7 @@
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/station/science/lab)
+/area/station/science/explab)
 "dbK" = (
 /obj/effect/spawner/atmos_canister/nitrous_oxide,
 /obj/structure/sign/warning/no_smoking{
@@ -5912,8 +5894,7 @@
 /area/station/security/execution/transfer)
 "dhN" = (
 /obj/machinery/power/apc/auto_name/directional/east{
-	areastring = "/area/station/maintenance/disposal";
-	name = "Disposal APC"
+	areastring = "/area/station/maintenance/disposal"
 	},
 /obj/structure/cable,
 /obj/effect/spawner/random/trash/garbage,
@@ -6295,11 +6276,7 @@
 /obj/machinery/computer/security{
 	dir = 1
 	},
-/obj/machinery/power/apc/auto_name/directional/south{
-	areastring = "/area/station/security/checkpoint/auxiliary";
-	name = "Security Checkpoint APC";
-	pixel_x = 1
-	},
+/obj/machinery/power/apc/auto_name/directional/south,
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/auxiliary)
@@ -6356,11 +6333,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/machinery/power/apc/auto_name/directional/north{
-	areastring = "/area/station/maintenance/port/fore";
-	name = "Port Bow Maintenance APC";
-	pixel_x = -1
-	},
+/obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
@@ -7067,11 +7040,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/machinery/power/apc/auto_name/directional/west{
-	areastring = "/area/station/engineering/gravity_generator";
-	name = "Gravity Generator APC";
-	pixel_y = -25
-	},
+/obj/machinery/power/apc/auto_name/directional/west,
 /obj/structure/closet/radiation,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/turf_decal/stripes/line{
@@ -7200,7 +7169,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
-/area/station/science/lab)
+/area/station/science/explab)
 "dRZ" = (
 /obj/vehicle/ridden/secway,
 /turf/open/floor/iron/dark,
@@ -7908,8 +7877,7 @@
 /area/station/service/janitor)
 "eiv" = (
 /obj/machinery/power/apc/auto_name/directional/south{
-	areastring = "/area/station/commons/dorms";
-	name = "Dormitory APC"
+	areastring = "/area/station/commons/dorms"
 	},
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -7954,7 +7922,7 @@
 	pixel_y = 11
 	},
 /turf/open/floor/iron/dark,
-/area/station/science/explab)
+/area/station/science/circuits)
 "ejx" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -8013,7 +7981,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/station/science/explab)
+/area/station/science/circuits)
 "elc" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -8051,8 +8019,7 @@
 /area/station/construction/mining/aux_base)
 "elP" = (
 /obj/machinery/power/apc/auto_name/directional/east{
-	areastring = "/area/station/hallway/secondary/entry";
-	name = "Arrivals APC"
+	areastring = "/area/station/hallway/secondary/entry"
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -8442,7 +8409,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
-/area/station/science/explab)
+/area/station/science/circuits)
 "exf" = (
 /obj/structure/closet/secure_closet/atmospherics,
 /turf/open/floor/iron/showroomfloor,
@@ -8539,8 +8506,7 @@
 /area/station/maintenance/port/fore)
 "eAr" = (
 /obj/machinery/power/apc/auto_name/directional/south{
-	areastring = "/area/station/maintenance/disposal/incinerator";
-	name = "Incinerator APC"
+	areastring = "/area/station/maintenance/disposal/incinerator"
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -8763,7 +8729,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/dark,
-/area/station/science/lab)
+/area/station/science/explab)
 "eHh" = (
 /obj/structure/window{
 	dir = 1
@@ -9037,10 +9003,7 @@
 /turf/open/floor/iron/sepia,
 /area/station/service/chapel)
 "eMT" = (
-/obj/machinery/power/apc/auto_name/directional/north{
-	areastring = "/area/station/maintenance/central/lesser";
-	name = "Central Maintenance APC"
-	},
+/obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/central/lesser)
@@ -10264,7 +10227,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
-/area/station/science/lab)
+/area/station/science/explab)
 "ftS" = (
 /obj/structure/alien/weeds,
 /obj/structure/alien/weeds,
@@ -10421,10 +10384,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/machinery/power/apc/auto_name/directional/north{
-	areastring = "/area/station/maintenance/fore";
-	name = "Fore Maintenance APC"
-	},
+/obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
@@ -10766,8 +10726,7 @@
 /area/station/maintenance/starboard/aft)
 "fLA" = (
 /obj/machinery/power/apc/auto_name/directional/west{
-	areastring = "/area/station/service/janitor";
-	name = "Custodial Closet APC"
+	areastring = "/area/station/service/janitor"
 	},
 /obj/structure/cable,
 /obj/effect/decal/cleanable/garbage,
@@ -10974,7 +10933,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
-/area/station/science/explab)
+/area/station/science/circuits)
 "fSc" = (
 /obj/structure/chair{
 	dir = 4
@@ -11060,7 +11019,7 @@
 	},
 /obj/machinery/module_duplicator,
 /turf/open/floor/iron/dark,
-/area/station/science/explab)
+/area/station/science/circuits)
 "fUu" = (
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible{
 	dir = 4
@@ -11185,7 +11144,7 @@
 /obj/effect/mapping_helpers/airlock/access/all/science/general,
 /obj/machinery/door/firedoor,
 /turf/open/floor/plating,
-/area/station/science/lab)
+/area/station/science/explab)
 "fXd" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -11805,8 +11764,7 @@
 /area/station/medical/medbay/central)
 "gqk" = (
 /obj/machinery/power/apc/auto_name/directional/south{
-	areastring = "/area/station/cargo/warehouse";
-	name = "Cargo Warehouse APC"
+	areastring = "/area/station/cargo/warehouse"
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -12185,7 +12143,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/station/science/explab)
+/area/station/science/circuits)
 "gAO" = (
 /obj/machinery/computer/secure_data,
 /obj/machinery/light{
@@ -12428,7 +12386,7 @@
 	},
 /obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/plating,
-/area/station/science/lab)
+/area/station/science/explab)
 "gJG" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -12622,6 +12580,9 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
+"gOs" = (
+/turf/closed/wall/r_wall,
+/area/station/science/circuits)
 "gOw" = (
 /obj/machinery/light{
 	dir = 1
@@ -12682,7 +12643,7 @@
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/station/science/lab)
+/area/station/science/explab)
 "gPo" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -12747,10 +12708,7 @@
 /area/station/hallway/primary/aft)
 "gRM" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/power/apc/auto_name/directional/south{
-	areastring = "/area/station/science/xenobiology";
-	name = "Xenobiology APC"
-	},
+/obj/machinery/power/apc/auto_name/directional/south,
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
@@ -12791,8 +12749,7 @@
 /area/station/security/brig)
 "gSZ" = (
 /obj/machinery/power/apc/auto_name/directional/south{
-	areastring = "/area/station/medical/chemistry";
-	name = "Chemistry APC"
+	areastring = "/area/station/medical/chemistry"
 	},
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -12996,7 +12953,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/showroomfloor,
-/area/station/science/lab)
+/area/station/science/explab)
 "haE" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
@@ -13276,10 +13233,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/start/security_officer,
 /obj/structure/chair/stool/directional/north,
-/obj/machinery/power/apc/auto_name/directional/east{
-	areastring = "/area/station/security/lockers";
-	name = "Brig Locker Room APC"
-	},
+/obj/machinery/power/apc/auto_name/directional/east,
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/lockers)
@@ -13647,8 +13601,7 @@
 /area/station/construction/mining/aux_base)
 "hqw" = (
 /obj/machinery/power/apc/auto_name/directional/south{
-	areastring = "/area/station/science/lab";
-	name = "Research Lab APC"
+	areastring = "/area/station/science/explab"
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -14334,7 +14287,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/showroomfloor,
-/area/station/science/lab)
+/area/station/science/explab)
 "hLf" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -14485,8 +14438,7 @@
 /area/station/service/bar)
 "hQj" = (
 /obj/machinery/power/apc/auto_name/directional/south{
-	areastring = "/area/station/medical/psychology";
-	name = "Psychology APC"
+	areastring = "/area/station/medical/psychology"
 	},
 /obj/structure/cable,
 /obj/effect/spawner/random/trash/garbage,
@@ -14662,10 +14614,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "hUL" = (
-/obj/machinery/power/apc/auto_name/directional/west{
-	areastring = "/area/station/security/warden";
-	name = "Brig Control APC"
-	},
+/obj/machinery/power/apc/auto_name/directional/west,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
@@ -14748,7 +14697,7 @@
 	pixel_x = -7
 	},
 /turf/open/floor/iron/dark,
-/area/station/science/lab)
+/area/station/science/explab)
 "hVG" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -15748,10 +15697,7 @@
 /turf/open/floor/iron/showroomfloor,
 /area/station/engineering/break_room)
 "iqf" = (
-/obj/machinery/power/apc/auto_name/directional/north{
-	areastring = "/area/station/maintenance/starboard/fore";
-	name = "Starboard Bow Maintenance APC"
-	},
+/obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
 /obj/structure/closet/toolcloset,
 /turf/open/floor/plating,
@@ -16339,8 +16285,7 @@
 "iFq" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/west{
-	areastring = "/area/station/security/courtroom";
-	name = "Courtroom APC"
+	areastring = "/area/station/security/courtroom"
 	},
 /obj/effect/spawner/random/trash/garbage,
 /turf/open/floor/plating,
@@ -16579,8 +16524,7 @@
 /area/station/command/heads_quarters/qm)
 "iNC" = (
 /obj/machinery/power/apc/auto_name/directional/south{
-	areastring = "/area/station/service/kitchen";
-	name = "Kitchen APC"
+	areastring = "/area/station/service/kitchen"
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 5
@@ -16790,9 +16734,7 @@
 /area/station/command/heads_quarters/cmo)
 "iTH" = (
 /obj/machinery/power/apc/auto_name/directional/south{
-	areastring = "/area/station/cargo/sorting";
-	name = "Delivery Office APC";
-	pixel_x = 1
+	areastring = "/area/station/cargo/sorting"
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -16994,7 +16936,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
-/area/station/science/explab)
+/area/station/science/circuits)
 "iZU" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
@@ -17134,10 +17076,7 @@
 /turf/open/floor/iron,
 /area/station/commons/vacant_room/commissary)
 "jdM" = (
-/obj/machinery/power/apc/auto_name/directional/north{
-	areastring = "/area/station/ai_monitored/command/nuke_storage";
-	name = "Vault APC"
-	},
+/obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
 /obj/effect/landmark/navigate_destination/vault,
 /turf/open/floor/circuit,
@@ -17425,10 +17364,7 @@
 /area/station/maintenance/starboard/fore)
 "joV" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/power/apc/auto_name/directional/south{
-	areastring = "/area/station/commons/locker";
-	name = "Fitness Room APC"
-	},
+/obj/machinery/power/apc/auto_name/directional/south,
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/commons/locker)
@@ -17503,10 +17439,7 @@
 /turf/open/floor/plating,
 /area/station/hallway/secondary/exit)
 "jrQ" = (
-/obj/machinery/power/apc/auto_name/directional/west{
-	areastring = "/area/station/hallway/secondary/service";
-	name = "Service Hall APC"
-	},
+/obj/machinery/power/apc/auto_name/directional/west,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/camera/directional/south{
 	c_tag = "Service Closet";
@@ -17623,7 +17556,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
-/area/station/science/lab)
+/area/station/science/explab)
 "jvC" = (
 /obj/machinery/bluespace_vendor/directional/south,
 /turf/open/floor/iron,
@@ -17727,7 +17660,7 @@
 	},
 /obj/structure/flora/grass/brown,
 /turf/open/floor/grass,
-/area/station/science/lab)
+/area/station/science/explab)
 "jwY" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 8
@@ -18404,7 +18337,7 @@
 /obj/structure/flora/grass/brown,
 /obj/structure/flora/bush/flowers_pp/style_random,
 /turf/open/floor/grass,
-/area/station/science/lab)
+/area/station/science/explab)
 "jPi" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/crate/freezer/blood,
@@ -18840,8 +18773,7 @@
 /area/station/medical/virology)
 "kbk" = (
 /obj/machinery/power/apc/auto_name/directional/east{
-	areastring = "/area/station/commons/toilet/locker";
-	name = "Dormitory Bathrooms APC"
+	areastring = "/area/station/commons/toilet/locker"
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -19268,7 +19200,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
-/area/station/science/lab)
+/area/station/science/explab)
 "kmA" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -19554,10 +19486,7 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/power/apc/auto_name/directional/west{
-	areastring = "/area/station/hallway/primary/port";
-	name = "Port Hallway APC"
-	},
+/obj/machinery/power/apc/auto_name/directional/west,
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
@@ -19627,7 +19556,7 @@
 	},
 /obj/effect/landmark/start/scientist,
 /turf/open/floor/iron/dark,
-/area/station/science/lab)
+/area/station/science/explab)
 "kwY" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -20207,12 +20136,9 @@
 /obj/item/controller,
 /obj/item/compact_remote,
 /obj/item/compact_remote,
-/obj/machinery/power/apc/auto_name/directional/south{
-	areastring = "/area/station/science/explab";
-	name = "Circuitry Lab APC"
-	},
+/obj/machinery/power/apc/auto_name/directional/south,
 /turf/open/floor/iron/dark,
-/area/station/science/explab)
+/area/station/science/circuits)
 "kLs" = (
 /obj/structure/table,
 /obj/item/assembly/igniter{
@@ -20650,10 +20576,7 @@
 /turf/open/floor/iron/showroomfloor,
 /area/station/commons/toilet/locker)
 "kZR" = (
-/obj/machinery/power/apc/auto_name/directional/north{
-	areastring = "/area/station/ai_monitored/command/storage/eva";
-	name = "EVA Storage APC"
-	},
+/obj/machinery/power/apc/auto_name/directional/north,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /obj/item/clothing/head/welding{
@@ -20833,7 +20756,7 @@
 	desc = "AnimeTitty"
 	},
 /turf/open/floor/iron/showroomfloor,
-/area/station/science/lab)
+/area/station/science/explab)
 "let" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -21407,10 +21330,7 @@
 	pixel_y = 1
 	},
 /obj/item/storage/medkit/regular,
-/obj/machinery/power/apc/auto_name/directional/east{
-	areastring = "/area/station/medical/storage";
-	name = "Medbay Storage APC"
-	},
+/obj/machinery/power/apc/auto_name/directional/east,
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/medical/storage)
@@ -23010,7 +22930,7 @@
 "mpi" = (
 /obj/machinery/rnd/experimentor,
 /turf/open/floor/iron/dark,
-/area/station/science/lab)
+/area/station/science/explab)
 "mpx" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/window/reinforced/plasma{
@@ -23577,8 +23497,7 @@
 	dir = 6
 	},
 /obj/machinery/power/apc/auto_name/directional/west{
-	areastring = "/area/station/hallway/secondary/exit";
-	name = "Escape Hallway APC"
+	areastring = "/area/station/hallway/secondary/exit"
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -23907,8 +23826,7 @@
 /area/station/medical/virology)
 "mOA" = (
 /obj/machinery/power/apc/auto_name/directional/west{
-	areastring = "/area/station/commons/storage/primary";
-	name = "Tool Storage APC"
+	areastring = "/area/station/commons/storage/primary"
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -23953,7 +23871,7 @@
 	pixel_x = -8
 	},
 /turf/open/floor/iron/dark,
-/area/station/science/explab)
+/area/station/science/circuits)
 "mPx" = (
 /obj/structure/table,
 /obj/item/paper/pamphlet/gateway{
@@ -23994,6 +23912,9 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/cmo)
+"mQN" = (
+/turf/closed/wall,
+/area/station/science/circuits)
 "mQR" = (
 /obj/machinery/shower/directional/north,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -24533,10 +24454,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/brown,
-/obj/machinery/power/apc/auto_name/directional/east{
-	areastring = "/area/station/cargo/office";
-	name = "Cargo Office APC"
-	},
+/obj/machinery/power/apc/auto_name/directional/east,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /obj/effect/landmark/navigate_destination/cargo,
@@ -24572,7 +24490,7 @@
 	network = list("ss13","rd")
 	},
 /turf/open/floor/iron/dark,
-/area/station/science/lab)
+/area/station/science/explab)
 "neu" = (
 /obj/machinery/light{
 	dir = 8
@@ -25266,7 +25184,7 @@
 	},
 /obj/structure/sign/departments/maint/alt/directional/north,
 /turf/open/floor/iron/dark,
-/area/station/science/lab)
+/area/station/science/explab)
 "nvU" = (
 /obj/structure/closet/crate/freezer/blood,
 /obj/machinery/light{
@@ -25419,7 +25337,7 @@
 	},
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron/showroomfloor,
-/area/station/science/lab)
+/area/station/science/explab)
 "nzM" = (
 /obj/machinery/door/airlock/medical/glass{
 	name = "Medbay Storage"
@@ -25434,10 +25352,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/machinery/power/apc/auto_name/directional/west{
-	areastring = "/area/station/command/teleporter";
-	name = "Teleporter APC"
-	},
+/obj/machinery/power/apc/auto_name/directional/west,
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/command/teleporter)
@@ -25452,7 +25367,7 @@
 	pixel_x = 24
 	},
 /turf/open/floor/iron/dark,
-/area/station/science/explab)
+/area/station/science/circuits)
 "nAz" = (
 /obj/structure/cable,
 /obj/effect/mapping_helpers/broken_floor,
@@ -25547,10 +25462,7 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
-/obj/machinery/power/apc/auto_name/directional/north{
-	areastring = "/area/station/command/heads_quarters/cmo";
-	name = "CM Office APC"
-	},
+/obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/table/glass,
 /obj/machinery/computer/security/telescreen/cmo{
 	dir = 4
@@ -25604,6 +25516,9 @@
 /obj/effect/spawner/random/trash/garbage,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/service)
+"nEs" = (
+/turf/open/floor/iron/dark,
+/area/station/science/circuits)
 "nEz" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -25611,10 +25526,7 @@
 	dir = 6
 	},
 /obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/west{
-	areastring = "/area/station/science/robotics/lab";
-	name = "Robotics Lab APC"
-	},
+/obj/machinery/power/apc/auto_name/directional/west,
 /turf/open/floor/iron/showroomfloor,
 /area/station/science/robotics/lab)
 "nEA" = (
@@ -25925,8 +25837,7 @@
 /area/station/hallway/primary/fore)
 "nKv" = (
 /obj/machinery/power/apc/auto_name/directional/east{
-	areastring = "/area/station/service/library";
-	name = "Library APC"
+	areastring = "/area/station/service/library"
 	},
 /obj/structure/cable,
 /obj/effect/spawner/random/trash/garbage,
@@ -26111,10 +26022,7 @@
 /turf/open/floor/iron,
 /area/station/engineering/storage/tech)
 "nQf" = (
-/obj/machinery/power/apc/auto_name/directional/north{
-	areastring = "/area/station/engineering/storage/tech";
-	name = "Tech Storage APC"
-	},
+/obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
 /obj/structure/rack,
 /obj/effect/spawner/random/techstorage/tcomms_all,
@@ -26312,7 +26220,7 @@
 /obj/item/folder,
 /obj/item/relic,
 /turf/open/floor/iron/dark,
-/area/station/science/lab)
+/area/station/science/explab)
 "nUM" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -26540,10 +26448,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/blue,
-/obj/machinery/power/apc/auto_name/directional/south{
-	areastring = "/area/station/medical/medbay/central";
-	name = "Medbay APC"
-	},
+/obj/machinery/power/apc/auto_name/directional/south,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
@@ -27569,7 +27474,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/item/stack/sheet/glass/fifty,
 /turf/open/floor/iron/showroomfloor,
-/area/station/science/lab)
+/area/station/science/explab)
 "oAt" = (
 /obj/machinery/holopad,
 /obj/effect/decal/cleanable/dirt,
@@ -27594,7 +27499,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/start/scientist,
 /turf/open/floor/iron/dark,
-/area/station/science/lab)
+/area/station/science/explab)
 "oAR" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/corner{
@@ -28182,10 +28087,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/power/apc/auto_name/directional/south{
-	areastring = "/area/station/hallway/primary/starboard";
-	name = "Starboard Primary Hallway APC"
-	},
+/obj/machinery/power/apc/auto_name/directional/south,
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
@@ -28698,10 +28600,7 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "pcm" = (
-/obj/machinery/power/apc/auto_name/directional/north{
-	areastring = "/area/station/command/heads_quarters/captain";
-	name = "Captain's Office APC"
-	},
+/obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
 /obj/structure/bed,
 /obj/item/disk/nuclear,
@@ -29032,7 +28931,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
-/area/station/science/explab)
+/area/station/science/circuits)
 "pqk" = (
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "robotics";
@@ -29099,10 +28998,7 @@
 /turf/open/floor/iron/white,
 /area/station/medical/exam_room)
 "prz" = (
-/obj/machinery/power/apc/auto_name/directional/east{
-	areastring = "/area/station/maintenance/starboard/central";
-	name = "Starboard Central Maintenance APC"
-	},
+/obj/machinery/power/apc/auto_name/directional/east,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/central)
@@ -29182,7 +29078,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/dark,
-/area/station/science/lab)
+/area/station/science/explab)
 "ptc" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -29292,10 +29188,7 @@
 /area/station/hallway/primary/starboard)
 "pvG" = (
 /obj/machinery/light,
-/obj/machinery/power/apc/auto_name/directional/south{
-	areastring = "/area/station/command/heads_quarters/hop";
-	name = "Head of Personnel APC"
-	},
+/obj/machinery/power/apc/auto_name/directional/south,
 /obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hop)
@@ -29609,7 +29502,7 @@
 	req_access = list("science")
 	},
 /turf/open/floor/plating,
-/area/station/science/lab)
+/area/station/science/explab)
 "pBU" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -29998,8 +29891,7 @@
 /area/station/maintenance/port/aft)
 "pPf" = (
 /obj/machinery/power/apc/auto_name/directional/east{
-	areastring = "/area/station/science/robotics/mechbay";
-	name = "Mech Bay APC"
+	areastring = "/area/station/science/robotics/mechbay"
 	},
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
@@ -30213,7 +30105,7 @@
 /obj/item/stack/sheet/glass/fifty,
 /obj/item/pen,
 /turf/open/floor/iron/showroomfloor,
-/area/station/science/lab)
+/area/station/science/explab)
 "pTY" = (
 /obj/structure/window{
 	dir = 4
@@ -30721,10 +30613,7 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "qha" = (
-/obj/machinery/power/apc/auto_name/directional/west{
-	areastring = "/area/station/tcommsat/server";
-	name = "Telecomms Server Room APC"
-	},
+/obj/machinery/power/apc/auto_name/directional/west,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
@@ -32280,10 +32169,7 @@
 	pixel_y = 8
 	},
 /obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/south{
-	areastring = "/area/station/medical/pharmacy";
-	name = "Pharmacy APC"
-	},
+/obj/machinery/power/apc/auto_name/directional/south,
 /turf/open/floor/iron/showroomfloor,
 /area/station/medical/pharmacy)
 "qVJ" = (
@@ -32371,10 +32257,7 @@
 /turf/open/floor/iron/showroomfloor,
 /area/station/medical/chemistry)
 "qWA" = (
-/obj/machinery/power/apc/auto_name/directional/south{
-	areastring = "/area/station/hallway/primary/central";
-	name = "Central Hall APC"
-	},
+/obj/machinery/power/apc/auto_name/directional/south,
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
@@ -32711,10 +32594,7 @@
 /area/station/service/theater)
 "rcY" = (
 /obj/structure/chair,
-/obj/machinery/power/apc/auto_name/directional/west{
-	areastring = "/area/station/service/lawoffice";
-	name = "Law Office APC"
-	},
+/obj/machinery/power/apc/auto_name/directional/west,
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/service/lawoffice)
@@ -33045,8 +32925,7 @@
 /area/station/hallway/primary/starboard)
 "roA" = (
 /obj/machinery/power/apc/auto_name/directional/north{
-	areastring = "/area/station/medical/cryo";
-	name = "Sleeper Room APC"
+	areastring = "/area/station/medical/exam_room"
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
@@ -33224,10 +33103,7 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "rsr" = (
-/obj/machinery/power/apc/auto_name/directional/west{
-	areastring = "/area/station/command/heads_quarters/qm";
-	name = "Quartermaster APC"
-	},
+/obj/machinery/power/apc/auto_name/directional/west,
 /obj/item/banner/cargo,
 /obj/structure/cable,
 /turf/open/floor/iron/showroomfloor,
@@ -33448,11 +33324,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/central/lesser)
 "rym" = (
-/obj/machinery/power/apc/auto_name/directional/west{
-	areastring = "/area/station/maintenance/port";
-	name = "Port Maintenance APC";
-	pixel_y = 2
-	},
+/obj/machinery/power/apc/auto_name/directional/west,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port)
@@ -33549,9 +33421,7 @@
 /area/station/service/theater)
 "rAw" = (
 /obj/machinery/power/apc/auto_name/directional/west{
-	areastring = "/area/station/command/gateway";
-	name = "Gateway APC";
-	pixel_y = -1
+	areastring = "/area/station/command/gateway"
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -33561,7 +33431,7 @@
 /obj/item/integrated_circuit/loaded/speech_relay,
 /obj/item/integrated_circuit/loaded/hello_world,
 /turf/open/floor/iron/dark,
-/area/station/science/explab)
+/area/station/science/circuits)
 "rBt" = (
 /obj/structure/table,
 /obj/effect/spawner/random/techstorage/service_all,
@@ -33898,7 +33768,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/showroomfloor,
-/area/station/science/lab)
+/area/station/science/explab)
 "rJT" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -34052,7 +33922,7 @@
 /obj/effect/turf_decal/tile/purple,
 /obj/item/paper/crumpled,
 /turf/open/floor/iron/dark,
-/area/station/science/lab)
+/area/station/science/explab)
 "rOv" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -34621,10 +34491,7 @@
 	},
 /area/station/service/theater)
 "sdP" = (
-/obj/machinery/power/apc/auto_name/directional/west{
-	areastring = "/area/station/command/heads_quarters/hos";
-	name = "Head of Security's Office APC"
-	},
+/obj/machinery/power/apc/auto_name/directional/west,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
 /turf/open/floor/carpet/red,
@@ -34692,7 +34559,7 @@
 	dir = 6
 	},
 /turf/open/floor/iron,
-/area/station/science/explab)
+/area/station/science/circuits)
 "sfF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/sign/departments/maint/alt/directional/west,
@@ -34898,9 +34765,7 @@
 /area/station/maintenance/port/aft)
 "slW" = (
 /obj/machinery/power/apc/auto_name/directional/north{
-	areastring = "/area/station/cargo/storage";
-	name = "Cargo Bay APC";
-	pixel_x = 1
+	areastring = "/area/station/cargo/storage"
 	},
 /obj/structure/cable,
 /obj/structure/closet/crate,
@@ -34973,10 +34838,7 @@
 "spJ" = (
 /obj/structure/table/glass,
 /obj/item/clothing/mask/gas/monkeymask,
-/obj/machinery/power/apc/auto_name/directional/west{
-	areastring = "/area/station/science/genetics";
-	name = "Genetics Lab APC"
-	},
+/obj/machinery/power/apc/auto_name/directional/west,
 /obj/item/storage/box/monkeycubes,
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 5;
@@ -35790,8 +35652,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/power/apc/auto_name/directional/west{
-	areastring = "/area/station/commons/vacant_room/office";
-	name = "Vacant Office APC"
+	areastring = "/area/station/commons/vacant_room/office"
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -36379,7 +36240,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/station/science/lab)
+/area/station/science/explab)
 "tfR" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -36480,7 +36341,7 @@
 	pixel_y = 30
 	},
 /turf/open/floor/iron/dark,
-/area/station/science/lab)
+/area/station/science/explab)
 "thU" = (
 /turf/open/floor/carpet/blue,
 /area/station/service/lawoffice)
@@ -36691,7 +36552,7 @@
 	},
 /obj/structure/sign/departments/maint/alt/directional/west,
 /turf/open/floor/iron/dark,
-/area/station/science/lab)
+/area/station/science/explab)
 "tnT" = (
 /obj/effect/decal/cleanable/food/egg_smudge,
 /turf/open/floor/iron/cafeteria,
@@ -36795,8 +36656,7 @@
 /area/station/cargo/miningdock)
 "tqr" = (
 /obj/machinery/power/apc/auto_name/directional/south{
-	areastring = "/area/station/service/chapel/office";
-	name = "Chapel Office APC"
+	areastring = "/area/station/service/chapel/office"
 	},
 /obj/structure/cable,
 /obj/effect/spawner/random/trash/garbage,
@@ -36805,8 +36665,7 @@
 /area/station/maintenance/starboard/aft)
 "tqt" = (
 /obj/machinery/power/apc/auto_name/directional/west{
-	areastring = "/area/station/service/theater";
-	name = "Theatre APC"
+	areastring = "/area/station/service/theater"
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 6
@@ -36845,10 +36704,7 @@
 	pixel_y = 4
 	},
 /obj/item/pen,
-/obj/machinery/power/apc/auto_name/directional/north{
-	areastring = "/area/station/security/brig";
-	name = "Brig APC"
-	},
+/obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/brig)
@@ -37820,7 +37676,7 @@
 	network = list("ss13","rd")
 	},
 /turf/open/floor/iron/dark,
-/area/station/science/lab)
+/area/station/science/explab)
 "tOz" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -37860,7 +37716,7 @@
 "tPh" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
-/area/station/science/lab)
+/area/station/science/explab)
 "tPx" = (
 /obj/structure/window/reinforced,
 /obj/structure/window{
@@ -37896,7 +37752,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/dark,
-/area/station/science/lab)
+/area/station/science/explab)
 "tQG" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -38083,7 +37939,7 @@
 "tVZ" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/showroomfloor,
-/area/station/science/lab)
+/area/station/science/explab)
 "tWz" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
@@ -38384,10 +38240,7 @@
 /turf/open/floor/carpet/royalblue,
 /area/station/command/heads_quarters/captain)
 "ubU" = (
-/obj/machinery/power/apc/auto_name/directional/west{
-	areastring = "/area/station/tcommsat/computer";
-	name = "Telecomms Monitoring APC"
-	},
+/obj/machinery/power/apc/auto_name/directional/west,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /turf/open/floor/iron/showroomfloor,
@@ -38683,7 +38536,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/station/science/lab)
+/area/station/science/explab)
 "uha" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/airlock/medical{
@@ -38707,7 +38560,7 @@
 /obj/effect/turf_decal/caution/red,
 /obj/item/paper/crumpled,
 /turf/open/floor/plating,
-/area/station/science/lab)
+/area/station/science/explab)
 "uhP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 6
@@ -38747,7 +38600,7 @@
 /obj/effect/turf_decal/caution/red,
 /obj/effect/decal/cleanable/oil,
 /turf/open/floor/plating,
-/area/station/science/lab)
+/area/station/science/explab)
 "uiy" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -38757,7 +38610,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
-/area/station/science/lab)
+/area/station/science/explab)
 "uiL" = (
 /obj/structure/chair/office{
 	dir = 8
@@ -38774,7 +38627,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/station/science/lab)
+/area/station/science/explab)
 "ujP" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/firedoor,
@@ -38930,10 +38783,7 @@
 /turf/open/floor/iron,
 /area/station/commons/locker)
 "unG" = (
-/obj/machinery/power/apc/auto_name/directional/east{
-	areastring = "/area/station/engineering/engine_smes";
-	name = "SMES room APC"
-	},
+/obj/machinery/power/apc/auto_name/directional/east,
 /obj/machinery/light{
 	dir = 4
 	},
@@ -39880,7 +39730,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/station/science/explab)
+/area/station/science/circuits)
 "uMO" = (
 /obj/structure/table,
 /obj/effect/spawner/random/trash/garbage,
@@ -39954,9 +39804,7 @@
 	network = list("ss13","rd")
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/power/apc/auto_name/directional/west{
-	name = "RD Office APC"
-	},
+/obj/machinery/power/apc/auto_name/directional/west,
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/rd)
@@ -40098,7 +39946,7 @@
 "uQZ" = (
 /obj/effect/decal/cleanable/greenglow,
 /turf/open/floor/plating,
-/area/station/science/lab)
+/area/station/science/explab)
 "uRg" = (
 /obj/structure/chair{
 	dir = 1
@@ -40579,10 +40427,7 @@
 /turf/open/floor/iron,
 /area/station/science/ordnance)
 "vdQ" = (
-/obj/machinery/power/apc/auto_name/directional/south{
-	areastring = "/area/station/science/server";
-	name = "Server Room APC"
-	},
+/obj/machinery/power/apc/auto_name/directional/south,
 /obj/machinery/light/small,
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
@@ -40866,9 +40711,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/rd)
-"vjw" = (
-/turf/open/floor/iron/dark,
-/area/station/science/lab)
 "vjQ" = (
 /obj/structure/bed,
 /obj/item/bedsheet/random,
@@ -40942,7 +40784,7 @@
 /obj/structure/table,
 /obj/item/book/manual/wiki/experimentor,
 /turf/open/floor/iron/dark,
-/area/station/science/lab)
+/area/station/science/explab)
 "vlS" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/layer_manifold/scrubbers,
@@ -40968,7 +40810,7 @@
 	req_access = list("research")
 	},
 /turf/open/floor/iron/dark,
-/area/station/science/lab)
+/area/station/science/explab)
 "vmW" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -41121,8 +40963,7 @@
 /area/station/command/heads_quarters/ce)
 "vrj" = (
 /obj/machinery/power/apc/auto_name/directional/north{
-	areastring = "/area/station/cargo/miningdock";
-	name = "Mining Dock APC"
+	areastring = "/area/station/cargo/miningdock"
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
@@ -41411,10 +41252,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/power/apc/auto_name/directional/north{
-	areastring = "/area/station/science/research";
-	name = "Research Division APC"
-	},
+/obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -42096,7 +41934,7 @@
 	pixel_y = 25
 	},
 /turf/open/floor/iron/dark,
-/area/station/science/lab)
+/area/station/science/explab)
 "vNn" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
@@ -42155,7 +41993,7 @@
 	dir = 10
 	},
 /turf/open/floor/iron/showroomfloor,
-/area/station/science/lab)
+/area/station/science/explab)
 "vPj" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 1
@@ -42246,7 +42084,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/showroomfloor,
-/area/station/science/lab)
+/area/station/science/explab)
 "vRb" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 9
@@ -42441,7 +42279,7 @@
 	},
 /obj/structure/closet/radiation,
 /turf/open/floor/plating,
-/area/station/science/lab)
+/area/station/science/explab)
 "vVu" = (
 /obj/item/paper,
 /turf/open/floor/iron,
@@ -42856,10 +42694,7 @@
 /area/station/science/xenobiology)
 "wga" = (
 /obj/structure/table/glass,
-/obj/machinery/power/apc/auto_name/directional/north{
-	areastring = "/area/station/medical/morgue";
-	name = "Morgue APC"
-	},
+/obj/machinery/power/apc/auto_name/directional/north,
 /obj/item/bodybag{
 	pixel_y = 5
 	},
@@ -42947,10 +42782,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/central/lesser)
 "whf" = (
-/obj/machinery/power/apc/auto_name/directional/south{
-	areastring = "/area/station/maintenance/starboard/aft";
-	name = "Starboard Quarter Maintenance APC"
-	},
+/obj/machinery/power/apc/auto_name/directional/south,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
@@ -43729,7 +43561,7 @@
 	},
 /obj/effect/landmark/start/scientist,
 /turf/open/floor/iron/dark,
-/area/station/science/lab)
+/area/station/science/explab)
 "wAM" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
@@ -44502,10 +44334,7 @@
 /turf/open/floor/iron/solarpanel/airless,
 /area/station/solars/port/fore)
 "wPO" = (
-/obj/machinery/power/apc/auto_name/directional/north{
-	areastring = "/area/station/medical/surgery";
-	name = "Surgery APC"
-	},
+/obj/machinery/power/apc/auto_name/directional/north,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 10
 	},
@@ -44627,7 +44456,7 @@
 /obj/item/paper/crumpled,
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
-/area/station/science/explab)
+/area/station/science/circuits)
 "wUh" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -44639,7 +44468,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
-/area/station/science/explab)
+/area/station/science/circuits)
 "wUs" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -44661,14 +44490,11 @@
 "wUB" = (
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark,
-/area/station/science/explab)
+/area/station/science/circuits)
 "wVj" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/command/heads_quarters/hos)
-"wVA" = (
-/turf/closed/wall,
-/area/station/science/explab)
 "wVF" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -44980,7 +44806,7 @@
 "xec" = (
 /obj/machinery/component_printer,
 /turf/open/floor/iron/dark,
-/area/station/science/explab)
+/area/station/science/circuits)
 "xef" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 8
@@ -45555,10 +45381,7 @@
 "xpV" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/secure_closet/medical2,
-/obj/machinery/power/apc/auto_name/directional/south{
-	areastring = "/area/station/medical/surgery/aft";
-	name = "Surgery Aft APC"
-	},
+/obj/machinery/power/apc/auto_name/directional/south,
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -45669,11 +45492,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 6
 	},
-/obj/machinery/power/apc/auto_name/directional/west{
-	areastring = "/area/station/maintenance/port/aft";
-	name = "Port Quarter Maintenance APC";
-	pixel_y = 1
-	},
+/obj/machinery/power/apc/auto_name/directional/west,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
@@ -45771,7 +45590,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/station/science/explab)
+/area/station/science/circuits)
 "xuK" = (
 /turf/closed/wall/r_wall,
 /area/station/ai_monitored/command/storage/eva)
@@ -46727,8 +46546,7 @@
 /area/station/maintenance/port/aft)
 "xPj" = (
 /obj/machinery/power/apc/auto_name/directional/north{
-	areastring = "/area/station/service/hydroponics";
-	name = "Hydroponics APC"
+	areastring = "/area/station/service/hydroponics"
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -47215,7 +47033,7 @@
 "ycg" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
-/area/station/science/explab)
+/area/station/science/circuits)
 "ycj" = (
 /obj/structure/sign/directions/engineering{
 	pixel_y = -10
@@ -47324,7 +47142,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/station/science/explab)
+/area/station/science/circuits)
 "yef" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/holopad,
@@ -47332,7 +47150,7 @@
 /obj/effect/landmark/event_spawn,
 /obj/effect/landmark/start/scientist,
 /turf/open/floor/iron,
-/area/station/science/explab)
+/area/station/science/circuits)
 "yek" = (
 /turf/closed/wall/r_wall,
 /area/station/tcommsat/computer)
@@ -47405,7 +47223,7 @@
 /area/station/engineering/supermatter/room)
 "yfO" = (
 /turf/closed/wall/r_wall,
-/area/station/science/lab)
+/area/station/science/explab)
 "yfQ" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 8
@@ -71996,12 +71814,12 @@ viz
 vJy
 gMx
 fIH
-wVA
-wVA
+mQN
+mQN
 ycg
 ycg
-wVA
-lTA
+mQN
+mQN
 kdS
 wKg
 kvx
@@ -72254,11 +72072,11 @@ yka
 rOO
 wFP
 wUB
-ydq
+nEs
 xec
-ydq
+nEs
 aNl
-kvx
+gOs
 aoH
 tuy
 kvx
@@ -72515,7 +72333,7 @@ iZG
 uMM
 ydX
 rAT
-kvx
+gOs
 jKY
 fxq
 kvx
@@ -72772,7 +72590,7 @@ xuG
 yef
 gAL
 kKY
-kvx
+gOs
 ycC
 fxq
 kvx
@@ -73029,7 +72847,7 @@ ppJ
 ekM
 sfu
 mPw
-kvx
+gOs
 pzf
 fxq
 kvx
@@ -73286,7 +73104,7 @@ fRL
 fTQ
 nAs
 ejv
-kvx
+gOs
 eQT
 fxq
 lTA
@@ -73538,12 +73356,12 @@ qHl
 vPl
 eUp
 uuZ
-wVA
-wVA
-wVA
-wVA
-wVA
-lTA
+mQN
+mQN
+mQN
+mQN
+mQN
+mQN
 kvx
 iam
 pOy
@@ -74047,7 +73865,7 @@ swk
 tnK
 tOt
 ugT
-vjw
+ydq
 eGW
 yfO
 srf
@@ -74559,7 +74377,7 @@ cgK
 wqn
 fDm
 thE
-vjw
+ydq
 uiu
 uQZ
 vlO

--- a/_maps/map_files/IceCubeStation/IceCube.dmm
+++ b/_maps/map_files/IceCubeStation/IceCube.dmm
@@ -1163,8 +1163,7 @@
 /area/mine/laborcamp)
 "avz" = (
 /obj/machinery/power/apc/auto_name/directional/north{
-	areastring = "/area/station/science/explab";
-	name = "Circuitry Lab APC"
+	areastring = "/area/station/science/circuits"
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -1360,8 +1359,7 @@
 	dir = 9
 	},
 /obj/machinery/power/apc/auto_name/directional/east{
-	areastring = "/area/station/science";
-	name = "Research Division APC"
+	areastring = "/area/station/science"
 	},
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
@@ -2259,7 +2257,7 @@
 	dir = 9
 	},
 /turf/open/floor/iron/dark,
-/area/station/science/explab)
+/area/station/science/circuits)
 "aPS" = (
 /obj/structure/railing/corner{
 	dir = 8
@@ -3654,7 +3652,7 @@
 /area/station/security/prison/visit)
 "boe" = (
 /turf/open/floor/circuit,
-/area/station/science/explab)
+/area/station/science/circuits)
 "bom" = (
 /turf/closed/wall,
 /area/station/security/prison/work)
@@ -3963,9 +3961,7 @@
 /area/mine/laborcamp/security)
 "bya" = (
 /obj/machinery/power/apc/auto_name/directional/east{
-	areastring = "/area/station/service/hydroponics/garden";
-	name = "Garden APC";
-	pixel_y = 2
+	areastring = "/area/station/service/hydroponics/garden"
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -4981,8 +4977,7 @@
 /area/station/maintenance/port/fore)
 "bVC" = (
 /obj/machinery/power/apc/auto_name/directional/north{
-	areastring = "/area/station/security/processing";
-	name = "Labor Processing APC"
+	areastring = "/area/station/security/processing"
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -5408,8 +5403,7 @@
 /area/station/maintenance/port/central)
 "cgq" = (
 /obj/machinery/power/apc/auto_name/directional/north{
-	areastring = "/area/mine/laborcamp";
-	name = "Labor Camp APC"
+	areastring = "/area/mine/laborcamp"
 	},
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/red/filled/line{
@@ -5769,7 +5763,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
-/area/station/science/explab)
+/area/station/science/circuits)
 "cqu" = (
 /obj/structure/table/reinforced/rglass,
 /obj/item/tank/jetpack/carbondioxide{
@@ -6462,8 +6456,7 @@
 "cHr" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/west{
-	areastring = "/area/station/cargo/warehouse";
-	name = "Cargo Warehouse APC"
+	areastring = "/area/station/cargo/warehouse"
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/central)
@@ -6584,7 +6577,7 @@
 	},
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron/dark,
-/area/station/science/explab)
+/area/station/science/circuits)
 "cKk" = (
 /obj/machinery/conveyor{
 	dir = 4;
@@ -7489,7 +7482,7 @@
 "ddI" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/dark,
-/area/station/science/explab)
+/area/station/science/circuits)
 "ddK" = (
 /obj/structure/table,
 /obj/item/storage/backpack/duffelbag/med/surgery,
@@ -7702,8 +7695,7 @@
 /area/station/maintenance/port/fore)
 "djf" = (
 /obj/machinery/power/apc/auto_name/directional/south{
-	areastring = "/area/station/service/chapel";
-	name = "Chapel APC"
+	areastring = "/area/station/service/chapel"
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -7975,8 +7967,7 @@
 	dir = 10
 	},
 /obj/machinery/power/apc/auto_name/directional/west{
-	areastring = "/area/station/medical/pharmacy";
-	name = "Pharmacy APC"
+	areastring = "/area/station/medical/pharmacy"
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -8272,8 +8263,7 @@
 /area/station/hallway/secondary/entry)
 "dvR" = (
 /obj/machinery/power/apc/auto_name/directional/west{
-	areastring = "/area/station/commons/fitness";
-	name = "Fitness Room APC"
+	areastring = "/area/station/commons/fitness"
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -8563,8 +8553,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/power/apc/auto_name/directional/south{
-	areastring = "/area/station/service/theater";
-	name = "Theatre APC"
+	areastring = "/area/station/service/theater"
 	},
 /obj/effect/gibspawner/confetti,
 /turf/open/floor/plating,
@@ -9009,8 +8998,7 @@
 /area/station/engineering/break_room)
 "dNG" = (
 /obj/machinery/power/apc/auto_name/directional/north{
-	areastring = "/area/station/commons/storage/primary";
-	name = "Primary Tool Storage APC"
+	areastring = "/area/station/commons/storage/primary"
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -9343,8 +9331,7 @@
 /area/station/hallway/primary/starboard)
 "dSd" = (
 /obj/machinery/power/apc/auto_name/directional/west{
-	areastring = "/area/station/commons/toilet";
-	name = "Dormitory Bathrooms APC"
+	areastring = "/area/station/commons/toilet"
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -9577,8 +9564,7 @@
 /area/station/command/heads_quarters/captain/private)
 "dWR" = (
 /obj/machinery/power/apc/auto_name/directional/south{
-	areastring = "/area/station/service/chapel/office";
-	name = "Chapel Office APC"
+	areastring = "/area/station/service/chapel/office"
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -9712,8 +9698,7 @@
 /area/station/security/office)
 "dZE" = (
 /obj/machinery/power/apc/auto_name/directional/east{
-	areastring = "/area/station/cargo/storage";
-	name = "Cargo Bay APC"
+	areastring = "/area/station/cargo/storage"
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -10370,7 +10355,7 @@
 "eow" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
-/area/station/science/explab)
+/area/station/science/circuits)
 "eoB" = (
 /turf/open/floor/iron,
 /area/station/security)
@@ -10990,7 +10975,7 @@
 /area/station/service/bar)
 "eCA" = (
 /turf/closed/wall,
-/area/station/science/explab)
+/area/station/science/circuits)
 "eCM" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -12162,7 +12147,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
-/area/station/science/explab)
+/area/station/science/circuits)
 "fgW" = (
 /obj/structure/closet/wardrobe,
 /turf/open/floor/iron/dark,
@@ -12444,8 +12429,7 @@
 /area/station/engineering/break_room)
 "fnW" = (
 /obj/machinery/power/apc/auto_name/directional/north{
-	areastring = "/area/station/commons/storage/art";
-	name = "Art Storage"
+	areastring = "/area/station/commons/storage/art"
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -14408,7 +14392,7 @@
 /obj/effect/mapping_helpers/airlock/access/all/science/general,
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark,
-/area/station/science/explab)
+/area/station/science/circuits)
 "ggh" = (
 /obj/effect/landmark/start/cargo_technician,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -15679,8 +15663,7 @@
 "gMq" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/south{
-	areastring = "/area/station/medical/psychology";
-	name = "Psychology APC"
+	areastring = "/area/station/medical/psychology"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -16967,7 +16950,7 @@
 	dir = 6
 	},
 /turf/open/floor/iron/dark,
-/area/station/science/explab)
+/area/station/science/circuits)
 "hqo" = (
 /obj/effect/turf_decal/trimline/white/filled/line,
 /obj/structure/chair/sofa/bench/right{
@@ -18751,8 +18734,7 @@
 /area/station/engineering/main)
 "iec" = (
 /obj/machinery/power/apc/auto_name/directional/east{
-	areastring = "/area/station/science/robotics/mechbay";
-	name = "Mech Bay APC"
+	areastring = "/area/station/science/robotics/mechbay"
 	},
 /obj/structure/cable,
 /obj/effect/mapping_helpers/broken_floor,
@@ -19319,7 +19301,7 @@
 /area/station/maintenance/starboard/fore)
 "ioU" = (
 /turf/open/floor/iron/dark,
-/area/station/science/explab)
+/area/station/science/circuits)
 "ipd" = (
 /obj/item/stack/cable_coil,
 /obj/effect/mapping_helpers/broken_floor,
@@ -22058,8 +22040,7 @@
 	dir = 6
 	},
 /obj/machinery/power/apc/auto_name/directional/east{
-	areastring = "/area/station/medical/medbay";
-	name = "Medbay Central APC"
+	areastring = "/area/station/medical/medbay"
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
@@ -22663,10 +22644,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/east{
-	areastring = "/area/station/tcommsat/computer";
-	name = "Telecomms Monitoring APC"
-	},
+/obj/machinery/power/apc/auto_name/directional/east,
 /turf/open/floor/iron,
 /area/station/tcommsat/computer)
 "jOM" = (
@@ -22734,10 +22712,7 @@
 /turf/open/floor/iron,
 /area/station/security/courtroom)
 "jQB" = (
-/obj/machinery/power/apc/auto_name/directional/north{
-	areastring = "/area/station/ai_monitored/command/nuke_storage";
-	name = "Vault APC"
-	},
+/obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/command/nuke_storage)
@@ -23926,9 +23901,7 @@
 /area/station/medical/morgue)
 "kqw" = (
 /obj/machinery/power/apc/auto_name/directional/west{
-	areastring = "/area/station/command/gateway";
-	name = "Gateway APC";
-	pixel_y = -1
+	areastring = "/area/station/command/gateway"
 	},
 /obj/structure/cable,
 /obj/effect/spawner/random/trash/grime,
@@ -23936,8 +23909,7 @@
 /area/station/maintenance/port/fore)
 "kqB" = (
 /obj/machinery/power/apc/auto_name/directional/east{
-	areastring = "/area/station/hallway/primary/port";
-	name = "Port Hall APC"
+	areastring = "/area/station/hallway/primary/port"
 	},
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
@@ -24334,8 +24306,7 @@
 	dir = 10
 	},
 /obj/machinery/power/apc/auto_name/directional/south{
-	areastring = "/area/station/medical/chemistry";
-	name = "Chemistry APC"
+	areastring = "/area/station/medical/chemistry"
 	},
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -24506,8 +24477,7 @@
 "kDq" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/south{
-	areastring = "/area/station/medical/paramedic";
-	name = "Paramedic APC"
+	areastring = "/area/station/medical/paramedic"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -26199,8 +26169,7 @@
 	dir = 9
 	},
 /obj/machinery/power/apc/auto_name/directional/west{
-	areastring = "/area/station/service/library";
-	name = "Library APC"
+	areastring = "/area/station/service/library"
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
@@ -26691,7 +26660,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/dark,
-/area/station/science/explab)
+/area/station/science/circuits)
 "lyG" = (
 /obj/machinery/iv_drip,
 /turf/open/floor/plating,
@@ -28414,8 +28383,7 @@
 "miS" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/north{
-	areastring = "/area/station/science/ordnance/storage";
-	name = "Ordnance Storage APC"
+	areastring = "/area/station/science/ordnance/storage"
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/xenobiology)
@@ -30307,8 +30275,7 @@
 	dir = 9
 	},
 /obj/machinery/power/apc/auto_name/directional/south{
-	areastring = "/area/station/science/genetics";
-	name = "Genetics Lab APC"
+	areastring = "/area/station/science/genetics"
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -30771,8 +30738,7 @@
 /obj/machinery/light/small/directional/east,
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/west{
-	areastring = "/area/station/hallway/primary/central";
-	name = "Central Hall APC"
+	areastring = "/area/station/hallway/primary/central"
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
@@ -31196,8 +31162,7 @@
 /area/station/maintenance/port/aft)
 "nrS" = (
 /obj/machinery/power/apc/auto_name/directional/north{
-	areastring = "/area/station/commons/storage/tools";
-	name = "Auxiliary Tool Storage APC"
+	areastring = "/area/station/commons/storage/tools"
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -31362,9 +31327,7 @@
 "nvg" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/west{
-	areastring = "/area/station/hallway/primary/aft";
-	name = "Aft Hall APC";
-	pixel_y = 1
+	areastring = "/area/station/hallway/primary/aft"
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
@@ -31417,7 +31380,7 @@
 	network = list("ss13","rd")
 	},
 /turf/open/floor/iron/dark,
-/area/station/science/explab)
+/area/station/science/circuits)
 "nws" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 10
@@ -31924,7 +31887,7 @@
 "nJy" = (
 /obj/item/radio/intercom/directional/west,
 /turf/open/floor/iron/dark,
-/area/station/science/explab)
+/area/station/science/circuits)
 "nJI" = (
 /obj/machinery/ntnet_relay,
 /turf/open/floor/circuit/telecomms/mainframe,
@@ -32021,7 +31984,6 @@
 /obj/structure/cable,
 /obj/machinery/power/apc/highcap/five_k{
 	areastring = "/area/station/engineering/atmos";
-	dir = 4;
 	name = "Atmospherics APC";
 	pixel_x = 25
 	},
@@ -32379,8 +32341,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/power/apc/auto_name/directional/south{
-	areastring = "/area/station/security/courtroom";
-	name = "Courtroom APC"
+	areastring = "/area/station/security/courtroom"
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
@@ -32789,8 +32750,7 @@
 	dir = 4
 	},
 /obj/machinery/power/apc/auto_name/directional/east{
-	areastring = "/area/station/security/checkpoint/auxiliary";
-	name = "Security Checkpoint APC"
+	areastring = "/area/station/security/checkpoint/auxiliary"
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/fore/upper)
@@ -33205,7 +33165,7 @@
 	dir = 9
 	},
 /turf/open/floor/iron/dark,
-/area/station/science/explab)
+/area/station/science/circuits)
 "ojh" = (
 /obj/structure/sign/departments/psychology/directional/west,
 /turf/open/floor/iron/white,
@@ -33355,8 +33315,7 @@
 /area/station/engineering/storage_shared)
 "olI" = (
 /obj/machinery/power/apc/auto_name/directional/north{
-	areastring = "/area/station/hallway/primary/fore";
-	name = "Fore Primary Hallway APC"
+	areastring = "/area/station/hallway/primary/fore"
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -33570,8 +33529,7 @@
 "oqh" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/east{
-	areastring = "/area/station/service/kitchen";
-	name = "Kitchen APC"
+	areastring = "/area/station/service/kitchen"
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/service)
@@ -33979,8 +33937,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/power/apc/auto_name/directional/east{
-	areastring = "/area/station/hallway/primary/starboard";
-	name = "Starboard Primary Hallway APC"
+	areastring = "/area/station/hallway/primary/starboard"
 	},
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
@@ -34893,8 +34850,7 @@
 /area/station/maintenance/starboard/fore)
 "oVZ" = (
 /obj/machinery/power/apc/auto_name/directional/west{
-	areastring = "/area/station/ai_monitored/command/storage/eva";
-	name = "EVA Storage APC"
+	areastring = "/area/station/ai_monitored/command/storage/eva"
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -35468,8 +35424,7 @@
 /area/station/engineering/main)
 "pjB" = (
 /obj/machinery/power/apc/auto_name/directional/north{
-	areastring = "/area/station/science/explab";
-	name = "Experimentation APC"
+	areastring = "/area/station/science/explab"
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -35626,8 +35581,7 @@
 /area/station/hallway/primary/central/aft)
 "pou" = (
 /obj/machinery/power/apc/auto_name/directional/west{
-	areastring = "/area/station/hallway/secondary/exit/departure_lounge";
-	name = "Escape Hallway APC"
+	areastring = "/area/station/hallway/secondary/exit/departure_lounge"
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -35688,8 +35642,7 @@
 /area/station/command/meeting_room)
 "pqa" = (
 /obj/machinery/power/apc/auto_name/directional/west{
-	areastring = "/area/station/hallway/secondary/entry";
-	name = "Entry Hall APC"
+	areastring = "/area/station/hallway/secondary/entry"
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -37920,8 +37873,7 @@
 "qpr" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/north{
-	areastring = "/area/station/service/hydroponics";
-	name = "Hydroponics APC"
+	areastring = "/area/station/service/hydroponics"
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
@@ -38180,7 +38132,7 @@
 "quY" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/circuit,
-/area/station/science/explab)
+/area/station/science/circuits)
 "qva" = (
 /obj/structure/closet/toolcloset,
 /obj/effect/spawner/random/exotic/antag_gear_weak,
@@ -38318,10 +38270,7 @@
 /turf/open/floor/iron,
 /area/station/science/breakroom)
 "qyO" = (
-/obj/machinery/power/apc/auto_name/directional/north{
-	areastring = "/area/station/engineering/storage/tech";
-	name = "Tech Storage APC"
-	},
+/obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
 /obj/structure/closet/crate/bin,
 /turf/open/floor/iron/checker,
@@ -41853,10 +41802,7 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/north{
-	areastring = "/area/station/engineering/break_room";
-	name = "Engineering Break Room APC"
-	},
+/obj/machinery/power/apc/auto_name/directional/north,
 /turf/open/floor/iron/cafeteria,
 /area/station/engineering/break_room)
 "rUx" = (
@@ -43040,10 +42986,6 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/purple/visible,
 /obj/machinery/meter,
-/obj/machinery/power/apc/auto_name/directional/south{
-	areastring = "/area/station/engineering/atmos";
-	name = "Atmospherics APC #2"
-	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "svq" = (
@@ -43081,8 +43023,7 @@
 /area/station/cargo/office)
 "swz" = (
 /obj/machinery/power/apc/auto_name/directional/west{
-	areastring = "/area/station/science/lab";
-	name = "Research Lab APC"
+	areastring = "/area/station/science/lab"
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -43525,8 +43466,7 @@
 /area/station/security/range)
 "sGM" = (
 /obj/machinery/power/apc/auto_name/directional/north{
-	areastring = "/area/station/service/lawoffice";
-	name = "Law Office APC"
+	areastring = "/area/station/service/lawoffice"
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -43557,8 +43497,7 @@
 /area/station/service/library/abandoned)
 "sHi" = (
 /obj/machinery/power/apc/auto_name/directional/west{
-	areastring = "/area/station/command/heads_quarters/hop";
-	name = "Head of Personnel APC"
+	areastring = "/area/station/command/heads_quarters/hop"
 	},
 /obj/structure/cable,
 /obj/effect/mapping_helpers/broken_floor,
@@ -43784,8 +43723,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/power/apc/auto_name/directional/south{
-	areastring = "/area/station/commons/vacant_room/commissary";
-	name = "Vacant Commissary APC"
+	areastring = "/area/station/commons/vacant_room/commissary"
 	},
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -43890,8 +43828,7 @@
 /area/station/engineering/storage_shared)
 "sPg" = (
 /obj/machinery/power/apc/auto_name/directional/east{
-	areastring = "/area/station/command/heads_quarters/qm";
-	name = "Quartermaster APC"
+	areastring = "/area/station/command/heads_quarters/qm"
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -45345,8 +45282,7 @@
 	dir = 4
 	},
 /obj/machinery/power/apc/auto_name/directional/south{
-	areastring = "/area/station/service/janitor";
-	name = "Custodial Closet APC"
+	areastring = "/area/station/service/janitor"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -46264,8 +46200,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/power/apc/auto_name/directional/west{
-	areastring = "/area/station/security/detectives_office";
-	name = "Detective's Office APC"
+	areastring = "/area/station/security/detectives_office"
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -46303,8 +46238,7 @@
 /area/station/tcommsat/server/upper)
 "tTD" = (
 /obj/machinery/power/apc/auto_name/directional/north{
-	areastring = "/area/station/science/robotics";
-	name = "Robotics Lab APC"
+	areastring = "/area/station/science/robotics"
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -47133,8 +47067,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/power/apc/auto_name/directional/south{
-	areastring = "/area/station/maintenance/disposal";
-	name = "Disposal APC"
+	areastring = "/area/station/maintenance/disposal"
 	},
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -47722,7 +47655,7 @@
 "uvq" = (
 /obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron/dark,
-/area/station/science/explab)
+/area/station/science/circuits)
 "uwg" = (
 /obj/structure/table,
 /obj/effect/spawner/random/trash/garbage,
@@ -48991,8 +48924,7 @@
 /area/station/maintenance/port/central)
 "uXB" = (
 /obj/machinery/power/apc/auto_name/directional/east{
-	areastring = "/area/station/commons/vacant_room/office";
-	name = "Vacant Office APC"
+	areastring = "/area/station/commons/vacant_room/office"
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -49829,8 +49761,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/power/apc/auto_name/directional/east{
-	areastring = "/area/station/cargo/office";
-	name = "Cargo Office APC"
+	areastring = "/area/station/cargo/office"
 	},
 /obj/structure/disposalpipe/junction/flip{
 	dir = 1
@@ -50463,8 +50394,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/power/apc/auto_name/directional/north{
-	areastring = "/area/station/commons/dorms";
-	name = "Dormitory APC"
+	areastring = "/area/station/commons/dorms"
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -51542,7 +51472,7 @@
 	pixel_y = 11
 	},
 /turf/open/floor/iron/dark,
-/area/station/science/explab)
+/area/station/science/circuits)
 "weS" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 9
@@ -51717,7 +51647,7 @@
 	pixel_y = 5
 	},
 /turf/open/floor/iron/dark,
-/area/station/science/explab)
+/area/station/science/circuits)
 "wiR" = (
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/plating,
@@ -51725,7 +51655,7 @@
 "wiS" = (
 /obj/machinery/component_printer,
 /turf/open/floor/iron/dark,
-/area/station/science/explab)
+/area/station/science/circuits)
 "wiV" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 4
@@ -51801,7 +51731,7 @@
 /obj/structure/table,
 /obj/item/controller,
 /turf/open/floor/iron/dark,
-/area/station/science/explab)
+/area/station/science/circuits)
 "wki" = (
 /obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron,
@@ -52067,7 +51997,7 @@
 "wpP" = (
 /obj/effect/landmark/start/scientist,
 /turf/open/floor/circuit,
-/area/station/science/explab)
+/area/station/science/circuits)
 "wqh" = (
 /obj/structure/sign/departments/science,
 /turf/closed/wall/r_wall,
@@ -52092,7 +52022,7 @@
 	anchored = 1
 	},
 /turf/open/floor/iron/dark,
-/area/station/science/explab)
+/area/station/science/circuits)
 "wqL" = (
 /obj/machinery/door/airlock/medical/glass{
 	id_tag = "MedbayFoyer";
@@ -52149,7 +52079,7 @@
 	},
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron/dark,
-/area/station/science/explab)
+/area/station/science/circuits)
 "wrl" = (
 /obj/structure/cable,
 /obj/structure/sign/poster/contraband/random{
@@ -52508,8 +52438,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/north{
-	areastring = "/area/station/service/hydroponics/upper";
-	name = "Upper Hydroponics APC"
+	areastring = "/area/station/service/hydroponics/upper"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -52560,7 +52489,7 @@
 	dir = 9
 	},
 /turf/open/floor/iron/dark,
-/area/station/science/explab)
+/area/station/science/circuits)
 "wBI" = (
 /obj/machinery/disposal/bin,
 /obj/effect/turf_decal/stripes/end,
@@ -52623,7 +52552,7 @@
 	dir = 9
 	},
 /turf/open/floor/iron/dark,
-/area/station/science/explab)
+/area/station/science/circuits)
 "wCB" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /obj/structure/window/reinforced{
@@ -52981,7 +52910,7 @@
 "wLa" = (
 /obj/effect/landmark/start/scientist,
 /turf/open/floor/iron/dark,
-/area/station/science/explab)
+/area/station/science/circuits)
 "wLp" = (
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/wood,
@@ -52991,10 +52920,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/solars/port)
 "wLs" = (
-/obj/machinery/power/apc/auto_name/directional/north{
-	areastring = "/area/station/medical/morgue";
-	name = "Morgue APC"
-	},
+/obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
@@ -53044,8 +52970,7 @@
 	dir = 6
 	},
 /obj/machinery/power/apc/auto_name/directional/west{
-	areastring = "/area/station/medical/exam_room";
-	name = "Treatment Center APC"
+	areastring = "/area/station/medical/exam_room"
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
@@ -53576,7 +53501,7 @@
 /obj/item/compact_remote,
 /obj/machinery/light/directional/west,
 /turf/open/floor/iron/dark,
-/area/station/science/explab)
+/area/station/science/circuits)
 "wZt" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -55279,7 +55204,7 @@
 	dir = 4
 	},
 /turf/open/floor/circuit,
-/area/station/science/explab)
+/area/station/science/circuits)
 "xKk" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 8
@@ -55290,8 +55215,7 @@
 "xKn" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/west{
-	areastring = "/area/station/cargo/sorting";
-	name = "Delivery Office APC"
+	areastring = "/area/station/cargo/sorting"
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/central)
@@ -56164,8 +56088,7 @@
 	dir = 4
 	},
 /obj/machinery/power/apc/auto_name/directional/west{
-	areastring = "/area/station/construction/mining/aux_base";
-	name = "Auxiliary Base Construction APC"
+	areastring = "/area/station/construction/mining/aux_base"
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/fore/upper)
@@ -56367,7 +56290,7 @@
 	},
 /obj/machinery/holopad,
 /turf/open/floor/iron/dark,
-/area/station/science/explab)
+/area/station/science/circuits)
 "yfc" = (
 /obj/machinery/suit_storage_unit/standard_unit,
 /obj/effect/turf_decal/stripes/line{
@@ -56672,7 +56595,7 @@
 /obj/machinery/cell_charger,
 /obj/item/stock_parts/cell/high,
 /turf/open/floor/iron/dark,
-/area/station/science/explab)
+/area/station/science/circuits)
 "yku" = (
 /obj/structure/table,
 /obj/machinery/camera/directional/east{

--- a/_maps/map_files/LimaStation/Lima.dmm
+++ b/_maps/map_files/LimaStation/Lima.dmm
@@ -1445,10 +1445,7 @@
 /obj/item/radio/off{
 	pixel_y = 6
 	},
-/obj/machinery/power/apc/auto_name/directional/south{
-	areastring = "/area/station/security/checkpoint/auxiliary";
-	name = "Security Checkpoint APC"
-	},
+/obj/machinery/power/apc/auto_name/directional/south,
 /obj/structure/cable,
 /obj/machinery/light_switch{
 	pixel_x = -10;
@@ -1548,10 +1545,7 @@
 /turf/open/floor/iron/showroomfloor,
 /area/station/science/lab)
 "amN" = (
-/obj/machinery/power/apc/auto_name/directional/west{
-	areastring = "/area/station/maintenance/solars/port/fore";
-	name = "Port Bow Solar APC"
-	},
+/obj/machinery/power/apc/auto_name/directional/west,
 /obj/machinery/camera/directional/south{
 	c_tag = "Fore Port Solar Control"
 	},
@@ -5322,10 +5316,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "bkU" = (
-/obj/machinery/power/apc/auto_name/directional/west{
-	areastring = "/area/station/hallway/primary/fore";
-	name = "Fore Primary Hallway APC"
-	},
+/obj/machinery/power/apc/auto_name/directional/west,
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
@@ -5849,10 +5840,7 @@
 /turf/open/floor/carpet/royalblue,
 /area/station/command/heads_quarters/captain)
 "bwR" = (
-/obj/machinery/power/apc/auto_name/directional/west{
-	areastring = "/area/station/maintenance/port";
-	name = "Port Maintenance APC"
-	},
+/obj/machinery/power/apc/auto_name/directional/west,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port)
@@ -10484,6 +10472,7 @@
 /obj/machinery/camera/directional/west{
 	c_tag = "Atmospherics North West"
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "dJV" = (
@@ -10754,6 +10743,11 @@
 /obj/machinery/camera/autoname/directional/west,
 /turf/open/floor/iron,
 /area/station/command/teleporter)
+"dRQ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/station/engineering/atmos)
 "dSi" = (
 /obj/structure/filingcabinet/chestdrawer,
 /obj/effect/turf_decal/tile/purple{
@@ -14633,6 +14627,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/bridge_pipe/dark/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
 "fIE" = (
@@ -15251,7 +15246,6 @@
 	dir = 4;
 	name = "Pure to Ports"
 	},
-/obj/machinery/atmospherics/pipe/bridge_pipe/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "gaV" = (
@@ -15737,8 +15731,7 @@
 /area/station/maintenance/starboard)
 "goC" = (
 /obj/machinery/power/apc/auto_name/directional/west{
-	areastring = "/area/station/commons/toilet";
-	name = "Dormitory Bathrooms APC"
+	areastring = "/area/station/commons/toilet"
 	},
 /obj/structure/cable,
 /obj/machinery/duct,
@@ -17053,6 +17046,7 @@
 "gYJ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible,
 /obj/machinery/light/directional/west,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
 "gYL" = (
@@ -18357,10 +18351,7 @@
 /turf/open/floor/iron/showroomfloor,
 /area/station/commons/toilet)
 "hGZ" = (
-/obj/machinery/power/apc/auto_name/directional/west{
-	areastring = "/area/station/maintenance/solars/starboard/aft";
-	name = "Starboard Quarter Solar APC"
-	},
+/obj/machinery/power/apc/auto_name/directional/west,
 /obj/machinery/light_switch{
 	pixel_x = -20;
 	pixel_y = 11
@@ -19438,8 +19429,7 @@
 /area/station/engineering/main)
 "ioD" = (
 /obj/machinery/power/apc/auto_name/directional/west{
-	areastring = "/area/station/medical/chemistry";
-	name = "Chemistry APC"
+	areastring = "/area/station/medical/chemistry"
 	},
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
@@ -20743,10 +20733,7 @@
 /area/station/security/brig)
 "jbw" = (
 /obj/machinery/food_cart,
-/obj/machinery/power/apc/auto_name/directional/east{
-	areastring = "/area/station/service/kitchen";
-	name = "Kitchen APC"
-	},
+/obj/machinery/power/apc/auto_name/directional/east,
 /obj/structure/cable,
 /turf/open/floor/iron/freezer,
 /area/station/service/kitchen)
@@ -20809,6 +20796,7 @@
 	dir = 4;
 	name = "Waste Release"
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
 "jcW" = (
@@ -20973,7 +20961,6 @@
 /obj/machinery/atmospherics/pipe/layer_manifold/orange/visible{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/bridge_pipe/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "jjC" = (
@@ -21335,7 +21322,6 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit)
 "jwu" = (
-/obj/machinery/power/apc/auto_name/directional/west,
 /obj/structure/cable,
 /obj/effect/spawner/random/maintenance/four,
 /obj/structure/closet/crate,
@@ -22092,9 +22078,7 @@
 /obj/structure/table,
 /obj/item/storage/fancy/donut_box,
 /obj/machinery/airalarm/directional/east,
-/obj/machinery/power/apc/auto_name/directional/north{
-	pixel_x = 3
-	},
+/obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 5
@@ -22295,6 +22279,7 @@
 "jTp" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/yellow/visible/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
 "jTE" = (
@@ -23515,8 +23500,7 @@
 "kCW" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/west{
-	areastring = "/area/station/medical/medbay/lobby";
-	name = "Medbay Lobby APC"
+	areastring = "/area/station/medical/medbay/lobby"
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
@@ -24517,6 +24501,7 @@
 "lgw" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible/layer4,
 /obj/machinery/light/directional/west,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
 "lgP" = (
@@ -24619,10 +24604,7 @@
 /turf/open/floor/iron,
 /area/station/service/hydroponics/garden)
 "ljS" = (
-/obj/machinery/power/apc/auto_name/directional/north{
-	areastring = "/area/station/hallway/primary/port";
-	name = "Port Hall APC"
-	},
+/obj/machinery/power/apc/auto_name/directional/north,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
@@ -24687,10 +24669,7 @@
 /turf/open/floor/iron/showroomfloor,
 /area/station/science/robotics/lab)
 "lli" = (
-/obj/machinery/power/apc/auto_name/directional/north{
-	areastring = "/area/station/security/brig";
-	name = "Brig APC"
-	},
+/obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
 /obj/structure/table,
 /obj/item/restraints/handcuffs,
@@ -25224,8 +25203,7 @@
 /area/station/medical/medbay/lobby)
 "lAx" = (
 /obj/machinery/power/apc/auto_name/directional/west{
-	areastring = "/area/station/hallway/secondary/exit";
-	name = "Escape Hallway APC"
+	areastring = "/area/station/hallway/secondary/exit"
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -25915,8 +25893,7 @@
 /area/station/medical/psychology)
 "lWw" = (
 /obj/machinery/power/apc/auto_name/directional/north{
-	areastring = "/area/station/medical/storage";
-	name = "Medical Storage APC"
+	areastring = "/area/station/medical/storage"
 	},
 /obj/structure/cable,
 /obj/effect/spawner/random/structure/crate,
@@ -26112,10 +26089,7 @@
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
 "mcO" = (
-/obj/machinery/power/apc/auto_name/directional/south{
-	areastring = "/area/station/hallway/primary/aft";
-	name = "Aft Hall APC"
-	},
+/obj/machinery/power/apc/auto_name/directional/south,
 /obj/structure/chair{
 	dir = 1
 	},
@@ -27644,8 +27618,7 @@
 "mVq" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/west{
-	areastring = "/area/station/medical/surgery";
-	name = "Surgery APC"
+	areastring = "/area/station/medical/surgery"
 	},
 /obj/machinery/duct,
 /turf/open/floor/plating,
@@ -27876,6 +27849,7 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "ncy" = (
@@ -27947,6 +27921,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "nfg" = (
@@ -28371,6 +28346,17 @@
 /obj/effect/turf_decal/weather/dirt,
 /turf/open/misc/grass/jungle,
 /area/station/security/prison)
+"nqL" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/purple/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/station/engineering/atmos)
 "nqZ" = (
 /obj/structure/chair{
 	dir = 1
@@ -31045,6 +31031,10 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
+"oXf" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/station/engineering/atmos)
 "oXr" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/plating,
@@ -31542,10 +31532,7 @@
 /turf/open/floor/iron/cafeteria,
 /area/station/security/prison)
 "pnD" = (
-/obj/machinery/power/apc/auto_name/directional/north{
-	areastring = "/area/station/maintenance/central";
-	name = "Central Maintenance APC"
-	},
+/obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/central)
@@ -33523,12 +33510,6 @@
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/aft)
-"qtj" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "qto" = (
 /obj/structure/chair/office/light{
 	dir = 8
@@ -34699,8 +34680,7 @@
 /area/station/security/brig)
 "rap" = (
 /obj/machinery/power/apc/auto_name/directional/north{
-	areastring = "/area/station/medical/exam_room";
-	name = "Exam Room APC"
+	areastring = "/area/station/medical/exam_room"
 	},
 /obj/structure/cable,
 /obj/structure/closet/emcloset,
@@ -34899,10 +34879,7 @@
 /turf/open/floor/iron/checker,
 /area/station/service/theater)
 "rfp" = (
-/obj/machinery/power/apc/auto_name/directional/west{
-	areastring = "/area/station/hallway/primary/starboard";
-	name = "Starboard Primary Hallway APC"
-	},
+/obj/machinery/power/apc/auto_name/directional/west,
 /obj/structure/cable,
 /obj/structure/table,
 /obj/item/trash/semki,
@@ -36488,8 +36465,7 @@
 /area/station/engineering/supermatter)
 "sfm" = (
 /obj/machinery/power/apc/auto_name/directional/west{
-	areastring = "/area/station/medical/pharmacy";
-	name = "Pharmacy APC"
+	areastring = "/area/station/medical/pharmacy"
 	},
 /obj/structure/cable,
 /obj/effect/spawner/random/trash/garbage,
@@ -36521,6 +36497,7 @@
 	c_tag = "Atmospherics South West";
 	network = list("ss13","engine")
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
 "sfD" = (
@@ -36721,10 +36698,7 @@
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/rd)
 "slw" = (
-/obj/machinery/power/apc/auto_name/directional/south{
-	areastring = "/area/station/maintenance/central/lesser";
-	name = "Starboard Central Maintenance APC"
-	},
+/obj/machinery/power/apc/auto_name/directional/south,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/central/lesser)
@@ -37066,10 +37040,7 @@
 /turf/open/floor/iron,
 /area/station/engineering/engine_smes)
 "suY" = (
-/obj/machinery/power/apc/auto_name/directional/south{
-	areastring = "/area/station/hallway/secondary/entry";
-	name = "Entry Hall APC"
-	},
+/obj/machinery/power/apc/auto_name/directional/south,
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
@@ -37865,16 +37836,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/station/commons/toilet)
-"sVS" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/purple/visible,
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
-/area/station/engineering/atmos)
 "sWj" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron,
@@ -37993,10 +37954,7 @@
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/incinerator)
 "tbU" = (
-/obj/machinery/power/apc/auto_name/directional/south{
-	areastring = "/area/station/maintenance/port/fore";
-	name = "Port Bow Maintenance APC"
-	},
+/obj/machinery/power/apc/auto_name/directional/south,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
@@ -38474,10 +38432,7 @@
 /area/station/command/bridge)
 "tmh" = (
 /obj/structure/rack,
-/obj/machinery/power/apc/auto_name/directional/east{
-	areastring = "/area/station/hallway/secondary/service";
-	name = "Service Hall APC"
-	},
+/obj/machinery/power/apc/auto_name/directional/east,
 /obj/item/stack/sheet/iron/fifty,
 /obj/item/stack/sheet/iron/fifty,
 /obj/item/stack/sheet/glass/fifty,
@@ -38808,14 +38763,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/pink,
 /turf/closed/wall/r_wall,
 /area/station/science/ordnance/burnchamber)
-"ttF" = (
-/obj/machinery/atmospherics/pipe/bridge_pipe/yellow/visible/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible/layer4,
-/obj/machinery/atmospherics/pipe/bridge_pipe/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "tuj" = (
 /turf/closed/wall,
 /area/station/cargo/warehouse)
@@ -39590,10 +39537,7 @@
 /turf/open/floor/iron,
 /area/station/service/hydroponics/garden)
 "tQL" = (
-/obj/machinery/power/apc/auto_name/directional/south{
-	areastring = "/area/station/hallway/primary/central";
-	name = "Central Hall APC"
-	},
+/obj/machinery/power/apc/auto_name/directional/south,
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
@@ -42173,10 +42117,7 @@
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "vqY" = (
-/obj/machinery/power/apc/auto_name/directional/west{
-	areastring = "/area/station/tcommsat/computer";
-	name = "Telecomms Monitoring APC"
-	},
+/obj/machinery/power/apc/auto_name/directional/west,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 6
@@ -43018,6 +42959,11 @@
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/station/commons/toilet)
+"vRs" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/station/engineering/atmos)
 "vRJ" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -43210,10 +43156,7 @@
 /area/station/cargo/office)
 "vXY" = (
 /obj/structure/table,
-/obj/machinery/power/apc/auto_name/directional/north{
-	areastring = "/area/station/engineering/engine_smes";
-	name = "SMES room APC"
-	},
+/obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
 /obj/item/storage/box/lights/mixed,
 /turf/open/floor/iron,
@@ -62567,21 +62510,21 @@ eNN
 mCh
 eNN
 dJL
-eNN
-eNN
+vRs
+vRs
 fIv
 gYJ
-eNN
+vRs
 jcG
 jTp
 lgw
-lJC
-jsP
+dRQ
+oXf
 jTp
 lgw
-lJC
-jsP
-jsP
+dRQ
+oXf
+oXf
 sft
 qLt
 rVV
@@ -62840,7 +62783,7 @@ oCe
 jfY
 jfY
 pNA
-pvo
+nqL
 rVV
 rVV
 rVV
@@ -63097,7 +63040,7 @@ mIz
 mIz
 mIz
 pQk
-pvo
+nqL
 smR
 fsz
 fsz
@@ -63338,23 +63281,23 @@ mpW
 yjw
 yjw
 njl
-kOv
-kOv
+ycG
+ycG
 gaS
 gaS
-kOv
+ycG
 jji
-kOv
-kOv
-kOv
-kOv
-kOv
-kOv
-kOv
-kOv
-ttF
-qtj
-sVS
+ycG
+ycG
+ycG
+ycG
+ycG
+ycG
+ycG
+ycG
+mIz
+pQk
+qOi
 smR
 fsz
 qUA


### PR DESCRIPTION
## What is changing?

Went through all of our maps looking for auto_name APCs which were manually setting their name or specifying an areapath when not needed and removed where appropriate. Also looked for places to remove pixel offsets from APCs where they weren't needed.

### Changes

- Removes `areastring` and `name` var edits in maps for auto_name APCs where possible 
- Also removed unnecessary pixel offsets where possible 
- Removed APC(s) or changed their location/area to fix duplicate APCs 
- (Echo & IceCube) Repathed area exp lab -> circuits lab to match APC/room usage 
- (Echo) Repathed area lab -> explab to match room usage (updated APC to match)

## Why these changes?

Fixes duplicate APCs, helps prevent accidental errors during map changes (as APCs now have less var edits), and helps reduce upstream merge conflicts due to changes/refactors to paths/areas.

## Map Diff Bot Results (not super useful for this PR but still including to verify not extra changes):
https://github.com/unv-annihilator/RussStation/pull/20/checks?check_run_id=8286145577
