### PR TITLE
IceCube brig entrance access fix + Cold alarm fixes

### DIFF
--- a/_maps/map_files/IceCubeStation/IceCube.dmm
+++ b/_maps/map_files/IceCubeStation/IceCube.dmm
@@ -24284,7 +24284,6 @@
 	name = "Kill Chamber"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/science/xenobio,
-/obj/machinery/door/firedoor/heavy,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /turf/open/floor/iron/smooth,
 /area/station/science/xenobiology)

--- a/_maps/map_files/IceCubeStation/IceCube.dmm
+++ b/_maps/map_files/IceCubeStation/IceCube.dmm
@@ -8383,7 +8383,7 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
-/obj/effect/mapping_helpers/airlock/access/all/security/brig,
+/obj/effect/mapping_helpers/airlock/access/all/security/entrance,
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
 "dxW" = (
@@ -25799,12 +25799,12 @@
 	id_tag = "innerbrig";
 	name = "Brig"
 	},
-/obj/effect/mapping_helpers/airlock/access/all/security/brig,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
 	cycle_id = "brig-entrance"
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
+/obj/effect/mapping_helpers/airlock/access/all/security/entrance,
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
 "lcv" = (

--- a/_maps/map_files/IceCubeStation/IceCube.dmm
+++ b/_maps/map_files/IceCubeStation/IceCube.dmm
@@ -46067,7 +46067,6 @@
 	name = "Research Division Server Room"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/science/rd,
-/obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden,
 /turf/open/floor/iron,
 /area/station/science/server)


### PR DESCRIPTION
## What is changing?

Security entrance doors had wrong access requirement, fixed now.
Also removed a firelock placed on exterior door (causing constant fire alarms)

### Changes

Security entrance now uses correct security entrance access helper
Removed Xenobio firelock on exterior door

## Why these changes?

Map bug fix

## Map Diff Bot
https://github.com/unv-annihilator/RussStation/pull/22/checks
