### PR TITLE
More minor crypto rebalancing

### DIFF
--- a/russstation/code/controllers/subsystem/cryptocurrency.dm
+++ b/russstation/code/controllers/subsystem/cryptocurrency.dm
@@ -7,8 +7,6 @@ SUBSYSTEM_DEF(cryptocurrency)
 
 	// funny name for display
 	var/coin_name = "SpaceCoin"
-	// the "person" that made the coin, used for some special alerts
-	var/nerd_name = "cake" // haha but not really :o)
 	// how much is payed out for an individual mining operation
 	var/payout_min = 800
 	var/payout_max = 1200
@@ -74,18 +72,7 @@ SUBSYSTEM_DEF(cryptocurrency)
 
 /datum/controller/subsystem/cryptocurrency/Initialize(timeofday)
 	// coin of the day
-	coin_name = pick(list(
-		"SpaceCoin",
-		"StarBucks", // this is clearly legally distinct
-		"ClownCoin",
-		"MimeMoney",
-		"FunnyMoney",
-		"RussMoney", // haha i referenced the streamer
-		"SyndiCoin",
-		"BananaBucks",
-		))
-	// inspired by the bitcoin creator but meme?
-	nerd_name = "[pick(list("Satoshi", "Kiryu", "Doraemon", "Greg"))] [pick(list("Naka", "Baka", "Shiba", "Tako"))][pick(list("moto", "mura", "nashi", "bana"))]"
+	coin_name = pick(world.file2list("russstation/strings/crypto_names.txt"))
 	// initialize event cache - copied from SSevents
 	for(var/type in subtypesof(/datum/round_event_control/cryptocurrency))
 		var/datum/round_event_control/cryptocurrency/E = new type()

--- a/russstation/code/modules/admin/verbs/cryptocurrency.dm
+++ b/russstation/code/modules/admin/verbs/cryptocurrency.dm
@@ -35,10 +35,9 @@
 	data["exchange_rate"] = SScryptocurrency.exchange_rate
 	data["wallet"] = SScryptocurrency.wallet
 	data["progress_required"] = SScryptocurrency.progress_required
-	data["exchange_rate_limit"] = initial(SScryptocurrency.exchange_rate) * 4
+	data["exchange_rate_limit"] = initial(SScryptocurrency.exchange_rate) * 2
 	data["total_mined"] = SScryptocurrency.total_mined
 	data["total_payout"] = SScryptocurrency.total_payout
-	data["event_chance"] = SScryptocurrency.event_chance
 	data["mining_history"] = SScryptocurrency.mining_history
 	data["payout_history"] = SScryptocurrency.payout_history
 	data["exchange_rate_history"] = SScryptocurrency.exchange_rate_history

--- a/russstation/code/modules/cargo/packs.dm
+++ b/russstation/code/modules/cargo/packs.dm
@@ -81,27 +81,30 @@
 
 /datum/supply_pack/engineering/crypto_mining_card
 	name = "Basic Graphics Card"
-	desc = "A poor gamer out there is suffering without this, but you're going to use it to mine crypto. Mining rig required."
+	desc = "An old card from a simpler time when games didn't have to look fancy to be fun. Mining rig required."
 	cost = CARGO_CRATE_VALUE * 5
-	contains = list(/obj/item/crypto_mining_card)
+	contains = list(/obj/item/electronics/crypto_mining_card)
 	crate_name = "graphics card crate"
 	crate_type = /obj/structure/closet/crate/engineering/electrical
 	special = FALSE // unlocked by default
 
 /datum/supply_pack/engineering/crypto_mining_card/tier2
 	name = "Intermediate Graphics Card"
+	desc = "Last year's top-tier card is this year's unwanted garbage."
 	cost = CARGO_CRATE_VALUE * 10
-	contains = list(/obj/item/crypto_mining_card/tier2)
+	contains = list(/obj/item/electronics/crypto_mining_card/tier2)
 	special = TRUE // must be unlocked by market activity
 
 /datum/supply_pack/engineering/crypto_mining_card/tier3
 	name = "Advanced Graphics Card"
+	desc = "The latest and greatest... that was in stock."
 	cost = CARGO_CRATE_VALUE * 20
-	contains = list(/obj/item/crypto_mining_card/tier3)
+	contains = list(/obj/item/electronics/crypto_mining_card/tier3)
 	special = TRUE // must be unlocked by market activity
 
 /datum/supply_pack/engineering/crypto_mining_card/tier4
 	name = "Experimental Graphics Card"
