### PR TITLE
Roundstart Atmos Tile Difference Fix

### DIFF
--- a/_maps/map_files/CubeStation/Cube.dmm
+++ b/_maps/map_files/CubeStation/Cube.dmm
@@ -884,8 +884,8 @@
 "avM" = (
 /obj/item/food/cakeslice/clown_slice,
 /obj/item/clothing/accessory/clown_enjoyer_pin,
-/turf/open/floor/plating,
-/area/station/maintenance/port/aft)
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "avR" = (
 /obj/structure/cable,
 /turf/open/floor/iron/cafeteria,
@@ -1203,7 +1203,7 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
-/turf/open/indestructible,
+/turf/open/floor/plating/airless,
 /area/station/science/ordnance/bomb)
 "aFF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -2195,7 +2195,7 @@
 	dir = 1
 	},
 /obj/item/target,
-/turf/open/indestructible,
+/turf/open/floor/plating/airless,
 /area/station/science/ordnance/bomb)
 "biK" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
@@ -2910,7 +2910,7 @@
 	dir = 8
 	},
 /obj/item/target/alien/anchored,
-/turf/open/indestructible,
+/turf/open/floor/plating/airless,
 /area/station/science/ordnance/bomb)
 "bDt" = (
 /obj/structure/chair{
@@ -3611,8 +3611,8 @@
 	dir = 4
 	},
 /obj/structure/disposaloutlet,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/aft)
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "bTO" = (
 /obj/structure/table,
 /obj/item/storage/box/cups{
@@ -3674,6 +3674,9 @@
 	},
 /turf/open/floor/iron/cafeteria,
 /area/station/security/prison)
+"bVy" = (
+/turf/open/floor/plating/airless,
+/area/station/maintenance/aft)
 "bVz" = (
 /obj/structure/cable,
 /obj/effect/spawner/structure/window/reinforced,
@@ -9021,7 +9024,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/turf/open/indestructible,
+/turf/open/floor/plating/airless,
 /area/station/science/ordnance/bomb)
 "eOD" = (
 /obj/machinery/door/airlock/maintenance,
@@ -9338,7 +9341,7 @@
 /area/station/maintenance/solars/port/fore)
 "eWr" = (
 /obj/effect/turf_decal/stripes/full,
-/turf/open/indestructible,
+/turf/open/floor/plating/airless,
 /area/station/science/ordnance/bomb)
 "eWt" = (
 /obj/structure/closet/radiation,
@@ -12252,7 +12255,7 @@
 /obj/structure/chair{
 	dir = 8
 	},
-/turf/open/indestructible,
+/turf/open/floor/plating/airless,
 /area/station/science/ordnance/bomb)
 "gxK" = (
 /obj/structure/table,
@@ -14557,10 +14560,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
-"hHj" = (
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/station/maintenance/port/aft)
 "hHl" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
@@ -14739,6 +14738,9 @@
 	},
 /turf/open/floor/iron/grimy,
 /area/station/service/lawoffice)
+"hMX" = (
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "hNj" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/maintenance/two,
@@ -21444,7 +21446,7 @@
 /obj/structure/chair{
 	dir = 1
 	},
-/turf/open/indestructible,
+/turf/open/floor/plating/airless,
 /area/station/science/ordnance/bomb)
 "lwm" = (
 /obj/structure/table/glass,
@@ -21666,7 +21668,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/turf/open/indestructible,
+/turf/open/floor/plating/airless,
 /area/station/science/ordnance/bomb)
 "lBT" = (
 /obj/machinery/vending/cigarette,
@@ -22309,6 +22311,13 @@
 	},
 /turf/open/floor/iron/grimy,
 /area/station/service/lawoffice)
+"lWm" = (
+/obj/structure/sign/warning/secure_area{
+	desc = "A warning sign which reads 'BOMB RANGE";
+	name = "BOMB RANGE"
+	},
+/turf/closed/indestructible/riveted,
+/area/station/science/ordnance/bomb)
 "lWs" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
@@ -24564,7 +24573,7 @@
 /obj/structure/chair{
 	dir = 4
 	},
