### PR TITLE
Add warning to silicon roles about behavior

### DIFF
--- a/RussStation.dme
+++ b/RussStation.dme
@@ -4801,6 +4801,7 @@
 #include "russstation\code\modules\mob\living\carbon\human\species_types\dwarf.dm"
 #include "russstation\code\modules\mob\living\carbon\human\species_types\kitsune.dm"
 #include "russstation\code\modules\mob\living\carbon\human\species_types\skaven.dm"
+#include "russstation\code\modules\mob\living\silicon\login.dm"
 #include "russstation\code\modules\mob\living\silicon\robot\emote.dm"
 #include "russstation\code\modules\mob\living\simple_animal\bot\secbot.dm"
 #include "russstation\code\modules\mob\living\simple_animal\friendly\cat.dm"

--- a/russstation/code/modules/mob/living/silicon/login.dm
+++ b/russstation/code/modules/mob/living/silicon/login.dm
@@ -1,0 +1,4 @@
+/mob/living/silicon/Login()
+	// warn silicon players to not be shitty
+	to_chat(src, span_boldwarning("Due to the nature of silicon roles your actions will be under more scrutiny, keep this in mind when following server rules and AI laws."))
+	return ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Title

## Why It's Good For The Game

Got a lot of new members lately (yay!) and some think they can get away with abusing silicon power. Doesn't really fly here. Please don't be an asshole silicon.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Warn silicon roles to behave better
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