+	desc = "A Syndicate double-agent is selling these ridiculous cards. We're not asking questions."
 	cost = CARGO_CRATE_VALUE * 30
-	contains = list(/obj/item/crypto_mining_card/tier4)
+	contains = list(/obj/item/electronics/crypto_mining_card/tier4)
 	special = TRUE // must be unlocked by market activity

--- a/russstation/code/modules/cryptocurrency/cryptocurrency.dm
+++ b/russstation/code/modules/cryptocurrency/cryptocurrency.dm
@@ -231,7 +231,7 @@
 /obj/machinery/crypto_mining_rig/process(delta_time)
 	// if we aren't on and working, obviously stop. also if we're in a no-no area (no free power for you)
 	var/area/area = get_area(src)
-	if(!on || machine_stat & BROKEN || (!wired_power && !powered()) || !area.requires_power || !SScryptocurrency.can_fire)
+	if(!on || machine_stat & BROKEN || (!wired_power && !powered(AREA_USAGE_EQUIP, TRUE)) || !area.requires_power || !SScryptocurrency.can_fire)
 		change_on(FALSE)
 		return PROCESS_KILL
 
@@ -460,10 +460,9 @@
 	data["exchange_rate"] = SScryptocurrency.exchange_rate
 	data["wallet"] = SScryptocurrency.wallet
 	data["progress_required"] = SScryptocurrency.progress_required
-	data["exchange_rate_limit"] = initial(SScryptocurrency.exchange_rate) * 4
+	data["exchange_rate_limit"] = initial(SScryptocurrency.exchange_rate) * 2
 	data["total_mined"] = SScryptocurrency.total_mined
 	data["total_payout"] = SScryptocurrency.total_payout
-	data["event_chance"] = SScryptocurrency.event_chance
 	data["mining_history"] = SScryptocurrency.mining_history
 	data["payout_history"] = SScryptocurrency.payout_history
 	data["exchange_rate_history"] = SScryptocurrency.exchange_rate_history

--- a/russstation/code/modules/cryptocurrency/cryptocurrency.dm
+++ b/russstation/code/modules/cryptocurrency/cryptocurrency.dm
@@ -94,7 +94,7 @@
 	. = ..()
 	. += "Its card slots contain:"
 	if(card_count > 0)
-		for(var/obj/item/crypto_mining_card/card in contents)
+		for(var/obj/item/electronics/crypto_mining_card/card in contents)
 			if(istype(card))
 				. += "&bull; \A [card.name]"
 		. += span_notice("Use a <b>screwdriver</b> to remove the cards.")
@@ -132,9 +132,6 @@
 	add_fingerprint(user)
 	return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
 
-/obj/structure/chair/AltClick(mob/user)
-	return ..() // This hotkey is BLACKLISTED since it's used by /datum/component/simple_rotation
-
 /obj/machinery/crypto_mining_rig/proc/change_on(new_on)
 	on = new_on
 	update_appearance()
@@ -152,7 +149,7 @@
 		wired_power = null
 
 /obj/machinery/crypto_mining_rig/attackby(obj/item/thing, mob/user, params)
-	if(istype(thing, /obj/item/crypto_mining_card))
+	if(istype(thing, /obj/item/electronics/crypto_mining_card))
 		if(on)
 			to_chat(user, span_warning("You need to turn \the [src] off to mess with its cards!"))
 		else if(card_count < max_cards)
@@ -194,7 +191,7 @@
 		to_chat(user, span_warning("You need to turn \the [src] off to mess with its cards!"))
 	else if(card_count > 0)
 		// i don't want to make an interface for removing/replacing individual cards, dump em all
-		for(var/obj/item/crypto_mining_card/card in contents)
+		for(var/obj/item/electronics/crypto_mining_card/card in contents)
 			if(istype(card))
 				card.forceMove(loc)
 		card_count = 0
@@ -295,7 +292,7 @@
 	if(raw_progress < min_progress_to_process)
 		raw_progress = 0
 	// adjust progress based on an exponent so individual rigs are better than many with the same power draw
-	progress = raw_progress / 2 + (raw_progress / 500) ** 2
+	progress = raw_progress / 1.5 + (raw_progress / 500) ** 2
 	// mine dat fukken coin
 	var/result = SScryptocurrency.mine(progress)
 	// announce result when finishing a mining unit
