### PR TITLE
More Twitch Intergration

### DIFF
--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -119,6 +119,7 @@ GLOBAL_LIST_INIT(admin_verbs_fun, list(
 	/client/proc/smite,
 	/client/proc/honk_smite, // honk -- new smites
 	/client/proc/twitchmeteor, // honk -- twitch intergration
+	/client/proc/twitch_command_announcement, //honk -- twitch intergration
 	/client/proc/admin_away,
 	/client/proc/add_mob_ability,
 	/client/proc/remove_mob_ability,

--- a/russstation/code/modules/events/honkbot_events.dm
+++ b/russstation/code/modules/events/honkbot_events.dm
@@ -14,3 +14,23 @@
 	message_admins("[key_name_admin(usr)] sent a single meteor to the station.")
 	SSblackbox.record_feedback("tally", "admin_verb", 1, "Twitch Meteor")
 
+/client/proc/twitch_command_announcement(msg as text)
+	set category = "Server"
+	set name = "Tsay" //Twitch say
+	set hidden = TRUE
+
+	if(!msg)
+		log_admin("[key_name(usr)] attempted to use Twitch Announcement, but didnt write anything.")
+		message_admins("[key_name_admin(usr)] attempted to use Twitch Announcement, but didnt write anything.")
+		return
+
+	if(!check_rights(R_ADMIN) || !check_rights(R_FUN))
+		log_admin("[key_name(usr)] attempted to use Twitch Announcement, but doesnt have rights to.")
+		message_admins("[key_name_admin(usr)] attempted to use Twitch Announcement, but doesnt have rights to.")
+		return
+
+	priority_announce(msg, "Message From a Central Command Employee.") //Sends the message to everyone
+
+	log_admin("[key_name(usr)] sent a command message to the station.")
+	message_admins("[key_name_admin(usr)] sent a command message to the station.")
+	SSblackbox.record_feedback("tally", "admin_verb", 1, "Tsay")


### PR DESCRIPTION
Adds a central command announcement client verb to the game, which honkbot can use to send CC announcements to the station when twitch chat redeems it.

Next on the list of twitch verbs to add: A special one for moon station :)

Also got any ideas you'd like to see for this? Share them!