### PR TITLE
Kitsune Dexterity Unfuckery

### DIFF
--- a/russstation/code/modules/mob/living/carbon/human/species_types/kitsune.dm
+++ b/russstation/code/modules/mob/living/carbon/human/species_types/kitsune.dm
@@ -3,6 +3,10 @@
 	id = SPECIES_KITSUNE
 	say_mod = "gekkers"
 	inherent_traits = list(
+		TRAIT_ADVANCEDTOOLUSER,
+		TRAIT_CAN_STRIP,
+		TRAIT_CAN_USE_FLIGHT_POTION,
+		TRAIT_LITERATE,
 		TRAIT_NATURALTACKLER,
 	)
 	mutant_bodyparts = list("wings" = "None")


### PR DESCRIPTION
<!-- Fill out each section with text below the header. 
 You can view https://github.com/RussStation/RussStation/wiki/Contributing for a detailed description of the pull request process. -->

## What is changing?

<!-- Briefly describe the Pull Request. Screenshots are recommended for new content.
 Include descriptions of interactions (such as new recipes or interfaces) so we know what the experience will be like.
 Example: Adds a new gas called "fartium". It is like miasma but doesn't make you as sick. It can be created by mixing super heated miasma with hydrogen in a 5:1 ratio. It degrades slowly when exposed to nitrogen. -->
 
 Giving the Kitsune race the ability to use complex machinery, strip corpses, read and use flight potions

### Changes

<!-- Itemized list of what was changed/added/removed. They should generally represent how a player might be affected by the changes so everyone understands the impact. 
 Example:
 * Added fartium gas
 * Added fartium gas containers to our maps as maint loot
 * Farts release fartium instead of miasma now -->
 
 * Kitsune can use complex machinery
 
 * Kitsune can strip corpses
 
 * Kitsune can read
 
 * Kitsune can use flight potions

<!-- ### Wiki -->

<!-- If our wiki needs updated to document the changed content, uncomment this header and provide text that can be used on the wiki to help players learn more about this content. Use the our wiki and the tg wiki as references for how you might describe your content. -->

## Why these changes?

<!-- Please add a short description of why you think these changes would benefit the game.
 If you can't justify it in words, it might not be worth adding.
 If code is modified in tg files (outside russstation/ folder) explain why that is necessary.
 Example: I like smelling my farts but I don't want my character to get so ill from it. This lets us fart more without poisoning everyone. -->

Because these are a little bit important, just a bit