@@ -318,7 +315,7 @@
 	// graphics cards for real gamer hours
 	var/energy_rating = 1
 	var/overclock_rating = 0
-	for(var/obj/item/crypto_mining_card/card in contents)
+	for(var/obj/item/electronics/crypto_mining_card/card in contents)
 		energy_rating += card.energy_rating
 		overclock_rating += card.overclock_rating
 	active_power_usage = initial(active_power_usage) * energy_rating
@@ -379,14 +376,12 @@
 				. = TRUE
 
 // "graphics" cards for shoving into the rig to get the most performance out
-/obj/item/crypto_mining_card
+/obj/item/electronics/crypto_mining_card
 	name = "\improper Brandless graphics card"
 	desc = "Only capable of producing the pipe dream screensaver."
 	icon = 'russstation/icons/obj/machines/cryptocurrency.dmi'
 	icon_state = "graphics_card_1"
 	w_class = WEIGHT_CLASS_SMALL
-	// TODO make sure these have miserable resale value
-	custom_materials = list(/datum/material/iron=50, /datum/material/glass=50)
 	// these are like stock parts but not so we can have finer control
 	var/rating = 1
 	// energy rating determines base power consumption
@@ -394,7 +389,7 @@
 	// overclock rating determines how much extra power can be consumed
 	var/overclock_rating = 0
 
-/obj/item/crypto_mining_card/examine(mob/user)
+/obj/item/electronics/crypto_mining_card/examine(mob/user)
 	. = ..()
 	. += "It requires [energy_rating * BASE_MACHINE_ACTIVE_CONSUMPTION]W to use."
 	if(overclock_rating > 0)
@@ -402,28 +397,29 @@
 	else
 		. += "It does not support overclocking."
 
-/obj/item/crypto_mining_card/tier2
+/obj/item/electronics/crypto_mining_card/tier2
 	name = "\improper Electron 9000 graphics card"
-	desc = "Last year's top-tier card is this year's unwanted garbage."
+	desc = "A decent graphics card that can play real games like Cargonian Warfare."
 	icon_state = "graphics_card_2"
 	rating = 2
 	energy_rating = 5
 	overclock_rating = 1.5
 
-/obj/item/crypto_mining_card/tier3
+/obj/item/electronics/crypto_mining_card/tier3
 	name = "\improper Plastitanium 800 graphics card"
-	desc = "The latest and greatest... that was in stock."
+	desc = "A poor gamer out there is suffering without this, but you're going to use it to mine crypto."
 	icon_state = "graphics_card_3"
 	w_class = WEIGHT_CLASS_NORMAL
 	rating = 3
 	energy_rating = 8
 	overclock_rating = 4
 
-/obj/item/crypto_mining_card/tier4
+/obj/item/electronics/crypto_mining_card/tier4
 	name = "\improper Syndivideo Ruby graphics card"
 	desc = "An experimental card using bluespace technology to render frames before they exist."
 	icon = 'russstation/icons/obj/machines/crypto_huge.dmi'
 	icon_state = "graphics_card_4"
+	// pixel offset because the icon is huge; not sure if working
 	pixel_x = -16
 	base_pixel_x = -16
 	pixel_y = -16
@@ -432,6 +428,12 @@
 	rating = 4
 	energy_rating = 12
 	overclock_rating = 12 // now that's spicy
+	// toolbox-esque combat applications
+	force = 10
+	throwforce = 10
+	throw_speed = 2
+	throw_range = 7
+	wound_bonus = 7 // sharp edges
 
 // NtOS program for crypto stuff
 /datum/computer_file/program/cryptocurrency

--- a/russstation/code/modules/events/cryptocurrency.dm
+++ b/russstation/code/modules/events/cryptocurrency.dm
@@ -12,24 +12,13 @@
 /datum/round_event_control/cryptocurrency/proc/adjust_weight()
 	return
 
+GLOBAL_LIST_INIT(crypto_reasons, world.file2list("russstation/strings/crypto_reasons.txt"))
+
 // event base for shared crypto stuff
 /datum/round_event/cryptocurrency
-	var/reasons = list(
-		"a reddit post",
-		"a Melon Tusk tweet",
-		"boomers",
-		"terrorist hackers",
-		"someone sneezing",
-		"a star going supernova",
-		"yo mama",
-		"a funny cat video",
-		"cargo bounty volume",
-		"unmaxed suit sensors",
-		"a crewmember",
-	)
 
 /datum/round_event/cryptocurrency/proc/reason()
