### PR TITLE
Disable secborg

### DIFF
--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -141,7 +141,7 @@ ALLOW_AI_MULTICAM
 
 ## Secborg ###
 ## Uncomment to prevent the security cyborg module from being chosen
-#DISABLE_SECBORG
+DISABLE_SECBORG
 
 ## Peacekeeper Borg ###
 ## Uncomment to prevent the peacekeeper cyborg module from being chosen


### PR DESCRIPTION
Changes config to disable security borg model.

Secborg has unlimited disabler & stunbaton as long as they have charge, are immune to stamina damage and chemicals, and when emagged has access to unlimited redlaser as long as they have charge.

Secborg is pretty strong, and was pretty much entirely replaced by peaceborg for a reason.