-/turf/open/indestructible,
+/turf/open/floor/plating/airless,
 /area/station/science/ordnance/bomb)
 "naF" = (
 /obj/structure/rack,
@@ -24811,7 +24820,7 @@
 /obj/structure/chair{
 	dir = 8
 	},
-/turf/open/indestructible,
+/turf/open/floor/plating/airless,
 /area/station/science/ordnance/bomb)
 "ngM" = (
 /obj/structure/table/wood,
@@ -27977,8 +27986,8 @@
 /obj/machinery/atmospherics/components/unary/outlet_injector/on{
 	dir = 4
 	},
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/aft)
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "oMc" = (
 /obj/machinery/light{
 	dir = 1
@@ -28754,9 +28763,6 @@
 /obj/effect/spawner/random/trash/grille_or_waste,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
-"pfV" = (
-/turf/open/space/basic,
-/area/station/maintenance/port/aft)
 "pgE" = (
 /obj/structure/cable,
 /obj/machinery/camera/autoname/directional/south,
@@ -28981,7 +28987,7 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "pkP" = (
-/turf/open/indestructible,
+/turf/open/floor/plating/airless,
 /area/station/science/ordnance/bomb)
 "plf" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
@@ -29550,7 +29556,7 @@
 /obj/structure/chair{
 	dir = 1
 	},
-/turf/open/indestructible,
+/turf/open/floor/plating/airless,
 /area/station/science/ordnance/bomb)
 "pzg" = (
 /obj/structure/sign/poster/official/cleanliness{
@@ -29918,6 +29924,10 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
+"pIS" = (
+/obj/effect/spawner/random/trash/garbage,
+/turf/open/floor/plating/airless,
+/area/station/maintenance/aft)
 "pIZ" = (
 /obj/structure/table,
 /obj/item/reagent_containers/food/condiment/peppermill,
@@ -32449,8 +32459,8 @@
 	dir = 8;
 	name = "Mix to Space"
 	},
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/aft)
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "qQZ" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -33036,7 +33046,7 @@
 /area/station/security/brig)
 "rcy" = (
 /obj/effect/turf_decal/stripes/line,
-/turf/open/indestructible,
+/turf/open/floor/plating/airless,
 /area/station/science/ordnance/bomb)
 "rcD" = (
 /obj/structure/table,
@@ -36079,7 +36089,7 @@
 /obj/effect/turf_decal/stripes/full,
 /obj/structure/window/reinforced,
 /obj/item/target,
-/turf/open/indestructible,
+/turf/open/floor/plating/airless,
 /area/station/science/ordnance/bomb)
 "sEy" = (
 /obj/machinery/computer/cargo/request,
@@ -39197,7 +39207,7 @@
 /obj/structure/chair{
 	dir = 4
 	},
-/turf/open/indestructible,
+/turf/open/floor/plating/airless,
 /area/station/science/ordnance/bomb)
 "ukQ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -39390,7 +39400,7 @@
 	dir = 9
 	},
 /obj/structure/chair,
-/turf/open/indestructible,
+/turf/open/floor/plating/airless,
 /area/station/science/ordnance/bomb)
 "uoM" = (
 /obj/machinery/suit_storage_unit/captain,
@@ -39456,7 +39466,7 @@
 	dir = 5
 	},
 /obj/structure/chair,
