### PR TITLE
add gas miner spawners for BYO station atmos

### DIFF
--- a/RussStation.dme
+++ b/RussStation.dme
@@ -4992,6 +4992,7 @@
 #include "russstation\code\modules\admin\verbs\randomverbs.dm"
 #include "russstation\code\modules\antagonists\ert.dm"
 #include "russstation\code\modules\antagonists\nukeop\equipment\pinpointer.dm"
+#include "russstation\code\modules\atmospherics\machinery\other\miner.dm"
 #include "russstation\code\modules\cargo\packs.dm"
 #include "russstation\code\modules\client\preferences\multilingual.dm"
 #include "russstation\code\modules\client\preferences\sound.dm"

--- a/russstation/code/modules/atmospherics/machinery/other/miner.dm
+++ b/russstation/code/modules/atmospherics/machinery/other/miner.dm
@@ -1,0 +1,38 @@
+// ripped from roulette beacon, for build-your-own-station atmos
+/obj/item/gas_miner_beacon
+	name = "gas miner beacon"
+	desc = "N.T. approved gas miner beacon, toss it down and you will have a complementary atmospherics gas miner delivered to you."
+	icon = 'icons/obj/objects.dmi'
+	icon_state = "floor_beacon"
+	var/used
+	// which miner to spawn
+	var/miner_type
+
+/obj/item/gas_miner_beacon/Initialize(mapload)
+	. = ..()
+	// use the subtypes
+	if(!miner_type)
+		qdel(src)
+
+/obj/item/gas_miner_beacon/attack_self()
+	if(used)
+		return
+	loc.visible_message(span_warning("\The [src] begins to beep loudly!"))
+	used = TRUE
+	addtimer(CALLBACK(src, PROC_REF(launch_payload)), 40)
+
+/obj/item/gas_miner_beacon/proc/launch_payload()
+	var/obj/structure/closet/supplypod/centcompod/toLaunch = new()
+
+	new miner_type(toLaunch)
+
+	new /obj/effect/pod_landingzone(drop_location(), toLaunch)
+	qdel(src)
+
+/obj/item/gas_miner_beacon/nitrogen
+	name = "nitrogen gas miner beacon"
+	miner_type = /obj/machinery/atmospherics/miner/nitrogen
+
+/obj/item/gas_miner_beacon/oxygen
+	name = "oxygen gas miner beacon"
+	miner_type = /obj/machinery/atmospherics/miner/oxygen


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

title. oxygen and nitrogen only currently (should we add more?). based on roulette wheel beacon.

## Why It's Good For The Game

last time we did BYOS engineering ignored announcements about us sending the gas miners, now they have to do it themselves.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: beacon items to summon atmos gas miners
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
