### PR TITLE
Fixes husked skavens & dionas invisibility

### DIFF
--- a/russstation/code/modules/surgery/species_parts/diona_bodyparts.dm
+++ b/russstation/code/modules/surgery/species_parts/diona_bodyparts.dm
@@ -2,7 +2,6 @@
 	icon = 'russstation/icons/mob/mutant_bodyparts.dmi'
 	icon_static = 'russstation/icons/mob/mutant_bodyparts.dmi'
 	icon_greyscale = 'russstation/icons/mob/mutant_bodyparts.dmi'
-	icon_husk = 'russstation/icons/mob/mutant_bodyparts.dmi'
 	limb_id = SPECIES_DIONA
 	is_dimorphic = FALSE
 	dmg_overlay_type = null // dionas don't have blood
@@ -11,7 +10,6 @@
 	icon = 'russstation/icons/mob/mutant_bodyparts.dmi'
 	icon_static = 'russstation/icons/mob/mutant_bodyparts.dmi'
 	icon_greyscale = 'russstation/icons/mob/mutant_bodyparts.dmi'
-	icon_husk = 'russstation/icons/mob/mutant_bodyparts.dmi'
 	limb_id = SPECIES_DIONA
 	is_dimorphic = FALSE
 	dmg_overlay_type = null
@@ -20,7 +18,6 @@
 	icon = 'russstation/icons/mob/mutant_bodyparts.dmi'
 	icon_static = 'russstation/icons/mob/mutant_bodyparts.dmi'
 	icon_greyscale = 'russstation/icons/mob/mutant_bodyparts.dmi'
-	icon_husk = 'russstation/icons/mob/mutant_bodyparts.dmi'
 	limb_id = SPECIES_DIONA
 	dmg_overlay_type = null
 
@@ -28,7 +25,6 @@
 	icon = 'russstation/icons/mob/mutant_bodyparts.dmi'
 	icon_static = 'russstation/icons/mob/mutant_bodyparts.dmi'
 	icon_greyscale = 'russstation/icons/mob/mutant_bodyparts.dmi'
-	icon_husk = 'russstation/icons/mob/mutant_bodyparts.dmi'
 	limb_id = SPECIES_DIONA
 	dmg_overlay_type = null
 
@@ -36,7 +32,6 @@
 	icon = 'russstation/icons/mob/mutant_bodyparts.dmi'
 	icon_static = 'russstation/icons/mob/mutant_bodyparts.dmi'
 	icon_greyscale = 'russstation/icons/mob/mutant_bodyparts.dmi'
-	icon_husk = 'russstation/icons/mob/mutant_bodyparts.dmi'
 	limb_id = SPECIES_DIONA
 	dmg_overlay_type = null
 
@@ -44,6 +39,5 @@
 	icon = 'russstation/icons/mob/mutant_bodyparts.dmi'
 	icon_static = 'russstation/icons/mob/mutant_bodyparts.dmi'
 	icon_greyscale = 'russstation/icons/mob/mutant_bodyparts.dmi'
-	icon_husk = 'russstation/icons/mob/mutant_bodyparts.dmi'
 	limb_id = SPECIES_DIONA
 	dmg_overlay_type = null

--- a/russstation/code/modules/surgery/species_parts/skaven_bodyparts.dm
+++ b/russstation/code/modules/surgery/species_parts/skaven_bodyparts.dm
@@ -2,7 +2,6 @@
 	icon = 'russstation/icons/mob/human_parts_greyscale.dmi'
 	icon_static = 'russstation/icons/mob/human_parts_greyscale.dmi'
 	icon_greyscale = 'russstation/icons/mob/human_parts_greyscale.dmi'
-	icon_husk = 'russstation/icons/mob/human_parts_greyscale.dmi'
 	icon_state = "skaven_head"
 	limb_id = SPECIES_SKAVEN
 	is_dimorphic = FALSE
@@ -11,7 +10,6 @@
 	icon = 'russstation/icons/mob/human_parts_greyscale.dmi'
 	icon_static = 'russstation/icons/mob/human_parts_greyscale.dmi'
 	icon_greyscale = 'russstation/icons/mob/human_parts_greyscale.dmi'
-	icon_husk = 'russstation/icons/mob/human_parts_greyscale.dmi'
 	icon_state = "skaven_chest"
 	limb_id = SPECIES_SKAVEN
 	is_dimorphic = FALSE
@@ -20,7 +18,6 @@
 	icon = 'russstation/icons/mob/human_parts_greyscale.dmi'
 	icon_static = 'russstation/icons/mob/human_parts_greyscale.dmi'
 	icon_greyscale = 'russstation/icons/mob/human_parts_greyscale.dmi'
-	icon_husk = 'russstation/icons/mob/human_parts_greyscale.dmi'
 	icon_state = "skaven_l_arm"
 	limb_id = SPECIES_SKAVEN
 	unarmed_attack_verb = "claw"
@@ -32,7 +29,6 @@
 	icon = 'russstation/icons/mob/human_parts_greyscale.dmi'
 	icon_static = 'russstation/icons/mob/human_parts_greyscale.dmi'
 	icon_greyscale = 'russstation/icons/mob/human_parts_greyscale.dmi'
-	icon_husk = 'russstation/icons/mob/human_parts_greyscale.dmi'
 	icon_state = "skaven_r_arm"
 	limb_id = SPECIES_SKAVEN
 	unarmed_attack_verb = "claw"
@@ -44,7 +40,6 @@
 	icon = 'russstation/icons/mob/human_parts_greyscale.dmi'
 	icon_static = 'russstation/icons/mob/human_parts_greyscale.dmi'
 	icon_greyscale = 'russstation/icons/mob/human_parts_greyscale.dmi'
-	icon_husk = 'russstation/icons/mob/human_parts_greyscale.dmi'
 	icon_state = "skaven_l_leg"
 	limb_id = SPECIES_SKAVEN
 
@@ -52,6 +47,5 @@
 	icon = 'russstation/icons/mob/human_parts_greyscale.dmi'
 	icon_static = 'russstation/icons/mob/human_parts_greyscale.dmi'
 	icon_greyscale = 'russstation/icons/mob/human_parts_greyscale.dmi'
-	icon_husk = 'russstation/icons/mob/human_parts_greyscale.dmi'
 	icon_state = "skaven_r_leg"
 	limb_id = SPECIES_SKAVEN


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes issue where Skavens & Dionas were turning invisible when husked due to missing sprites. 

## Why It's Good For The Game
-1 broken thing.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: fixes skaven and diona bodyparts.dm referencing non-existent sprites.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