-/turf/open/indestructible,
+/turf/open/floor/plating/airless,
 /area/station/science/ordnance/bomb)
 "upP" = (
 /obj/structure/disposalpipe/segment{
@@ -41896,7 +41906,7 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
-/turf/open/indestructible,
+/turf/open/floor/plating/airless,
 /area/station/science/ordnance/bomb)
 "vyP" = (
 /obj/machinery/computer/security,
@@ -43147,8 +43157,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/aft)
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "weo" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -43249,7 +43259,8 @@
 "wgf" = (
 /obj/effect/turf_decal/stripes/box,
 /obj/item/beacon,
-/turf/open/indestructible,
+/obj/effect/spawner/random/engineering/tracking_beacon,
+/turf/open/floor/plating/airless,
 /area/station/science/ordnance/bomb)
 "wgg" = (
 /turf/closed/wall,
@@ -45018,6 +45029,10 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/service/theater)
+"wVl" = (
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating/airless,
+/area/station/maintenance/aft)
 "wVq" = (
 /obj/machinery/door/poddoor,
 /turf/open/floor/plating,
@@ -46639,7 +46654,7 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
-/turf/open/indestructible,
+/turf/open/floor/plating/airless,
 /area/station/science/ordnance/bomb)
 "xIN" = (
 /obj/effect/turf_decal/stripes/line{
@@ -47483,7 +47498,7 @@
 /area/station/cargo/office)
 "ydW" = (
 /obj/effect/turf_decal/stripes/corner,
-/turf/open/indestructible,
+/turf/open/floor/plating/airless,
 /area/station/science/ordnance/bomb)
 "ydX" = (
 /obj/structure/disposalpipe/segment,
@@ -49268,11 +49283,11 @@ bXj
 bXj
 ggx
 ggx
-oyg
+lWm
 wCU
 oyg
 wCU
-oyg
+lWm
 ggx
 ggx
 bXj
@@ -50630,11 +50645,11 @@ bXj
 bXj
 ggx
 ggx
-oyg
+lWm
 wCU
 eWr
 wCU
-oyg
+lWm
 ggx
 ggx
 bXj
@@ -67680,7 +67695,7 @@ jIb
 uos
 xeS
 xii
-fSl
+hMX
 pRn
 wbG
 fSl
@@ -67907,7 +67922,7 @@ sPL
 xyI
 wgj
 xii
-hHj
+ggx
 pRn
 xCh
 jeI
@@ -68134,7 +68149,7 @@ jIb
 tlN
 cIM
 xii
-pfV
+bXj
 pRn
 wbG
 sWW
@@ -68361,7 +68376,7 @@ xii
 xii
 xii
 xii
-pfV
+bXj
 pRn
 wbG
 fSl
@@ -68585,10 +68600,10 @@ xii
 xii
 xii
 avM
-fSl
-fSl
+hMX
+hMX
 pRn
-hHj
+ggx
 pRn
 gdh
 mQH
@@ -68808,14 +68823,14 @@ nxC
 qJW
 aMX
 pRn
-pfV
-fSl
-fSl
-fSl
-fSl
-fSl
-fSl
-fSl
+bXj
+hMX
+hMX
+hMX
+hMX
+hMX
+hMX
+hMX
 pRn
 fOn
 fSl
@@ -69035,14 +69050,14 @@ uYI
 qJW
 aMX
 pRn
-fSl
-pfV
-pfV
-hHj
-pfV
-pfV
-pfV
-fSl
+hMX
+bXj
+bXj
+ggx
+bXj
+bXj
+bXj
+hMX
 pRn
 qre
 gMq
@@ -79475,9 +79490,9 @@ fVT
 kbU
 jZy
 fVT
-wce
-wce
-wce
+bVy
+bVy
+bVy
 fVT
 wce
 nYk
@@ -79702,9 +79717,9 @@ fVT
 wce
 vxS
 hSN
-wce
+bVy
 sLn
-wce
+bVy
 hSN
 wce
 nYk
@@ -79929,9 +79944,9 @@ qFD
 qFD
 iGk
 fVT
-kbU
-wce
-fzs
+pIS
+bVy
+wVl
 fVT
 wce
 nYk

--- a/_maps/map_files/EchoStation/EchoStation.dmm
+++ b/_maps/map_files/EchoStation/EchoStation.dmm
@@ -1216,7 +1216,7 @@
 "aGJ" = (
 /obj/item/beacon,
 /obj/effect/turf_decal/stripes/box,
-/turf/open/indestructible,
+/turf/open/floor/plating/airless,
 /area/station/science/ordnance/bomb)
 "aGW" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -1290,7 +1290,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
-/turf/open/indestructible,
+/turf/open/floor/plating/airless,
 /area/station/science/ordnance/bomb)
 "aJc" = (
 /obj/effect/decal/cleanable/dirt,
@@ -2276,7 +2276,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/stripes/full,
-/turf/open/indestructible,
+/turf/open/floor/plating/airless,
 /area/station/science/ordnance/bomb)
 "bjQ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -4854,7 +4854,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/turf/open/indestructible,
+/turf/open/floor/plating/airless,
 /area/station/science/ordnance/bomb)
 "cHc" = (
 /obj/structure/table,
@@ -9345,7 +9345,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
-/turf/open/indestructible,
+/turf/open/floor/plating/airless,
 /area/station/science/ordnance/bomb)
 "eWf" = (
 /obj/structure/cable,
@@ -11791,7 +11791,7 @@
 /area/station/maintenance/starboard/fore)
 "gqx" = (
 /obj/effect/turf_decal/stripes/line,
-/turf/open/indestructible,
+/turf/open/floor/plating/airless,
 /area/station/science/ordnance/bomb)
 "gqC" = (
 /obj/structure/window/reinforced{
@@ -14702,7 +14702,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
-/turf/open/indestructible,
+/turf/open/floor/plating/airless,
 /area/station/science/ordnance/bomb)
 "hVN" = (
 /obj/structure/disposalpipe/segment{
@@ -16473,7 +16473,7 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
-/turf/open/indestructible,
+/turf/open/floor/plating/airless,
 /area/station/science/ordnance/bomb)
 "iMj" = (
 /obj/structure/extinguisher_cabinet{
@@ -17406,6 +17406,13 @@
 "jpN" = (
 /turf/open/floor/plating,
 /area/station/commons/locker)
+"jqg" = (
+/obj/structure/sign/warning/secure_area{
+	desc = "A warning sign which reads 'BOMB RANGE";
+	name = "BOMB RANGE"
+	},
+/turf/closed/indestructible/riveted,
+/area/station/science/ordnance/bomb)
 "jqm" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
@@ -17610,7 +17617,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
-/turf/open/indestructible,
+/turf/open/floor/plating/airless,
 /area/station/science/ordnance/bomb)
 "jwg" = (
 /obj/effect/decal/cleanable/dirt,
@@ -18429,7 +18436,7 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
-/turf/open/indestructible,
+/turf/open/floor/plating/airless,
 /area/station/science/ordnance/bomb)
 "jQD" = (
 /obj/machinery/firealarm{
@@ -22449,7 +22456,7 @@
 	dir = 9
 	},
 /obj/machinery/camera/preset/ordnance,
-/turf/open/indestructible,
+/turf/open/floor/plating/airless,
 /area/station/science/ordnance/bomb)
 "lYl" = (
 /obj/machinery/mass_driver{
@@ -24499,7 +24506,7 @@
 /area/station/service/bar)
 "neO" = (
 /obj/effect/turf_decal/stripes/full,
-/turf/open/indestructible,
+/turf/open/floor/plating/airless,
 /area/station/science/ordnance/bomb)
 "neU" = (
 /obj/effect/turf_decal/bot,
@@ -25328,7 +25335,7 @@
 	},
 /obj/item/target,
 /obj/effect/turf_decal/stripes/full,
-/turf/open/indestructible,
+/turf/open/floor/plating/airless,
 /area/station/science/ordnance/bomb)
 "nzf" = (
 /obj/machinery/holopad,
@@ -28140,7 +28147,7 @@
 /obj/structure/window/reinforced,
 /obj/item/target,
 /obj/effect/turf_decal/stripes/full,
-/turf/open/indestructible,
+/turf/open/floor/plating/airless,
 /area/station/science/ordnance/bomb)
 "oPw" = (
 /obj/structure/rack,
@@ -30147,7 +30154,7 @@
 /area/station/medical/pharmacy)
 "pVn" = (
 /obj/effect/turf_decal/stripes/corner,
-/turf/open/indestructible,
+/turf/open/floor/plating/airless,
 /area/station/science/ordnance/bomb)
 "pVw" = (
 /obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
@@ -30655,7 +30662,7 @@
 	dir = 8
 	},
 /obj/item/target/clown,
-/turf/open/indestructible,
+/turf/open/floor/plating/airless,
 /area/station/science/ordnance/bomb)
 "qiw" = (
 /obj/structure/altar_of_gods,
@@ -36109,7 +36116,7 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
-/turf/open/indestructible,
+/turf/open/floor/plating/airless,
 /area/station/science/ordnance/bomb)
 "tcZ" = (
 /turf/open/floor/iron,
@@ -41542,7 +41549,7 @@
 /turf/open/floor/wood,
 /area/station/service/bar)
 "vCU" = (
-/turf/open/indestructible,
+/turf/open/floor/plating/airless,
 /area/station/science/ordnance/bomb)
 "vCW" = (
 /obj/structure/disposalpipe/segment{
@@ -41727,7 +41734,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/turf/open/indestructible,
+/turf/open/floor/plating/airless,
 /area/station/science/ordnance/bomb)
 "vIw" = (
 /turf/open/floor/iron/white,
@@ -56392,9 +56399,9 @@ jjW
 jjW
 xZl
 xZl
-xfz
+jqg
 tXo
-xfz
+jqg
 xZl
 xZl
 jjW
@@ -58448,9 +58455,9 @@ jjW
 jjW
 xZl
 xZl
-xfz
+jqg
 neO
-xfz
+jqg
 xZl
 xZl
 jjW

--- a/_maps/map_files/ShitStation/ShitStation.dmm
+++ b/_maps/map_files/ShitStation/ShitStation.dmm
@@ -1252,8 +1252,8 @@
 /turf/open/floor/iron/dark,
 /area/station/security/prison)
 "aeN" = (
-/turf/open/floor/circuit,
-/area/station/maintenance/port/aft)
+/turf/open/floor/circuit/airless,
+/area/station/science/xenobiology)
 "aeP" = (
 /turf/closed/wall/r_wall,
 /area/station/maintenance/department/cargo)
@@ -2895,12 +2895,9 @@
 /obj/machinery/camera/directional/north,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
-"ako" = (
-/turf/open/space/basic,
-/area/station/maintenance/port/aft)
 "akp" = (
 /obj/structure/sign/warning/cold_temp/directional/north,
-/turf/open/floor/circuit,
+/turf/open/floor/circuit/airless,
 /area/station/science/xenobiology)
 "akq" = (
 /obj/machinery/door/airlock/external{
@@ -3081,7 +3078,7 @@
 /area/station/service/hydroponics/garden)
 "akW" = (
 /obj/machinery/camera/directional/north,
-/turf/open/floor/circuit,
+/turf/open/floor/circuit/airless,
 /area/station/science/xenobiology)
 "akX" = (
 /obj/effect/spawner/random/trash/garbage,
@@ -4788,9 +4785,6 @@
 /obj/structure/cable,
 /turf/open/floor/carpet,
 /area/station/commons/storage/tools)
-"aqP" = (
-/turf/open/floor/circuit,
-/area/station/science/xenobiology)
 "aqQ" = (
 /obj/machinery/power/apc/auto_cell/south{
 	dir = 2;
@@ -5184,7 +5178,7 @@
 /area/station/science/xenobiology)
 "arJ" = (
 /obj/structure/window/reinforced/fulltile,
-/turf/open/floor/circuit,
+/turf/open/floor/circuit/airless,
 /area/station/science/xenobiology)
 "arK" = (
 /obj/machinery/shower/directional/east{
@@ -5419,7 +5413,7 @@
 /area/station/science/robotics/lab)
 "asz" = (
 /obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/space/nearstation)
 "asA" = (
 /obj/machinery/vending/tool,
@@ -9893,7 +9887,7 @@
 /turf/open/floor/iron,
 /area/station/security)
 "aEF" = (
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/station/security/prison)
 "aEG" = (
 /obj/machinery/airalarm/directional/west,
@@ -10170,7 +10164,7 @@
 /area/station/command/heads_quarters/cmo)
 "aFr" = (
 /obj/structure/girder,
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/station/security/prison)
 "aFs" = (
 /obj/structure/bed/dogbed/ian,
@@ -11385,6 +11379,10 @@
 	},
 /turf/open/floor/iron/grimy,
 /area/station/commons/toilet)
+"bfR" = (
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating/airless,
+/area/station/maintenance/department/crew_quarters/dorms)
 "bfZ" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 8
@@ -11822,10 +11820,6 @@
 /obj/structure/disposalpipe/trunk/multiz/down,
 /turf/open/floor/plating,
 /area/station/maintenance/aft/upper)
-"bsn" = (
-/obj/effect/spawner/random/maintenance,
-/turf/open/floor/plating/foam,
-/area/space/nearstation)
 "bsA" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /obj/effect/mapping_helpers/burnt_floor,
@@ -12645,7 +12639,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard)
 "caz" = (
-/turf/open/floor/iron,
+/turf/open/floor/iron/airless,
 /area/space/nearstation)
 "caQ" = (
 /obj/structure/cable,
@@ -13346,7 +13340,7 @@
 /area/station/maintenance/department/science)
 "cDW" = (
 /obj/effect/mapping_helpers/burnt_floor,
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/space/nearstation)
 "cDZ" = (
 /obj/structure/chair/pew/right{
@@ -15244,6 +15238,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/structure/foamedmetal,
 /turf/open/floor/plating/foam,
 /area/space/nearstation)
 "egg" = (
@@ -16416,7 +16411,7 @@
 "eZQ" = (
 /obj/structure/lattice,
 /obj/effect/mapping_helpers/burnt_floor,
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/space/nearstation)
 "fam" = (
 /obj/structure/barricade/wooden,
@@ -16638,7 +16633,7 @@
 /area/station/hallway/primary/starboard)
 "flT" = (
 /obj/effect/spawner/random/trash/mess,
-/turf/open/floor/iron,
+/turf/open/floor/iron/airless,
 /area/space/nearstation)
 "fmq" = (
 /obj/effect/turf_decal/tile/yellow/anticorner{
@@ -18453,7 +18448,7 @@
 /area/station/maintenance/fore/upper)
 "gAL" = (
 /obj/structure/foamedmetal,
-/turf/open/floor/plating/foam,
+/turf/open/floor/plating/airless,
 /area/station/maintenance/port/aft)
 "gBv" = (
 /obj/structure/cable,
@@ -19055,7 +19050,7 @@
 /area/station/medical)
 "gWv" = (
 /obj/structure/transit_tube/horizontal,
-/turf/open/floor/iron,
+/turf/open/floor/iron/airless,
 /area/space/nearstation)
 "gWy" = (
 /obj/structure/window/reinforced/tinted{
@@ -21133,8 +21128,8 @@
 /area/station/medical/surgery)
 "iBa" = (
 /obj/structure/sign/warning/vacuum/directional/north,
-/turf/open/floor/circuit,
-/area/station/maintenance/port/aft)
+/turf/open/floor/circuit/airless,
+/area/station/science/xenobiology)
 "iBq" = (
 /obj/structure/sign/poster/random{
 	pixel_y = 32
@@ -21641,10 +21636,6 @@
 /obj/machinery/suit_storage_unit/industrial/loader,
 /turf/open/floor/iron/textured,
 /area/station/cargo/warehouse)
-"iVT" = (
-/obj/effect/spawner/random/trash/garbage,
-/turf/open/floor/plating/airless,
-/area/station/maintenance/aft/upper)
 "iVV" = (
 /obj/structure/chair/comfy/black{
 	dir = 4
@@ -23748,7 +23739,7 @@
 /area/station/engineering/gravity_generator)
 "kuS" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/space/nearstation)
 "kuV" = (
 /obj/effect/spawner/random/maintenance,
@@ -23932,7 +23923,7 @@
 /turf/open/floor/iron/white,
 /area/station/medical)
 "kEg" = (
-/turf/open/floor/circuit/red/off,
+/turf/open/floor/circuit/red/airless,
 /area/space/nearstation)
 "kEB" = (
 /obj/effect/turf_decal/bot,
@@ -24168,7 +24159,7 @@
 /area/station/maintenance/port/aft)
 "kOu" = (
 /obj/effect/decal/cleanable/oil/slippery,
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
 "kOx" = (
 /obj/structure/disposalpipe/segment,
@@ -24708,10 +24699,6 @@
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
 /area/station/maintenance/fore/upper)
-"lnM" = (
-/obj/effect/decal/cleanable/generic,
-/turf/open/floor/plating/airless,
-/area/station/maintenance/aft/upper)
 "log" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
 /obj/structure/cable,
@@ -24765,7 +24752,7 @@
 /area/station/hallway/primary/upper)
 "lqc" = (
 /obj/effect/turf_decal/stripes/red/line,
-/turf/open/floor/iron,
+/turf/open/floor/iron/airless,
 /area/space/nearstation)
 "lqw" = (
 /obj/structure/cable,
@@ -25492,9 +25479,13 @@
 /obj/structure/window/reinforced/fulltile,
 /turf/open/floor/iron/white,
 /area/station/medical/surgery)
+"lQN" = (
+/obj/structure/foamedmetal,
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "lQV" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/station/maintenance/aft/upper)
 "lRI" = (
 /obj/structure/sign/warning/deathsposal/directional/east,
@@ -26241,7 +26232,7 @@
 /area/station/engineering/atmos)
 "mqR" = (
 /obj/machinery/power/energy_accumulator/tesla_coil/anchored,
-/turf/open/floor/circuit/red/anim,
+/turf/open/floor/circuit/red/airless,
 /area/space/nearstation)
 "mqV" = (
 /obj/machinery/camera/autoname/directional/east,
@@ -27064,7 +27055,7 @@
 /area/station/engineering/gravity_generator)
 "nbH" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/space/nearstation)
 "nbM" = (
 /obj/structure/spider/stickyweb,
@@ -28310,9 +28301,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
-"nYi" = (
-/turf/open/floor/plating/airless,
-/area/station/maintenance/aft/upper)
 "nYq" = (
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
@@ -28581,7 +28569,8 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "oiX" = (
-/turf/open/floor/plating/foam,
+/obj/structure/foamedmetal,
+/turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "ojl" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
@@ -28991,9 +28980,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/commons/locker)
-"oBK" = (
-/turf/open/floor/plating/airless,
-/area/station/maintenance/department/cargo)
 "oCg" = (
 /obj/effect/spawner/random/trash/cigbutt,
 /turf/open/floor/wood,
@@ -29029,10 +29015,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/brig)
-"oDe" = (
-/obj/effect/spawner/random/maintenance,
-/turf/open/floor/plating/airless,
-/area/station/maintenance/department/cargo)
 "oDn" = (
 /obj/structure/sign/warning/vacuum/external/directional/west,
 /obj/structure/closet/emcloset/anchored,
@@ -29442,7 +29424,7 @@
 "oXv" = (
 /obj/effect/spawner/random/maintenance,
 /obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/station/maintenance/department/crew_quarters/dorms)
 "oXD" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
@@ -31246,7 +31228,7 @@
 /area/station/hallway/primary/upper)
 "qgr" = (
 /obj/structure/transit_tube/horizontal,
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/space/nearstation)
 "qhf" = (
 /obj/machinery/portable_atmospherics/canister/plasma,
@@ -31519,7 +31501,9 @@
 /turf/open/floor/iron,
 /area/station/maintenance/fore/upper)
 "qsv" = (
-/turf/open/floor/plating/foam,
+/obj/structure/foamedmetal,
+/obj/structure/foamedmetal,
+/turf/open/floor/plating/airless,
 /area/space/nearstation)
 "qsS" = (
 /obj/structure/transit_tube,
@@ -33187,15 +33171,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/textured,
 /area/station/engineering/atmos/project)
-"rxR" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
-/turf/open/floor/plating/foam,
-/area/space/nearstation)
 "rxW" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -34655,7 +34630,7 @@
 "stw" = (
 /obj/effect/turf_decal/stripes/red/line,
 /obj/structure/transit_tube,
-/turf/open/floor/iron,
+/turf/open/floor/iron/airless,
 /area/space/nearstation)
 "stG" = (
 /obj/effect/decal/cleanable/dirt,
@@ -35205,9 +35180,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
-"sOH" = (
-/turf/open/floor/plating,
-/area/space)
 "sON" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -35972,7 +35944,7 @@
 /area/station/engineering/atmospherics_engine)
 "tue" = (
 /obj/machinery/atmospherics/pipe/multiz/general/visible,
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/space/nearstation)
 "tui" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/purple/visible,
@@ -36059,7 +36031,7 @@
 /area/station/medical/chemistry)
 "twJ" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/circuit,
+/turf/open/floor/circuit/airless,
 /area/station/science/xenobiology)
 "twQ" = (
 /obj/structure/sign/poster/random{
@@ -36467,7 +36439,7 @@
 "tLo" = (
 /obj/structure/girder,
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/station/maintenance/department/crew_quarters/dorms)
 "tLq" = (
 /obj/structure/disposalpipe/trunk{
@@ -36922,9 +36894,6 @@
 /obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/plating,
 /area/station/maintenance/central)
-"ucP" = (
-/turf/open/floor/plating/rust,
-/area/space/nearstation)
 "ucR" = (
 /turf/open/floor/carpet/orange,
 /area/station/command/meeting_room)
@@ -37076,10 +37045,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
-"ukM" = (
-/obj/structure/girder,
-/turf/open/floor/plating/airless,
-/area/station/maintenance/aft/upper)
 "ulW" = (
 /obj/machinery/camera/autoname/directional/west,
 /obj/effect/turf_decal/tile/yellow/anticorner{
@@ -37406,10 +37371,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
-"uxo" = (
-/obj/structure/lattice,
-/turf/open/floor/plating/rust,
-/area/space/nearstation)
 "uxx" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
 /obj/structure/disposalpipe/junction/flip{
@@ -38223,7 +38184,7 @@
 	dir = 1
 	},
 /obj/structure/transit_tube,
-/turf/open/floor/iron,
+/turf/open/floor/iron/airless,
 /area/space/nearstation)
 "vaa" = (
 /obj/structure/disposalpipe/segment{
@@ -38771,7 +38732,7 @@
 /obj/effect/turf_decal/stripes/red/line{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/airless,
 /area/space/nearstation)
 "vqm" = (
 /obj/structure/disposalpipe/segment{
@@ -38861,10 +38822,6 @@
 	},
 /turf/open/misc/asteroid/airless,
 /area/space/nearstation)
-"vuw" = (
-/obj/machinery/space_heater,
-/turf/open/floor/plating/airless,
-/area/station/maintenance/aft/upper)
 "vuL" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/pink/visible,
 /turf/open/floor/iron/large,
@@ -39000,10 +38957,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
-"vye" = (
-/obj/structure/grille/broken,
-/turf/open/floor/plating/airless,
-/area/station/maintenance/aft/upper)
 "vyi" = (
 /obj/structure/falsewall,
 /turf/open/floor/plating,
@@ -39092,7 +39045,7 @@
 /obj/structure/transit_tube/curved{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/airless,
 /area/space/nearstation)
 "vDQ" = (
 /obj/machinery/space_heater,
@@ -39603,7 +39556,7 @@
 /area/station/engineering/lobby)
 "wck" = (
 /obj/structure/reagent_dispensers/fueltank,
-/turf/open/floor/iron,
+/turf/open/floor/iron/airless,
 /area/space/nearstation)
 "wcs" = (
 /turf/open/floor/engine,
@@ -39771,7 +39724,7 @@
 /area/station/hallway/primary/upper)
 "whS" = (
 /obj/structure/barricade/wooden,
-/turf/open/floor/plating/rust,
+/turf/open/floor/plating/airless,
 /area/station/maintenance/department/crew_quarters/dorms)
 "whY" = (
 /obj/structure/cable,
@@ -39786,9 +39739,6 @@
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating,
 /area/station/maintenance/department/crew_quarters/dorms)
-"wil" = (
-/turf/open/floor/plating,
-/area/space/nearstation)
 "wim" = (
 /obj/machinery/light/directional/west,
 /turf/open/openspace,
@@ -40183,7 +40133,7 @@
 "wuY" = (
 /obj/structure/girder,
 /obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/space/nearstation)
 "wvd" = (
 /obj/structure/table/glass,
@@ -41110,10 +41060,6 @@
 "xmU" = (
 /turf/open/floor/iron/textured,
 /area/station/cargo/warehouse)
-"xnq" = (
-/obj/effect/spawner/random/structure/crate,
-/turf/open/floor/plating/airless,
-/area/station/maintenance/aft/upper)
 "xnu" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -65825,11 +65771,11 @@ tdT
 tLo
 nef
 pKU
-gUg
+bfR
 xYL
 jMN
 xUN
-ucP
+vLQ
 aeQ
 azl
 aeQ
@@ -66084,7 +66030,7 @@ hQz
 vCL
 jMN
 uEt
-gUg
+bfR
 adf
 asz
 usd
@@ -66595,16 +66541,16 @@ lrN
 xUN
 asu
 vjz
-gUg
+bfR
 umt
 ktd
 xUN
 tdT
-uxo
+usd
 eZQ
 vLQ
 asz
-ucP
+vLQ
 asz
 aeQ
 aeQ
@@ -66861,7 +66807,7 @@ tdT
 qps
 qps
 tdT
-uxo
+usd
 azl
 aeQ
 aeQ
@@ -67380,7 +67326,7 @@ qps
 muQ
 obH
 asz
-ucP
+vLQ
 aeQ
 aeQ
 aeQ
@@ -67898,7 +67844,7 @@ wfg
 rSL
 kpG
 obH
-qsv
+koQ
 vaf
 asz
 qWQ
@@ -67910,7 +67856,7 @@ eUW
 kHf
 eUW
 aeQ
-ucP
+vLQ
 aeQ
 aeQ
 aeQ
@@ -68156,14 +68102,14 @@ dfg
 djY
 muQ
 koQ
-rxR
-qsv
-qsv
-ucP
-koQ
-koQ
+vaf
+lQN
+lQN
+vLQ
+lQN
+lQN
 aIp
-ucP
+vLQ
 eUW
 eUW
 eFW
@@ -68413,12 +68359,12 @@ tsp
 wpS
 muQ
 koQ
-rxR
+vaf
 qsv
-koQ
-koQ
-koQ
-koQ
+lQN
+lQN
+lQN
+lQN
 aIp
 asz
 asz
@@ -68670,11 +68616,11 @@ xxW
 kLl
 obH
 efT
-rxR
-qsv
+vaf
+lQN
 wuY
-qsv
-qsv
+lQN
+lQN
 vLQ
 dxh
 eUW
@@ -68684,7 +68630,7 @@ eUW
 eUW
 oTu
 aeQ
-wil
+vLQ
 aeQ
 obH
 bho
@@ -68929,10 +68875,10 @@ muQ
 obH
 vSg
 muQ
-koQ
-koQ
-qsv
-bsn
+lQN
+lQN
+lQN
+wPM
 aIp
 aIp
 oSb
@@ -69189,7 +69135,7 @@ muQ
 gAL
 gAL
 gAL
-koQ
+lQN
 dxh
 aIp
 aIp
@@ -69738,7 +69684,7 @@ qdB
 asV
 aaa
 aaa
-wil
+vLQ
 azk
 aaa
 vLQ
@@ -69995,7 +69941,7 @@ mkc
 asV
 aaa
 aaa
-wil
+vLQ
 azk
 aaa
 aaa
@@ -70005,7 +69951,7 @@ aaa
 aaa
 rtj
 rtj
-sOH
+rtj
 rtj
 aaa
 rtj
@@ -70252,7 +70198,7 @@ dUZ
 aeq
 aaa
 aaa
-wil
+vLQ
 aaa
 azk
 wPM
@@ -70507,7 +70453,7 @@ ash
 aEl
 aEx
 aeq
-wil
+vLQ
 aaa
 aaa
 aaa
@@ -70764,8 +70710,8 @@ afx
 ajF
 qdB
 aeq
-wil
-wil
+vLQ
+vLQ
 aaa
 aaa
 vLQ
@@ -71021,8 +70967,8 @@ afx
 qdy
 cxW
 aeq
-wil
-wil
+vLQ
+vLQ
 aaa
 vLQ
 azk
@@ -71279,8 +71225,8 @@ vdX
 lut
 asV
 aaa
-wil
-wil
+vLQ
+vLQ
 vLQ
 vLQ
 aaa
@@ -71794,7 +71740,7 @@ mkc
 asV
 aaa
 aaa
-wil
+vLQ
 aaa
 aaa
 vLQ
@@ -72049,16 +71995,16 @@ afx
 aBl
 jDs
 aeq
-wil
-wil
-wil
+vLQ
+vLQ
+vLQ
 vLQ
 azk
 aaa
 aaa
 aaa
 aaa
-sOH
+rtj
 rtj
 aaa
 aaa
@@ -72254,8 +72200,8 @@ abN
 tvW
 wib
 xUN
-ako
-ako
+aaa
+aaa
 obH
 cWd
 tDM
@@ -72307,11 +72253,11 @@ jwp
 qdB
 aeq
 aaa
-wil
+vLQ
 aaa
 vLQ
-wil
-wil
+vLQ
+vLQ
 aaa
 aaa
 rtj
@@ -72563,13 +72509,13 @@ axi
 qXu
 qdB
 aeq
-wil
-wil
-wil
+vLQ
+vLQ
+vLQ
 vLQ
 aaa
-wil
-wil
+vLQ
+vLQ
 aaa
 aaa
 aaa
@@ -72769,7 +72715,7 @@ gUg
 tvW
 xUN
 akp
-aqP
+aeN
 arJ
 act
 azW
@@ -72826,8 +72772,8 @@ aFb
 aFb
 auG
 auG
-wil
-sOH
+vLQ
+rtj
 rtj
 rtj
 aaa
@@ -73084,7 +73030,7 @@ bDi
 iqn
 auG
 aaa
-sOH
+rtj
 aaa
 rtj
 rtj
@@ -73282,8 +73228,8 @@ abN
 xfn
 nWR
 xUN
-aqP
-aqP
+aeN
+aeN
 arJ
 xNR
 wcI
@@ -73855,7 +73801,7 @@ aEY
 jxK
 auG
 aaa
-wil
+vLQ
 azk
 aaa
 vLQ
@@ -74112,7 +74058,7 @@ aEY
 jxQ
 auG
 aaa
-wil
+vLQ
 aaa
 aaa
 vLQ
@@ -80269,7 +80215,7 @@ asK
 sxz
 aFN
 aFN
-oBK
+rEi
 oZN
 oZN
 aaa
@@ -80783,7 +80729,7 @@ xyD
 rEi
 rEi
 rEi
-oDe
+oqJ
 oZN
 aaa
 aaa
@@ -139135,7 +139081,7 @@ aaa
 ibF
 pUx
 qZS
-vuw
+nYq
 lQV
 hiM
 qZS
@@ -139143,9 +139089,9 @@ oPw
 qZS
 qZS
 qZS
-vye
-iVT
-xnq
+pNI
+rpU
+cYL
 ibF
 azk
 aaa
@@ -139402,7 +139348,7 @@ ewa
 hiM
 sax
 lQV
-ukM
+vmO
 ibF
 aaa
 azk
@@ -139655,11 +139601,11 @@ ibF
 xtt
 oPw
 qZS
-nYi
+qZS
 lQV
-lnM
-nYi
-nYi
+wUD
+qZS
+qZS
 ibF
 aaa
 azk
@@ -145510,7 +145456,7 @@ azk
 aaa
 aaa
 azk
-wil
+vLQ
 hIf
 qsS
 stw
@@ -145764,7 +145710,7 @@ aaa
 aaa
 ddt
 azk
-wil
+vLQ
 aaa
 aaa
 dxh
@@ -147561,12 +147507,12 @@ rqO
 sea
 xEl
 aaa
-wil
+vLQ
 azk
 azk
 aaa
 azk
-wil
+vLQ
 aaa
 aaa
 aaa
@@ -147817,7 +147763,7 @@ rbh
 ald
 srB
 xEl
-wil
+vLQ
 azk
 aaa
 aaa
@@ -148076,7 +148022,7 @@ thQ
 xEl
 aaa
 azk
-wil
+vLQ
 aaa
 azk
 azk
@@ -148331,7 +148277,7 @@ tfY
 xEl
 xEl
 xEl
-wil
+vLQ
 aaa
 dxh
 aaa
@@ -148589,8 +148535,8 @@ xJo
 lnG
 xEl
 xEl
-wil
-wil
+vLQ
+vLQ
 azk
 aaa
 aaa
@@ -148847,7 +148793,7 @@ ihR
 kQu
 xEl
 aaa
-wil
+vLQ
 azk
 aaa
 aaa
@@ -149103,7 +149049,7 @@ thQ
 ald
 frL
 xEl
-wil
+vLQ
 aaa
 azk
 aaa
@@ -149618,7 +149564,7 @@ tvs
 riW
 aaa
 azk
-wil
+vLQ
 aaa
 aaa
 aaa
@@ -149873,8 +149819,8 @@ xEl
 bhX
 maU
 riW
-wil
-wil
+vLQ
+vLQ
 azk
 azk
 aaa
@@ -150131,7 +150077,7 @@ xEl
 xEl
 xEl
 aaa
-wil
+vLQ
 dxh
 aaa
 aaa


### PR DESCRIPTION
## What is changing?

Swapped exterior tiles to airless tiles
Some area remappings (exterior space being marked as areas removed, some exterior swapped to nearstation)

### Changes

CUBE:
- Replace exterior plating with /airless type to prevent atmos air differences on tiles on round start
- Slight area remapping (removes open space set as an area)
- Decals and tracking beacon added to ordnance test site (based off Meta)

ECHO:
- Ordnance test site plating changed to use airless
- Decals and tracking beacon added to ordnance test site (based off Meta)

SHITSTATION:
- Fixed hundreds of tile air differences replacing plating with airless variant 

## Why these changes?

Fixes these messages in server logs on startup (also loads quicker)
![air_tile_difference](https://user-images.githubusercontent.com/665570/189544859-a1dc3926-edfb-4976-8837-9fe41178abc7.png)

## Map Diff Bot Results: 
https://github.com/unv-annihilator/RussStation/pull/21/checks?check_run_id=8295698219