### PR TITLE
Adds queekish language to borgs

### DIFF
--- a/code/modules/language/language_holder.dm
+++ b/code/modules/language/language_holder.dm
@@ -319,7 +319,8 @@ Key procs
 								/datum/language/calcic = list(LANGUAGE_ATOM),
 								/datum/language/voltaic = list(LANGUAGE_ATOM),
 								/datum/language/nekomimetic = list(LANGUAGE_ATOM),
-								/datum/language/kitsumimetic = list(LANGUAGE_ATOM)) // honk -- add kitsumimetic
+								/datum/language/kitsumimetic = list(LANGUAGE_ATOM), // honk -- add kitsumimetic
+								/datum/language/queekish = list(LANGUAGE_ATOM)) // honk -- add queekish
 	spoken_languages = list(/datum/language/common = list(LANGUAGE_ATOM),
 							/datum/language/uncommon = list(LANGUAGE_ATOM),
 							/datum/language/machine = list(LANGUAGE_ATOM),
@@ -328,7 +329,8 @@ Key procs
 							/datum/language/calcic = list(LANGUAGE_ATOM),
 							/datum/language/voltaic = list(LANGUAGE_ATOM),
 							/datum/language/nekomimetic = list(LANGUAGE_ATOM),
-							/datum/language/kitsumimetic = list(LANGUAGE_ATOM)) // honk -- add kitsumimetic
+							/datum/language/kitsumimetic = list(LANGUAGE_ATOM), // honk -- add kitsumimetic
+							/datum/language/queekish = list(LANGUAGE_ATOM)) // honk -- add queekish
 
 /datum/language_holder/moth
 	understood_languages = list(/datum/language/common = list(LANGUAGE_ATOM),


### PR DESCRIPTION
## What is changing?

Allows borgs to understand and speak queekish. It was mentioned most roundstart languages are available so opening this to cover queekish. Feel free to discuss any concerns or any additional fixes/changes that may be needed.

### Changes

Allows borgs to understand and speak queekish.

## Why these changes?

Keeps similar theme of roundstart languages being available to borgs
Thanks to Sucy for pointing out that this wasn't available to borgs!