-	var/reason = pick(reasons)
+	var/reason = pick(GLOB.crypto_reasons)
 	if(reason == "a crewmember")
 		// blame a real person
 		var/mob/living/player = pick(GLOB.alive_player_list)

--- a/russstation/code/modules/events/cryptocurrency.dm
+++ b/russstation/code/modules/events/cryptocurrency.dm
@@ -77,7 +77,7 @@
 	// oops too late to cash out
 	announce_when = 40
 	// we don't need to hear this every time; also keeps players on their toes
-	announce_chance = 80
+	announce_chance = 75
 
 /datum/round_event/cryptocurrency/market_crash/announce(fake)
 	crypto_announce("Because of [reason()], the [SScryptocurrency.coin_name] market has crashed! Cash out before it's too late!")
@@ -86,9 +86,9 @@
 	var/dip = 1
 	// crash harder when the exchange rate is high
 	if(SScryptocurrency.exchange_rate > 1)
-		dip = LERP(2, 10, rand())
+		dip = LERP(3, 10, rand())
 	else
-		dip = LERP(1.5, 2.5, rand())
+		dip = LERP(2, 3, rand())
 	// tank the mining exchange rate and market trend
 	SScryptocurrency.next_exchange_rate /= dip
 	SScryptocurrency.market_trend_up = FALSE
@@ -97,7 +97,7 @@
 /datum/round_event_control/cryptocurrency/market_boom
 	name = "Market Boom (Crypto)"
 	typepath = /datum/round_event/cryptocurrency/market_boom
-	max_occurrences = 5
+	max_occurrences = 8
 
 /datum/round_event_control/cryptocurrency/market_boom/adjust_weight()
 	// can only boom so many times - hope you cashed out!
@@ -109,7 +109,7 @@
 /datum/round_event/cryptocurrency/market_boom
 	announce_when = 40
 	// what's that, you didn't see the exchange skyrocket? were you tabbed out?
-	announce_chance = 90
+	announce_chance = 85
 
 /datum/round_event/cryptocurrency/market_boom/announce(fake)
 	crypto_announce("Because of [reason()], the [SScryptocurrency.coin_name] market is booming! We're going to the moon!")
@@ -118,35 +118,12 @@
 	var/stonks = 1
 	// boom harder when the exchange rate is smol
 	if(SScryptocurrency.exchange_rate < 0.5)
-		stonks = LERP(2, 10, rand())
+		stonks = LERP(3, 10, rand())
 	else
-		stonks = LERP(1.5, 2.5, rand())
+		stonks = LERP(2, 3, rand())
 	// boost the mining exchange rate and market trend
 	SScryptocurrency.next_exchange_rate *= stonks
 	SScryptocurrency.market_trend_up = TRUE
-
-// increase cost of cards because realism fuck you
-/datum/round_event_control/cryptocurrency/card_stock
-	name = "Silicon Shortage (Crypto)"
-	typepath = /datum/round_event/cryptocurrency/card_stock
-	max_occurrences = 1
-
-/datum/round_event_control/cryptocurrency/card_stock/adjust_weight()
-	// likely to occur ONCE after we've made good progress toward market cap
-	if(occurrences < max_occurrences && SScryptocurrency.total_payout >= SScryptocurrency.market_cap / 3)
-		weight = 20
-	else
-		weight = 0
-
-/datum/round_event/cryptocurrency/card_stock/announce(fake)
-	crypto_announce("Because of [reason()], everyone is buying graphics cards to mine [SScryptocurrency.coin_name]! Cards will now be sourced from scalpers at exorbitant prices.")
-
-/datum/round_event/cryptocurrency/card_stock/start()
-	. = ..()
-	// double the cost of the card supply packs
-	for(var/pack_type in typesof(/datum/supply_pack/engineering/crypto_mining_card))
-		var/datum/supply_pack/pack = SSshuttle.supply_packs[pack_type]
-		pack.cost *= 2
 
 // release a new graphics card
 /datum/round_event_control/cryptocurrency/card_release

