### PR TITLE
Xenobio Bag Fix + Ore Satchel & Reagent Grinder

### DIFF
--- a/code/datums/storage/storage.dm
+++ b/code/datums/storage/storage.dm
@@ -542,7 +542,7 @@ GLOBAL_LIST_EMPTY(cached_storage_typecaches)
 
 	if(!force)
 		if(check_adjacent)
-			if(!user || !user.CanReach(destination) || !user.CanReach(parent))
+			if(!user || !user.CanReach(destination) || !user.CanReach(resolve_location))
 				return FALSE
 	var/list/taking = typecache_filter_list(resolve_location.contents, typecacheof(type))
 	if(taking.len > amount)

--- a/code/modules/mining/satchel_ore_boxdm.dm
+++ b/code/modules/mining/satchel_ore_boxdm.dm
@@ -13,7 +13,7 @@
 	if (istype(W, /obj/item/stack/ore))
 		user.transferItemToLoc(W, src)
 	else if(W.atom_storage)
-		W.atom_storage.remove_type(/obj/item/stack/ore, src)
+		W.atom_storage.remove_type(/obj/item/stack/ore, src, INFINITY, TRUE, FALSE, user, null)
 		to_chat(user, span_notice("You empty the ore in [W] into \the [src]."))
 	else
 		return ..()

--- a/code/modules/reagents/chemistry/machinery/reagentgrinder.dm
+++ b/code/modules/reagents/chemistry/machinery/reagentgrinder.dm
@@ -174,7 +174,7 @@
 	//Fill machine with a bag!
 	if(istype(I, /obj/item/storage/bag))
 		var/list/inserted = list()
-		if(I.atom_storage.remove_type(/obj/item/food/grown, src, limit - length(holdingitems), null, null, user, inserted))
+		if(I.atom_storage.remove_type(/obj/item/food/grown, src, limit - length(holdingitems), TRUE, FALSE, user, inserted))
 			for(var/i in inserted)
 				holdingitems[i] = TRUE
 			if(!I.contents.len)


### PR DESCRIPTION
## What is changing?

Upstream bug fix for the Xenobio bag, as well as ore satchel and reagent grinder, that was preventing movement of items to them from bags.

### Changes

Now able to transfer cubes from xenobio bag into slime again

Upstream Fix: https://github.com/tgstation/tgstation/pull/69518

## Why these changes?

Bug fixes from upstream