--- a/russstation/strings/crypto_names.txt
+++ b/russstation/strings/crypto_names.txt
@@ -1,0 +1,27 @@
+SpaceCash
+StarBucks
+ClownCoin
+MimeMoney
+FunnyMoney
+RussMoney
+SyndiCoin
+BananaBucks
+LavaLira
+Research Peseta
+DonkDosh
+Non-Fungible Apes
+NanoTrasen Rubles
+Engiemins
+MoonMoola
+IanCoin
+BathSaltz
+DorfBucks
+Jimmy Jams
+Chimkin Tendies
+Telecrystals
+Cigarette Butts
+Space Ants
+Souls
+Geo
+Gil
+Rupees

--- a/russstation/strings/crypto_reasons.txt
+++ b/russstation/strings/crypto_reasons.txt
@@ -1,0 +1,48 @@
+a reddit post
+a Melon Tusk tweet
+boomers
+terrorist hackers
+someone sneezing
+a star going supernova
+yo mama
+a funny cat video
+cargo bounty volume
+unmaxed suit sensors
+a crewmember
+adminbuse
+a time paradox
+greytiders
+shitsec
+CRAB-17
+stream snipers
+cat gang
+poisoned cafeteria food
+Poly
+tram-related accidents
+floor pill consumption
+a hoard of Skaven
+Jerry clones
+insufficient grass touching
+megafauna on the station
+a vile force of darkness
+Gorilla Prime
+deez nuts
+erotic roleplay
+unstamped cargo manifests
+dead miners
+a corpse stuck in the cryo tube
+the voracious appetite of the undead
+a tritium fire in the bar
+a bluespace artillery barrage
+asphyxiating an engineer in the bathroom
+fluke ops
+a clown car driving into a supermatter crystal
+how cute mothroaches are
+no reason in particular
+the invisible hand of the market
+upstream removing fun features from the game
+an increase in bread-related suicides
+the never-ending rivalry between clowns and mimes
+vending machines flattening crewmembers
+a dwarven trade embargo
+sober dwarves

--- a/tgui/packages/tgui/interfaces/Cryptocurrency.js
+++ b/tgui/packages/tgui/interfaces/Cryptocurrency.js
@@ -24,7 +24,6 @@ export const CryptocurrencyDetails = (props, context) => {
     progress_required,
     total_mined,
     total_payout,
-    event_chance,
     market_closed,
   } = data;
   return (
@@ -52,14 +51,11 @@ export const CryptocurrencyDetails = (props, context) => {
               <LabeledList.Item label="Work Units Required">
                 {progress_required} Units
               </LabeledList.Item>
-              <LabeledList.Item label="Total Mined Work">
-                {total_mined} Units
-              </LabeledList.Item>
               <LabeledList.Item label="Total Earned Coin">
                 {total_payout}
               </LabeledList.Item>
-              <LabeledList.Item label="Market Volatility">
-                {event_chance}%
+              <LabeledList.Item label="Total Mined Work">
+                {total_mined} Units
               </LabeledList.Item>
             </LabeledList>
           </Stack.Item>


### PR DESCRIPTION
## About The Pull Request

A number of small tweaks to "improve" crypto, including:

* the smaller cards fit in construction bag (this is a restriction of the bag)
* new progress curve, slower exponent
* shorter cooldown between events
* better distributed card unlock milestones
* removed market cap
* remove shitty silicon shortage event

## Why It's Good For The Game

No one does crypto anymore, even though it was a feature no one asked for. So I decided to mess with it instead of letting it become dead code. These are mostly just number changes so that it's easier to make some actual gains within the timeframe of a typical stream round.

The old progress curve was picked arbitrarily, as were the unlock requirements for each card tier. After doing some math, it turns out that this was really poorly balanced and it was extremely difficult to get huge payouts. The new curve is less ridiculous, and features better distributed unlocks. Cards unlock slightly later than they used to, which means you should have more money to purchase them.

![image](https://user-images.githubusercontent.com/6422050/230150502-28cfc1af-a774-4a74-a483-bc823ce07224.png)

Additionally, machines got a small buff (15%ish?) and event cooldown was reduced by half, so it will take less time to see results. The gameplay loop is the same though; make rigs with tier 1 cards, slap down a freezer or just vacuum the room, unlock better cards that support liquid cooling, pester chemistry and mining for materials, and hope the market booms really big.

I think the system could still be improved by replacing the random events with intentional market patterns, but I couldn't figure out a good solution. Feel free to leave feedback on the discord thread.

## Changelog

:cl:
balance: crypto numbers tweaked to favor shorter rounds
/:cl:
